### PR TITLE
feat(rum-core): limit the length of keyword/non-keyword fields 

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -23,7 +23,7 @@
  *
  */
 
-const { getCurrentScript, sanitizeString, setTag, merge } = require('./utils')
+const { getCurrentScript, setTag, merge } = require('./utils')
 const Subscription = require('../common/subscription')
 const constants = require('./constants')
 
@@ -177,23 +177,17 @@ class Config {
 
   setUserContext(userContext) {
     var context = {}
-    if (typeof userContext.id === 'number') {
+    if (
+      typeof userContext.id === 'number' ||
+      typeof userContext.id === 'string'
+    ) {
       context.id = userContext.id
     }
-    if (typeof userContext.id === 'string') {
-      context.id = sanitizeString(userContext.id, this.get('serverStringLimit'))
-    }
     if (typeof userContext.username === 'string') {
-      context.username = sanitizeString(
-        userContext.username,
-        this.get('serverStringLimit')
-      )
+      context.username = userContext.username
     }
     if (typeof userContext.email === 'string') {
-      context.email = sanitizeString(
-        userContext.email,
-        this.get('serverStringLimit')
-      )
+      context.email = userContext.email
     }
     this.set('context.user', context)
   }

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -1,0 +1,194 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+/**
+ * Goes over the object in Breadth first fashion
+ * Example:
+ * {
+ *    a: '10',
+ *    b: { c: 20, d: { e: 30 } },
+ *    f: { g: '100' }
+ * }
+ *
+ * Execute callbacks on below paths in order
+ * ['a'],  ['b', 'c'], ['b', 'd', 'e'], ['f', 'g']
+ */
+
+function breathFilter(obj = {}, callback, path = []) {
+  const queue = []
+  let index = 0
+  const keys = Object.keys(obj)
+  if (keys.length === index) {
+    return obj
+  }
+  queue.push(keys[index])
+
+  while (queue.length > 0) {
+    const currKey = queue.shift()
+    const value = obj[currKey]
+
+    if (typeof value === 'object') {
+      breathFilter(value, callback, path.concat(currKey))
+    } else {
+      obj[currKey] = callback(value, path.concat(currKey))
+    }
+    index++
+    if (index < keys.length) {
+      queue.push(keys[index])
+    }
+  }
+  return obj
+}
+
+function truncate(value, limit, required = false, placeholder = 'N/A') {
+  if (required && !value) {
+    value = placeholder
+  }
+  if (value) {
+    return String(value).substr(0, limit)
+  }
+  return value
+}
+
+function truncateMetadata(metadata, opts) {
+  return breathFilter(metadata, (value, path) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+    let limit
+    let required = false
+    switch (path[0]) {
+      case 'service': {
+        switch (path[1]) {
+          case 'version':
+          case 'environment':
+            limit = opts.stringLimit
+            break
+          case 'name':
+            limit = opts.stringLimit
+            required = true
+            break
+
+          case 'agent':
+          case 'language':
+          case 'runtime':
+            switch (path[2]) {
+              case 'name':
+              case 'version':
+                limit = opts.stringLimit
+                break
+            }
+            break
+        }
+        break
+      }
+    }
+    return truncate(value, limit, required)
+  })
+}
+
+function contextLength(path, opts) {
+  switch (path[1]) {
+    case 'user':
+      switch (path[2]) {
+        case 'id':
+        case 'email':
+        case 'username':
+          return opts.stringLimit
+      }
+      break
+
+    case 'tags':
+      return opts.stringLimit
+  }
+
+  return opts.stringLimit
+}
+
+function truncateSpan(span, opts) {
+  return breathFilter(span, (value, path) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+    let limit
+    let required = false
+    switch (path[0]) {
+      case 'name':
+      case 'type':
+        required = true
+        limit = opts.stringLimit
+        break
+
+      case 'id':
+      case 'trace_id':
+      case 'parent_id':
+      case 'transaction_id':
+      case 'subtype':
+      case 'action':
+        limit = opts.stringLimit
+        break
+
+      case 'context':
+        limit = contextLength(path, opts)
+        break
+    }
+    return truncate(value, limit, required)
+  })
+}
+
+function truncateTransaction(trans, opts) {
+  return breathFilter(trans, (value, path) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+    let limit
+    let required = false
+    switch (path[0]) {
+      case 'type':
+      case 'id':
+      case 'trace_id':
+      case 'parent_id':
+        required = true
+        limit = opts.stringLimit
+        break
+
+      case 'name':
+        limits = opts.stringLimit
+        break
+
+      case 'context':
+        limit = contextLength(path, opts)
+        break
+    }
+    return truncate(value, limit, required)
+  })
+}
+
+module.exports = {
+  truncate,
+  truncateMetadata,
+  truncateSpan,
+  truncateTransaction
+}

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -93,7 +93,6 @@ function truncateMetadata(metadata, opts) {
 
           case 'agent':
           case 'language':
-          case 'runtime':
             switch (path[2]) {
               case 'name':
               case 'version':

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -124,7 +124,7 @@ function contextLength(path, opts) {
       return opts.stringLimit
   }
 
-  return opts.stringLimit
+  return undefined
 }
 
 function truncateSpan(span, opts) {
@@ -158,8 +158,8 @@ function truncateSpan(span, opts) {
   })
 }
 
-function truncateTransaction(trans, opts) {
-  return breathFilter(trans, (value, path) => {
+function truncateTransaction(transaction, opts) {
+  return breathFilter(transaction, (value, path) => {
     if (typeof value !== 'string') {
       return value
     }
@@ -175,7 +175,7 @@ function truncateTransaction(trans, opts) {
         break
 
       case 'name':
-        limits = opts.stringLimit
+        limit = opts.stringLimit
         break
 
       case 'context':

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -186,9 +186,55 @@ function truncateTransaction(trans, opts) {
   })
 }
 
+function truncateError(error, opts) {
+  return breathFilter(error, (value, path) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+
+    let limit
+    let required = false
+    switch (path[0]) {
+      case 'id':
+        limit = opts.stringLimit
+        required = true
+        break
+
+      case 'trace_id':
+      case 'transaction_id':
+      case 'parent_id':
+      case 'culprit':
+        limit = opts.stringLimit
+        break
+
+      case 'exception':
+        switch (path[1]) {
+          case 'type':
+            limit = opts.stringLimit
+            break
+        }
+        break
+
+      case 'transaction':
+        switch (path[1]) {
+          case 'type':
+            limit = opts.stringLimit
+            break
+        }
+        break
+
+      case 'context':
+        limit = contextLength(path, opts)
+        break
+    }
+    return truncate(value, limit, required)
+  })
+}
+
 module.exports = {
   truncate,
   truncateMetadata,
   truncateSpan,
-  truncateTransaction
+  truncateTransaction,
+  truncateError
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -23,7 +23,6 @@
  *
  */
 
-const { serverStringLimit } = require('./constants')
 const Url = require('../common/url')
 const rng = require('uuid/lib/rng-browser')
 
@@ -135,47 +134,13 @@ function isPlatformSupported() {
   )
 }
 
-function sanitizeString(
-  value,
-  limit = serverStringLimit,
-  required = false,
-  placeholder = 'NA'
-) {
-  if (typeof value === 'number') {
-    value = String(value)
-  }
-  if (required && !value) {
-    value = placeholder
-  }
-  if (value) {
-    return String(value).substr(0, limit)
-  } else {
-    return value
-  }
-}
-
 function setTag(key, value, obj) {
   if (!obj || !key) return
   var skey = removeInvalidChars(key)
-  obj[skey] = sanitizeString(value, serverStringLimit)
-  return obj
-}
-
-function sanitizeObjectStrings(obj, limit, required, placeholder) {
-  if (!obj) return obj
-  if (typeof obj === 'string') {
-    return sanitizeString(obj, limit, required, placeholder)
+  if (typeof value === 'object') {
+    value = String(value)
   }
-  var keys = Object.keys(obj)
-  keys.forEach(function(k) {
-    var value = obj[k]
-    if (typeof value === 'string') {
-      value = sanitizeString(obj[k], limit, required, placeholder)
-    } else if (typeof value === 'object') {
-      value = sanitizeObjectStrings(value, limit, required, placeholder)
-    }
-    obj[k] = value
-  })
+  obj[skey] = value
   return obj
 }
 
@@ -374,8 +339,6 @@ module.exports = {
   generateRandomId,
   rng,
   checkSameOrigin,
-  sanitizeString,
-  sanitizeObjectStrings,
   setTag,
   stripQueryStringFromUrl,
   find,

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -134,10 +134,18 @@ function isPlatformSupported() {
   )
 }
 
+/**
+ * Convert values of the tag to be string to be compatible
+ * with the apm server prior to <6.7 version
+ *
+ * TODO: Remove string conversion in the next major release since
+ * support for boolean and number in the APM server has landed in 6.7
+ * https://github.com/elastic/apm-server/pull/1712/
+ */
 function setTag(key, value, obj) {
   if (!obj || !key) return
   var skey = removeInvalidChars(key)
-  if (typeof value === 'object') {
+  if (value) {
     value = String(value)
   }
   obj[skey] = value

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -23,9 +23,9 @@
  *
  */
 
-var StackTraceService = require('./stack-trace-service')
-
-var utils = require('../common/utils')
+const StackTraceService = require('./stack-trace-service')
+const utils = require('../common/utils')
+const { truncate } = require('../common/truncate')
 
 class ErrorLogging {
   constructor(apmServer, configService, loggingService, transactionService) {
@@ -89,11 +89,11 @@ class ErrorLogging {
 
     var errorObject = {
       id: utils.generateRandomId(),
-      culprit: utils.sanitizeString(culprit),
+      culprit: truncate(culprit),
       exception: {
-        message: utils.sanitizeString(message, undefined, true),
+        message: truncate(message, undefined, true),
         stacktrace: frames,
-        type: utils.sanitizeString(errorType, stringLimit, false)
+        type: truncate(errorType, stringLimit, false)
       },
       context
     }

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -364,7 +364,7 @@ describe('ApmServer', function() {
     expect(apmServer._postJson).not.toHaveBeenCalled()
   })
 
-  it('should set service object from config along with defaults', () => {
+  it('should set metadata from config along with defaults', () => {
     configService.setConfig({
       serviceName: 'test',
       serviceVersion: '0.0.1',
@@ -373,7 +373,8 @@ describe('ApmServer', function() {
       agentVersion: '3.0.0'
     })
 
-    expect(apmServer.createServiceObject()).toEqual({
+    const { service } = apmServer.createMetaData()
+    expect(service).toEqual({
       name: 'test',
       version: '0.0.1',
       environment: 'staging',
@@ -388,9 +389,9 @@ describe('ApmServer', function() {
     var result = apmServer.ndjsonTransactions(trs)
     /* eslint-disable max-len */
     var expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n'
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n'
     ]
     expect(result).toEqual(expected)
   })

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -165,7 +165,7 @@ describe('ConfigService', function() {
     const contextTags = configService.get('context.tags')
     expect(contextTags).toEqual({
       test: 'test',
-      no: 1,
+      no: '1',
       test_test: 'test',
       obj: '[object Object]',
       date: String(date)

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -154,33 +154,18 @@ describe('ConfigService', function() {
 
   it('should addTags', function() {
     var date = new Date()
-    configService.addTags({
+    const tags = {
       test: 'test',
       no: 1,
       'test.test': 'test',
       obj: { just: 'object' },
       date
-    })
-    var tags = configService.get('context.tags')
-    expect(tags).toEqual({
+    }
+    configService.addTags(tags)
+    const contextTags = configService.get('context.tags')
+    expect(contextTags).toEqual({
       test: 'test',
-      no: '1',
-      test_test: 'test',
-      obj: '[object Object]',
-      date: String(date)
-    })
-
-    configService.addTags({
-      test: undefined,
       no: 1,
-      'test.test': 'test',
-      obj: { just: 'object' },
-      date
-    })
-    tags = configService.get('context.tags')
-    expect(tags).toEqual({
-      test: undefined,
-      no: '1',
       test_test: 'test',
       obj: '[object Object]',
       date: String(date)

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -1,0 +1,67 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const { truncate, truncateMetadata } = require('../../src/common/truncate')
+
+describe('Truncate', () => {
+  it('truncate values with options', () => {
+    expect(truncate('', undefined, true)).toEqual('N/A')
+    const longString = 'a'.repeat('10')
+    expect(truncate(longString, 2)).toEqual('aa')
+    const placeHolder = 'dummyplaceholder'
+    expect(truncate('', undefined, true, placeHolder)).toEqual(placeHolder)
+  })
+
+  it('truncate metadata with specifed limits', () => {
+    const longName = '0'.repeat('10')
+    const metadata = {
+      service: {
+        name: '',
+        version: 2.0,
+        agent: {
+          name: longName,
+          version: 3
+        },
+        environment: 'dev'
+      }
+    }
+
+    const newMetadata = truncateMetadata(metadata, {
+      stringLimit: 5
+    })
+
+    expect(newMetadata).toEqual({
+      service: {
+        name: 'N/A',
+        version: 2.0,
+        agent: {
+          name: '00000',
+          version: 3
+        },
+        environment: 'dev'
+      }
+    })
+  })
+})

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -28,14 +28,14 @@ const { truncate, truncateMetadata } = require('../../src/common/truncate')
 describe('Truncate', () => {
   it('truncate values with options', () => {
     expect(truncate('', undefined, true)).toEqual('N/A')
-    const longString = 'a'.repeat('10')
-    expect(truncate(longString, 2)).toEqual('aa')
+    const longString = 'abcde'
+    expect(truncate(longString, 2)).toEqual('ab')
     const placeHolder = 'dummyplaceholder'
     expect(truncate('', undefined, true, placeHolder)).toEqual(placeHolder)
   })
 
-  it('truncate metadata with specifed limits', () => {
-    const longName = '0'.repeat('10')
+  it('truncate metadata', () => {
+    const longName = 'aaaaaaaa'
     const metadata = {
       service: {
         name: '',
@@ -48,16 +48,16 @@ describe('Truncate', () => {
       }
     }
 
-    const newMetadata = truncateMetadata(metadata, {
-      stringLimit: 5
+    const filtered = truncateMetadata(metadata, {
+      stringLimit: 3
     })
 
-    expect(newMetadata).toEqual({
+    expect(filtered).toEqual({
       service: {
         name: 'N/A',
         version: 2.0,
         agent: {
-          name: '00000',
+          name: 'aaa',
           version: 3
         },
         environment: 'dev'

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -89,7 +89,6 @@ describe('Truncate', () => {
           username: generateStr('f', keywordLen)
         },
         tags: {
-          pageload: true,
           key: generateStr('g', keywordLen)
         }
       },
@@ -123,7 +122,6 @@ describe('Truncate', () => {
           username: generateStr('f', stringLimit)
         },
         tags: {
-          pageload: true,
           key: generateStr('g', stringLimit)
         }
       },

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -247,7 +247,7 @@ describe('lib/utils', function() {
     utils.setTag('obj', {}, tags)
     expect(tags).toEqual({
       test: 'test',
-      no: 1,
+      no: '1',
       test_test: 'passed',
       date: String(date),
       removed: undefined,

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -69,62 +69,6 @@ describe('lib/utils', function() {
     html.removeChild(script)
   })
 
-  describe('sanitizeString', function() {
-    it('should sanitize', function() {
-      expect(utils.sanitizeString()).toBe(undefined)
-      expect(utils.sanitizeString(null, 10)).toBe(null)
-      expect(utils.sanitizeString(null, 10, true)).toBe('NA')
-      expect(utils.sanitizeString(undefined, 10, true)).toBe('NA')
-      expect(utils.sanitizeString(undefined, 5, true, 'no string')).toBe(
-        'no st'
-      )
-      expect(utils.sanitizeString('justlong', 5, true, 'no string')).toBe(
-        'justl'
-      )
-      expect(
-        utils.sanitizeString('justlong', undefined, true, 'no string')
-      ).toBe('justlong')
-      expect(utils.sanitizeString('just', 5, true, 'no string')).toBe('just')
-      expect(
-        utils.sanitizeString(
-          { what: 'This is an object' },
-          5,
-          true,
-          'no string'
-        )
-      ).toBe('[obje')
-      expect(utils.sanitizeString(0, 5, true, 'no string')).toBe('0')
-      expect(utils.sanitizeString(1, 5, true, 'no string')).toBe('1')
-    })
-
-    it('should sanitize objects', function() {
-      var result = utils.sanitizeObjectStrings(
-        {
-          string: 'string',
-          null: null,
-          undefined,
-          number: 1,
-          object: {
-            string: 'string'
-          }
-        },
-        3
-      )
-
-      expect(result).toEqual({
-        string: 'str',
-        null: null,
-        undefined,
-        number: 1,
-        object: {
-          string: 'str'
-        }
-      })
-
-      expect(utils.sanitizeObjectStrings('test', 3)).toBe('tes')
-    })
-  })
-
   it('should getNavigationTimingMarks', function() {
     var marks = utils.getNavigationTimingMarks()
     expect(marks.fetchStart).toBeGreaterThanOrEqual(0)
@@ -303,7 +247,7 @@ describe('lib/utils', function() {
     utils.setTag('obj', {}, tags)
     expect(tags).toEqual({
       test: 'test',
-      no: '1',
+      no: 1,
       test_test: 'passed',
       date: String(date),
       removed: undefined,

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -35,11 +35,11 @@
   "bundlesize": [
     {
       "path": "./dist/bundles/elastic-apm-js-base*.min.js",
-      "maxSize": "16.5 kB"
+      "maxSize": "16 kB"
     },
     {
       "path": "./dist/bundles/elastic-apm-opentracing*.min.js",
-      "maxSize": "18.5 kB"
+      "maxSize": "18kB"
     }
   ]
 }

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -35,11 +35,11 @@
   "bundlesize": [
     {
       "path": "./dist/bundles/elastic-apm-js-base*.min.js",
-      "maxSize": "16 kB"
+      "maxSize": "16.5 kB"
     },
     {
       "path": "./dist/bundles/elastic-apm-opentracing*.min.js",
-      "maxSize": "18kB"
+      "maxSize": "18.5 kB"
     }
   ]
 }


### PR DESCRIPTION
+ fixes elastic/apm-agent-js-base#61

+ We now have the ability to truncate both keyword and non keywords fields to APM Server at a single place. This applies to Metadata, Transactions, Spans and Errors - Future:  Metricsets as well

+ Inspired heavily from Node.js agent truncation module. Instead of truncating the string at creation time, We are now moving the truncation when the payload is sent to the server. This enables us to measure the performance of payload creation and filtering that gets applied. 

+ All the undefined and null values are removed from the server payload to reduce the payload size. This is done using required field in truncation. 
