### PR TITLE
BREAKING CHANGE: move IE 10 and Android 4 to unsupported list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,13 +100,13 @@ To run unit/integration/end-to-end tests for packages:
 
 ```sh
 // Unit tests
-$ npx lerna run --scope @elastic/apm-rum runUnitTests
+$ npx lerna run --scope @elastic/apm-rum test:unit
 
 // Integration tests
-$ npx lerna run --scope @elastic/apm-rum runNodeTests
+$ npx lerna run --scope @elastic/apm-rum test:integration
 
 // End to end tests
-$ npx lerna run --scope @elastic/apm-rum run-e2e
+$ npx lerna run --scope @elastic/apm-rum test:e2e
 ```
 
 ### Linting

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -57,23 +57,11 @@ const baseLaunchers = {
     platform: 'Windows 8.1',
     version: '11'
   },
-  SL_IE10: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    platform: 'Windows 2012',
-    version: '10'
-  },
   SL_EDGE: {
     base: 'SauceLabs',
     browserName: 'microsoftedge',
     platform: 'Windows 10',
     version: '13'
-  },
-  'SL_ANDROID4.4': {
-    base: 'SauceLabs',
-    browserName: 'android',
-    platform: 'Linux',
-    version: '4.4'
   },
   SL_ANDROID: {
     base: 'SauceLabs',

--- a/dev-utils/run-script.js
+++ b/dev-utils/run-script.js
@@ -34,9 +34,9 @@ const { generateNotice } = require('./dep-info')
 const sauceConnectOpts = getSauceConnectOptions()
 const { sauceLabs } = getTestEnvironmentVariables()
 
-function runUnitTests(launchSauceConnect = false, directory) {
+function runUnitTests(launchSauceConnect = 'false', directory) {
   const karmaConfigFile = join(__dirname, '..', directory, './karma.conf.js')
-  if (launchSauceConnect && sauceLabs) {
+  if (launchSauceConnect === 'true' && sauceLabs) {
     return runSauceConnect(sauceConnectOpts, () => runKarma(karmaConfigFile))
   }
   runKarma(karmaConfigFile)
@@ -51,10 +51,17 @@ function launchSauceConnect() {
   console.log('set MODE=saucelabs to launch sauce connect')
 }
 
-function runScript(scripts, scriptName, scriptArgs) {
+const scripts = {
+  runUnitTests,
+  launchSauceConnect,
+  generateNotice
+}
+
+function runScript() {
+  const [, , scriptName, ...scriptArgs] = process.argv
   if (scriptName) {
-    const message = `Running: ${scriptName}(${scriptArgs
-      .map(a => "'" + a + "'")
+    var message = `Running: ${scriptName}(${scriptArgs
+      .map(a => a.trim())
       .join(', ')}) \n`
     console.log(message)
     if (typeof scripts[scriptName] === 'function') {
@@ -65,10 +72,4 @@ function runScript(scripts, scriptName, scriptArgs) {
   }
 }
 
-const scripts = {
-  runUnitTests,
-  launchSauceConnect,
-  generateNotice
-}
-
-runScript(scripts, process.argv[2], [].concat(process.argv).slice(3))
+runScript()

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:js": "eslint .",
     "lint:license": "node scripts/license-checker",
     "format": "eslint . --fix",
-    "test": "lerna run test --stream --scope=$SCOPE",
+    "test": "lerna run test --stream --scope=$SCOPE --no-prefix",
     "serve": "lerna run serve",
     "bundlesize": "lerna run --scope @elastic/apm-rum bundlesize"
   },

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -11,10 +11,10 @@
   },
   "scripts": {
     "karma": "karma start",
-    "karma-bench": "karma start karma.bench.conf.js",
-    "karma-coverage": "karma start --coverage",
-    "runUnitTests": "node ../../dev-utils/run-script.js runUnitTests true packages/rum-core",
-    "test": "npm run runUnitTests"
+    "karma:bench": "karma start karma.bench.conf.js",
+    "karma:coverage": "karma start --coverage",
+    "test:unit": "node ../../dev-utils/run-script.js runUnitTests true packages/rum-core",
+    "test": "npm run test:unit"
   },
   "files": [
     "src"

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -10,17 +10,18 @@
   },
   "scripts": {
     "build": "webpack",
-    "build-dev": "webpack -w",
+    "build:dev": "webpack -w",
+    "build:e2e": "npm run script buildE2eBundles",
     "bundlesize": "npm run build && bundlesize",
     "karma": "karma start",
-    "karma-coverage": "karma start --coverage",
-    "serve": "npm run script serveE2e ./ 8000",
-    "runUnitTests": "node ../../dev-utils/run-script.js runUnitTests true packages/rum",
-    "runNodeTests": "npm run script runNodeTests",
-    "buildE2eBundles": "npm run script buildE2eBundles",
-    "run-e2e": "npm run script runE2eTests",
+    "karma:coverage": "karma start --coverage",
     "script": "node ./run-script.js",
-    "test": "npm run build && npm run buildE2eBundles && npm run runNodeTests && npm run runUnitTests && npm run run-e2e"
+    "serve": "npm run script serveE2e ./ 8000",
+    "test:unit": "node ../../dev-utils/run-script.js runUnitTests true packages/rum",
+    "test:integration": "npm run script runNodeTests",
+    "test:e2e": "npm run script runE2eTests",
+    "test:e2e:failsafe": "npm run script runE2eFailsafeTests",
+    "test": "npm run test:e2e && npm run test:e2e:failsafe"
   },
   "files": [
     "src",

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -17,11 +17,12 @@
     "karma:coverage": "karma start --coverage",
     "script": "node ./run-script.js",
     "serve": "npm run script serveE2e ./ 8000",
-    "test:unit": "node ../../dev-utils/run-script.js runUnitTests true packages/rum",
     "test:integration": "npm run script runNodeTests",
-    "test:e2e": "npm run script runE2eTests",
-    "test:e2e:failsafe": "npm run script runE2eFailsafeTests",
-    "test": "npm run test:e2e && npm run test:e2e:failsafe"
+    "test:unit": "node ../../dev-utils/run-script.js runUnitTests false packages/rum",
+    "test:e2e:supported": "npm run script runE2eTests wdio.conf.js",
+    "test:e2e:failsafe": "npm run script runE2eTests wdio-failsafe.conf.js",
+    "test:sauce": "npm run script runSauceTests",
+    "test": "npm-run-all build build:e2e test:integration test:sauce"
   },
   "files": [
     "src",

--- a/packages/rum/run-script.js
+++ b/packages/rum/run-script.js
@@ -126,18 +126,22 @@ function runJasmine(cb) {
   jrunner.execute()
 }
 
-function runE2eTests(serve) {
-  if (serve !== 'false') {
-    serveE2e('./', 8000)
-  }
-
+function runE2eTests(serve = true) {
+  serve && serveE2e('./', 8000)
   const file = path.join(PROJECT_DIR, 'wdio.conf.js')
+  testUtils.runE2eTests(file, false)
+}
+
+function runE2eFailsafeTests(serve = true) {
+  serve && serveE2e('./', 8000)
+  const file = path.join(PROJECT_DIR, 'wdio-failsafe.conf.js')
   testUtils.runE2eTests(file, false)
 }
 
 const scripts = {
   startSelenium: testUtils.startSelenium,
   runE2eTests,
+  runE2eFailsafeTests,
   runNodeTests() {
     var servers = serveE2e('./', 8000)
     runJasmine(function(err) {

--- a/packages/rum/run-script.js
+++ b/packages/rum/run-script.js
@@ -27,7 +27,9 @@ const path = require('path')
 const JasmineRunner = require('jasmine')
 const express = require('express')
 const serveIndex = require('serve-index')
+const runAll = require('npm-run-all')
 const testUtils = require('../../dev-utils/test-utils')
+const { getSauceConnectOptions } = require('../../dev-utils/test-config')
 const { runIntegrationTest } = require('./test/e2e/integration-test')
 const { generateNotice } = require('../../dev-utils/dep-info')
 
@@ -49,10 +51,10 @@ function createBackendAgentServer() {
   })
 
   function dTRespond(req, res) {
-    var header = req.headers['elastic-apm-traceparent']
-    var payload = { noHeader: true }
+    const header = req.headers['elastic-apm-traceparent']
+    let payload = { noHeader: true }
     if (header) {
-      var splited = header.split('-')
+      const splited = header.split('-')
       payload = {
         version: splited[0],
         traceId: splited[1],
@@ -68,24 +70,24 @@ function createBackendAgentServer() {
   app.post('/data', dTRespond)
   app.post('/fetch', dTRespond)
 
-  var port = 8003
-  var server = app.listen(port)
+  const port = 8003
+  const server = app.listen(port)
 
-  console.log('serving on: ', port)
+  console.log('[Backend Server] - serving on: ', port)
   return server
 }
 
 function serveE2e(servingPath, port) {
   const app = express()
-  var staticPath = path.join(__dirname, servingPath)
+  const staticPath = path.join(__dirname, servingPath)
 
   app.get('/healthcheck', function(req, res) {
     res.send('OK')
   })
 
   app.get('/run_integration_test', async function(req, res) {
-    var echo = req.query.echo
-    var result = await runIntegrationTest(
+    const echo = req.query.echo
+    const result = await runIntegrationTest(
       'http://localhost:8000/test/e2e/general-usecase/'
     )
     if (echo) {
@@ -96,11 +98,12 @@ function serveE2e(servingPath, port) {
   })
 
   app.use(express.static(staticPath), serveIndex(staticPath, { icons: false }))
-  var server = app.listen(port)
+  const staticServer = app.listen(port)
 
-  console.log('serving on: ', staticPath, port)
-  var backendAgentServer = createBackendAgentServer()
-  return [server, backendAgentServer]
+  console.log('[Static Server] - serving on: ', staticPath, port)
+  const backendAgentServer = createBackendAgentServer()
+
+  return [staticServer, backendAgentServer]
 }
 
 function runJasmine(cb) {
@@ -126,43 +129,69 @@ function runJasmine(cb) {
   jrunner.execute()
 }
 
-function runE2eTests(serve = true) {
-  serve && serveE2e('./', 8000)
-  const file = path.join(PROJECT_DIR, 'wdio.conf.js')
-  testUtils.runE2eTests(file, false)
+function runE2eTests(config) {
+  const webDriverConfig = path.join(PROJECT_DIR, config)
+  testUtils.runE2eTests(webDriverConfig, false)
 }
 
-function runE2eFailsafeTests(serve = true) {
-  serve && serveE2e('./', 8000)
-  const file = path.join(PROJECT_DIR, 'wdio-failsafe.conf.js')
-  testUtils.runE2eTests(file, false)
+function runSauceTests(serve = 'true') {
+  let servers = []
+  if (serve === 'true') {
+    servers = serveE2e('./', 8000)
+  }
+  /**
+   * Since there is no easy way to reuse the sauce connect tunnel even using same tunnel identifier,
+   * we launch the sauce connect tunnel before starting all the saucelab tests
+   *
+   * Unit tests are not run in parallel with E2E because of concurrency limit in saucelabs
+   */
+  const sauceConnectOpts = getSauceConnectOptions()
+  testUtils.runSauceConnect(sauceConnectOpts, () => {
+    runAll('test:unit', {
+      stdout: process.stdout,
+      stderr: process.stderr
+    })
+      .then(() =>
+        runAll(['test:e2e:supported', 'test:e2e:failsafe'], {
+          parallel: true,
+          aggregateOutput: true,
+          printLabel: true,
+          stdout: process.stdout,
+          stderr: process.stderr
+        })
+      )
+      .then(() => {
+        console.log('All Unit and E2E Sauce Tests done')
+      })
+      .catch(err => {
+        console.log('Sauce Tests Failed', err)
+      })
+      .then(() => {
+        servers.map(s => s.close())
+        process.exit(0)
+      })
+  })
 }
 
 const scripts = {
   startSelenium: testUtils.startSelenium,
+  runSauceTests,
   runE2eTests,
-  runE2eFailsafeTests,
   runNodeTests() {
-    var servers = serveE2e('./', 8000)
+    const servers = serveE2e('./', 8000)
     runJasmine(function(err) {
       servers.forEach(server => server.close())
       if (err) {
         console.log('Node tests failed:', err)
-        var exitCode = 2
-        process.exit(exitCode)
+        process.exit(2)
       }
     })
   },
   buildE2eBundles(basePath) {
     basePath = basePath || './test/e2e'
-    function callback(err) {
-      if (err) {
-        var exitCode = 2
-        process.exit(exitCode)
-      }
-    }
-
-    testUtils.buildE2eBundles(path.join(PROJECT_DIR, basePath), callback)
+    testUtils.buildE2eBundles(path.join(PROJECT_DIR, basePath), err => {
+      err && process.exit(2)
+    })
   },
   serveE2e,
   generateNotice
@@ -171,12 +200,10 @@ const scripts = {
 module.exports = scripts
 
 function runScript() {
-  var scriptName = process.argv[2]
+  const [, , scriptName, ...scriptArgs] = process.argv
   if (scriptName) {
-    var scriptArgs = [].concat(process.argv)
-    scriptArgs.splice(0, 3)
     var message = `Running: ${scriptName}(${scriptArgs
-      .map(a => "'" + a + "'")
+      .map(a => a.trim())
       .join(', ')}) \n`
     console.log(message)
     if (typeof scripts[scriptName] === 'function') {

--- a/packages/rum/test/e2e/.babelrc.js
+++ b/packages/rum/test/e2e/.babelrc.js
@@ -6,7 +6,7 @@ module.exports = function(api) {
         '@babel/preset-env',
         {
           targets: {
-            ie: '10'
+            ie: '11'
           },
           useBuiltIns: false,
           modules: 'umd'

--- a/packages/rum/test/e2e/general-usecase/app.e2e-spec.js
+++ b/packages/rum/test/e2e/general-usecase/app.e2e-spec.js
@@ -27,10 +27,7 @@ const { allowSomeBrowserErrors } = require('../../../../../dev-utils/webdriver')
 
 describe('general-usercase', function() {
   it('should run the general usecase', function() {
-    browser.timeouts('script', 30000)
-    browser.url('/test/e2e/general-usecase/index.html')
-
-    browser.waitUntil(
+    browser.url('/test/e2e/general-usecase/index.html').waitUntil(
       function() {
         return browser.getText('#test-element') === 'Passed'
       },

--- a/packages/rum/test/e2e/standalone-html/app.e2e-failsafe.js
+++ b/packages/rum/test/e2e/standalone-html/app.e2e-failsafe.js
@@ -23,21 +23,36 @@
  *
  */
 
-module.exports = function(api) {
-  api.cache(true)
-  return {
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          targets: {
-            ie: '11'
-          },
-          useBuiltIns: false,
-          modules: false,
-          loose: true
-        }
-      ]
-    ]
-  }
-}
+describe('standalone-html', function() {
+  it('should run application without errors for base bundle', function() {
+    browser.url('/test/e2e/standalone-html/index.html').waitUntil(
+      () => {
+        return browser.getText('#test-element') === 'Passed'
+      },
+      10000,
+      'expected element #test-element'
+    )
+
+    const { value: capturedErrors } = browser.execute(function() {
+      return window.capturedTestErrors
+    })
+    console.error('CapturedErrors', capturedErrors)
+    expect(capturedErrors.length).toEqual(0)
+  })
+
+  it('should run application without errors for opentracing bundle', function() {
+    browser.url('/test/e2e/standalone-html/opentracing.html').waitUntil(
+      function() {
+        return browser.getText('#test-element') === 'Passed'
+      },
+      10000,
+      'expected element #test-element'
+    )
+
+    const { value: capturedErrors } = browser.execute(function() {
+      return window.capturedTestErrors
+    })
+    console.error('CapturedErrors', capturedErrors)
+    expect(capturedErrors.length).toEqual(0)
+  })
+})

--- a/packages/rum/test/e2e/standalone-html/app.e2e-spec.js
+++ b/packages/rum/test/e2e/standalone-html/app.e2e-spec.js
@@ -27,10 +27,7 @@ const { allowSomeBrowserErrors } = require('../../../../../dev-utils/webdriver')
 
 describe('standalone-html', function() {
   it('should run the usecase', function() {
-    browser.timeouts('script', 30000)
-    browser.url('/test/e2e/standalone-html/index.html')
-
-    browser.waitUntil(
+    browser.url('/test/e2e/standalone-html/index.html').waitUntil(
       function() {
         return browser.getText('#test-element') === 'Passed'
       },
@@ -42,10 +39,7 @@ describe('standalone-html', function() {
   })
 
   it('should run the opentracing use-case', function() {
-    browser.timeouts('script', 30000)
-    browser.url('/test/e2e/standalone-html/opentracing.html')
-
-    browser.waitUntil(
+    browser.url('/test/e2e/standalone-html/opentracing.html').waitUntil(
       function() {
         return browser.getText('#test-element') === 'Passed'
       },

--- a/packages/rum/test/e2e/standalone-html/index.html
+++ b/packages/rum/test/e2e/standalone-html/index.html
@@ -4,6 +4,15 @@
     <title>test</title>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <script type="application/javascript">
+      /**
+       * Used for testing errors on unsupported browsers
+       */
+      window.capturedTestErrors = []
+      window.onerror = function(err) {
+        window.capturedTestErrors.push(err)
+      }
+    </script>
   </head>
 
   <body>

--- a/packages/rum/test/e2e/standalone-html/opentracing.html
+++ b/packages/rum/test/e2e/standalone-html/opentracing.html
@@ -4,6 +4,15 @@
     <title>test</title>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <script type="application/javascript">
+      /**
+       * Used for testing errors on unsupported browsers
+       */
+      window.capturedTestErrors = []
+      window.onerror = function(err) {
+        window.capturedTestErrors.push(err)
+      }
+    </script>
   </head>
 
   <body>

--- a/packages/rum/wdio-failsafe.conf.js
+++ b/packages/rum/wdio-failsafe.conf.js
@@ -23,21 +23,23 @@
  *
  */
 
-module.exports = function(api) {
-  api.cache(true)
-  return {
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          targets: {
-            ie: '11'
-          },
-          useBuiltIns: false,
-          modules: false,
-          loose: true
-        }
-      ]
-    ]
+const { join } = require('path')
+const { config } = require('./wdio.conf')
+
+const browserList = [
+  {
+    browserName: 'internet explorer',
+    platform: 'Windows 7',
+    version: '10'
+  },
+  {
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.4'
   }
-}
+]
+
+exports.config = Object.assign({}, config, {
+  specs: join(__dirname, '/test/e2e/**/*failsafe.js'),
+  capabilities: browserList
+})

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -61,7 +61,7 @@ exports.config = {
   services: ['sauce'],
   user: sauceConnectOpts.username,
   key: sauceConnectOpts.accessKey,
-  sauceConnect: true,
+  sauceConnect: false,
   sauceConnectOpts,
   capabilities: browserList,
   logLevel: 'silent',

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -23,7 +23,7 @@
  *
  */
 
-const path = require('path')
+const { join } = require('path')
 const { getSauceConnectOptions } = require('../../dev-utils/test-config')
 const { isChrome } = require('../../dev-utils/webdriver')
 
@@ -36,12 +36,6 @@ const browserList = [
     browserName: 'firefox',
     version: '57'
   },
-  // {
-  //   browserName: 'internet explorer',
-  //   platform: 'Windows 10',
-  //   version: '11',
-  //   iedriverVersion: 'x64_2.48.0'
-  // },
   {
     browserName: 'microsoftedge',
     platform: 'Windows 10',
@@ -62,7 +56,7 @@ const browserList = [
 const sauceConnectOpts = getSauceConnectOptions()
 
 exports.config = {
-  specs: [path.join(__dirname, '/test/e2e/**/*.e2e-spec.js')],
+  specs: [join(__dirname, '/test/e2e/standalone-html/*.e2e-spec.js')],
   maxInstancesPerCapability: 3,
   services: ['sauce'],
   user: sauceConnectOpts.username,
@@ -71,7 +65,7 @@ exports.config = {
   sauceConnectOpts,
   capabilities: browserList,
   logLevel: 'silent',
-  screenshotPath: path.join(__dirname, 'error-screenshot'),
+  screenshotPath: join(__dirname, 'error-screenshot'),
   baseUrl: 'http://localhost:8000',
   waitforTimeout: 30000,
   framework: 'jasmine',

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -56,7 +56,7 @@ const browserList = [
 const sauceConnectOpts = getSauceConnectOptions()
 
 exports.config = {
-  specs: [join(__dirname, '/test/e2e/standalone-html/*.e2e-spec.js')],
+  specs: [join(__dirname, '/test/e2e/**/*.e2e-spec.js')],
   maxInstancesPerCapability: 3,
   services: ['sauce'],
   user: sauceConnectOpts.username,


### PR DESCRIPTION
Dropping the support for IE 10 and android 4* versions. Bundling configurations and testing environments are changed to reflect the same

+ fixes https://github.com/elastic/apm-agent-js-base/issues/132

 + Unit and E2E Tests now use single saucelabs tunnel to improve the test speed and also parallized the tests for supported/unsupported browsers. 