### PR TITLE
BREAKING CHANGE(rum): resolve main field to source file

### DIFF
--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -2,7 +2,7 @@
   "name": "elastic-apm-js-base",
   "version": "3.0.0",
   "description": "Elastic APM JavaScript agent",
-  "main": "dist/bundles/elastic-apm-js-base.umd.js",
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/elastic/apm-agent-js-base.git",


### PR DESCRIPTION
+ This is a bug, We should allow the users of our library to do necessary optimisations(Preferring ES6 or ES5) on the lib.  