### PR TITLE
chore(rum): e2e bundles should point to correct apm server url

### DIFF
--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -76,8 +76,9 @@ function getGlobalConfig(packageName = 'rum') {
  * Used for injecting process.env across webpack bundles for testing
  */
 function getWebpackEnv() {
+  const { serverUrl } = getTestEnvironmentVariables()
   return {
-    APM_SERVER_URL: defaultApmServerUrl
+    APM_SERVER_URL: serverUrl
   }
 }
 


### PR DESCRIPTION
+ We were defaulting to `http://localhost:8200` for . server url which was wrong and caught by https://github.com/elastic/apm-integration-testing/pull/370