### PR TITLE
feat(rum-core): add size & server timing information to traces

### DIFF
--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -43,7 +43,14 @@ const METADATA_MODEL = {
   }
 }
 
-const CONTEXT_COMMON = {
+const RESPONSE_MODEL = {
+  '*': true,
+  headers: {
+    '*': true
+  }
+}
+
+const CONTEXT_MODEL = {
   user: {
     id: true,
     email: true,
@@ -51,7 +58,13 @@ const CONTEXT_COMMON = {
   },
   tags: {
     '*': true
-  }
+  },
+  /** Spans */
+  http: {
+    response: RESPONSE_MODEL
+  },
+  /** Transactions */
+  response: RESPONSE_MODEL
 }
 
 const SPAN_MODEL = {
@@ -63,7 +76,7 @@ const SPAN_MODEL = {
   transaction_id: [KEYWORD_LIMIT, true],
   subtype: true,
   action: true,
-  context: CONTEXT_COMMON
+  context: CONTEXT_MODEL
 }
 
 const TRANSACTION_MODEL = {
@@ -75,7 +88,7 @@ const TRANSACTION_MODEL = {
   span_count: {
     started: [KEYWORD_LIMIT, true]
   },
-  context: CONTEXT_COMMON
+  context: CONTEXT_MODEL
 }
 
 const ERROR_MODEL = {
@@ -90,7 +103,7 @@ const ERROR_MODEL = {
   transaction: {
     type: true
   },
-  context: CONTEXT_COMMON
+  context: CONTEXT_MODEL
 }
 
 function truncate(

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -230,8 +230,7 @@ function getServerTimingInfo(serverTimingEntries = []) {
   const valueSeparator = ';'
   for (let i = 0; i < serverTimingEntries.length; i++) {
     const { name, duration, description } = serverTimingEntries[i]
-    let timingValue = ''
-    timingValue += name
+    let timingValue = name
     if (description) {
       timingValue += valueSeparator + 'desc=' + description
     }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -209,38 +209,38 @@ function getPaintTimingMarks() {
 
 /**
  *  Server timing information on Performance resource timing entries
+ *  https://www.w3.org/TR/server-timing/
  *  [
  *    {
- *      name: "cache",
- *      duration:  "200",
- *      desciprion: "Cache read"
+ *      name: "cdn-cache",
+ *      duration: 0,
+ *      desciprion: "HIT"
  *    },
  *    {
- *      name: "app",
- *      duration: "500"
+ *      name: "edge",
+ *      duration: 4,
+ *      desciption: ''
  *    }
  *  ]
- *  returns "Cache read;cache=200,app=500"
+ *  returns "cdn-cache;desc=HIT, edge;dur=4"
  */
-function getServerTimingInfo(serverTimingEntries) {
-  let serverTimingStr = ''
-  if (!serverTimingEntries) {
-    return serverTimingStr
-  }
-
+function getServerTimingInfo(serverTimingEntries = []) {
+  let serverTimingInfo = []
+  const entrySeparator = ', '
+  const valueSeparator = ';'
   for (let i = 0; i < serverTimingEntries.length; i++) {
     const { name, duration, description } = serverTimingEntries[i]
-    // Separate the entries by ','
-    serverTimingStr += i > 0 ? ',' : ''
+    let timingValue = ''
+    timingValue += name
     if (description) {
-      serverTimingStr += description + ';'
+      timingValue += valueSeparator + 'desc=' + description
     }
-    serverTimingStr += name
     if (duration) {
-      serverTimingStr += `=${duration}`
+      timingValue += valueSeparator + 'dur=' + duration
     }
+    serverTimingInfo.push(timingValue)
   }
-  return serverTimingStr
+  return serverTimingInfo.join(entrySeparator)
 }
 
 function getTimeOrigin() {

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -223,25 +223,24 @@ function getPaintTimingMarks() {
  *  returns "Cache read;cache=200,app=500"
  */
 function getServerTimingInfo(serverTimingEntries) {
-  const entries = ''
+  let serverTimingStr = ''
   if (!serverTimingEntries) {
-    return entries
+    return serverTimingStr
   }
 
   for (let i = 0; i < serverTimingEntries.length; i++) {
     const { name, duration, description } = serverTimingEntries[i]
     // Separate the entries by ','
-    let entry = i ? 0 > ',' : ''
+    serverTimingStr += i > 0 ? ',' : ''
     if (description) {
-      entry += description + ';'
+      serverTimingStr += description + ';'
     }
-    entry += name
+    serverTimingStr += name
     if (duration) {
-      entry += `=${duration}`
+      serverTimingStr += `=${duration}`
     }
-    entries.push(entry)
   }
-  return entries
+  return serverTimingStr
 }
 
 function getTimeOrigin() {

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -207,6 +207,43 @@ function getPaintTimingMarks() {
   return paints
 }
 
+/**
+ *  Server timing information on Performance resource timing entries
+ *  [
+ *    {
+ *      name: "cache",
+ *      duration:  "200",
+ *      desciprion: "Cache read"
+ *    },
+ *    {
+ *      name: "app",
+ *      duration: "500"
+ *    }
+ *  ]
+ *  returns "Cache read;cache=200,app=500"
+ */
+function getServerTimingInfo(serverTimingEntries) {
+  const entries = ''
+  if (!serverTimingEntries) {
+    return entries
+  }
+
+  for (let i = 0; i < serverTimingEntries.length; i++) {
+    const { name, duration, description } = serverTimingEntries[i]
+    // Separate the entries by ','
+    let entry = i ? 0 > ',' : ''
+    if (description) {
+      entry += description + ';'
+    }
+    entry += name
+    if (duration) {
+      entry += `=${duration}`
+    }
+    entries.push(entry)
+  }
+  return entries
+}
+
 function getTimeOrigin() {
   return window.performance.timing.fetchStart
 }
@@ -378,6 +415,7 @@ export {
   parseDtHeaderValue,
   getNavigationTimingMarks,
   getPaintTimingMarks,
+  getServerTimingInfo,
   getDtHeaderValue,
   getPageMetadata,
   getCurrentScript,

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -80,7 +80,7 @@ function shouldCreateSpan(start, end, baseTime, transactionEnd) {
 /**
  * Both Navigation and Resource timing level 2 exposes these below information
  *
- * for CORS requests, transferSize & encodedBodySize will be 0
+ * for CORS requests without Timing-Allow-Origin header, transferSize & encodedBodySize will be 0
  */
 function getResponseContext(perfTimingEntry) {
   const {

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -114,7 +114,7 @@ function createNavigationTimingSpans(timings, baseTime, transactionEnd) {
 }
 
 function createResourceTimingSpan(resourceTimingEntry) {
-  const { name, initiatorType, start, end } = resourceTimingEntry
+  const { name, initiatorType, startTime, responseEnd } = resourceTimingEntry
   let kind = 'resource'
   if (initiatorType) {
     kind += '.' + initiatorType
@@ -130,9 +130,9 @@ function createResourceTimingSpan(resourceTimingEntry) {
       response: getResponseContext(resourceTimingEntry)
     }
   })
-  span._start = start
+  span._start = startTime
   span.end()
-  span._end = end
+  span._end = responseEnd
   return span
 }
 

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -90,14 +90,18 @@ function getResponseContext(perfTimingEntry) {
     serverTiming
   } = perfTimingEntry
 
-  return {
+  const respContext = {
     transfer_size: transferSize,
     encoded_body_size: encodedBodySize,
-    decoded_body_size: decodedBodySize,
-    headers: {
-      'server-timing': getServerTimingInfo(serverTiming)
+    decoded_body_size: decodedBodySize
+  }
+  const serverTimingStr = getServerTimingInfo(serverTiming)
+  if (serverTimingStr) {
+    respContext.headers = {
+      'server-timing': serverTimingStr
     }
   }
+  return respContext
 }
 
 function createNavigationTimingSpans(timings, baseTime, transactionEnd) {

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -165,7 +165,8 @@ describe('Truncate', () => {
           de: null,
           ef: '',
           headers: {
-            fg: ''
+            fg: '',
+            gh: 'asd'
           }
         }
       },
@@ -205,7 +206,9 @@ describe('Truncate', () => {
         },
         response: {
           cb: 2134,
-          headers: {}
+          headers: {
+            gh: 'asd'
+          }
         }
       },
       marks: {

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -38,6 +38,14 @@ const getMetadataModel = limit => ({
     environment: [limit]
   }
 })
+
+const RESPONSE_MODEL = {
+  '*': true,
+  headers: {
+    '*': true
+  }
+}
+
 const getContextModel = limit => ({
   user: {
     id: [limit],
@@ -46,7 +54,11 @@ const getContextModel = limit => ({
   },
   tags: {
     '*': [limit]
-  }
+  },
+  http: {
+    response: RESPONSE_MODEL
+  },
+  response: RESPONSE_MODEL
 })
 const getSpanModel = limit => ({
   name: [limit, true],
@@ -147,6 +159,14 @@ describe('Truncate', () => {
         tags: {
           ab: generateStr('g', keywordLen),
           bc: generateStr('h', keywordLen)
+        },
+        response: {
+          cb: 2134,
+          de: null,
+          ef: '',
+          headers: {
+            fg: ''
+          }
         }
       },
       marks: {
@@ -182,6 +202,10 @@ describe('Truncate', () => {
         tags: {
           ab: generateStr('g', stringLimit),
           bc: generateStr('h', stringLimit)
+        },
+        response: {
+          cb: 2134,
+          headers: {}
         }
       },
       marks: {
@@ -221,6 +245,16 @@ describe('Truncate', () => {
         page: {
           referer: 'blah',
           url: 'http://a.com/script.js'
+        },
+        http: {
+          response: {
+            cb: 2134,
+            de: null,
+            ef: '',
+            headers: {
+              fg: ''
+            }
+          }
         }
       }
     }
@@ -248,6 +282,12 @@ describe('Truncate', () => {
         page: {
           referer: 'blah',
           url: 'http://a.com/script.js'
+        },
+        http: {
+          response: {
+            cb: 2134,
+            headers: {}
+          }
         }
       }
     })

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -304,7 +304,7 @@ describe('lib/utils', function() {
       }
     ])
     expect(serverTimingStr).toEqual(
-      'Origin cache;cache=200,Edge Cache;edge=20,miss'
+      'Origin cache;cache=200,Edge cache;edge=20,miss'
     )
     // Without description
     expect(

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -301,19 +301,14 @@ describe('lib/utils', function() {
       },
       {
         name: 'miss'
+      },
+      {
+        name: 'app',
+        duration: '50'
       }
     ])
     expect(serverTimingStr).toEqual(
-      'Origin cache;cache=200,Edge cache;edge=20,miss'
+      'cache;desc=Origin cache;dur=200, edge;desc=Edge cache;dur=20, miss, app;dur=50'
     )
-    // Without description
-    expect(
-      utils.getServerTimingInfo([
-        {
-          name: 'app',
-          duration: '50'
-        }
-      ])
-    ).toEqual('app=50')
   })
 })

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -286,4 +286,34 @@ describe('lib/utils', function() {
     )
     expect(utils.removeInvalidChars('invalid"')).toEqual('invalid_')
   })
+
+  it('get servertiming info from servertiming entries', () => {
+    const serverTimingStr = utils.getServerTimingInfo([
+      {
+        name: 'cache',
+        duration: '200',
+        description: 'Origin cache'
+      },
+      {
+        name: 'edge',
+        duration: '20',
+        description: 'Edge cache'
+      },
+      {
+        name: 'miss'
+      }
+    ])
+    expect(serverTimingStr).toEqual(
+      'Origin cache;cache=200,Edge Cache;edge=20,miss'
+    )
+    // Without description
+    expect(
+      utils.getServerTimingInfo([
+        {
+          name: 'app',
+          duration: '50'
+        }
+      ])
+    ).toEqual('app=50')
+  })
 })

--- a/packages/rum-core/test/fixtures/navigation-entries.js
+++ b/packages/rum-core/test/fixtures/navigation-entries.js
@@ -23,30 +23,22 @@
  *
  */
 
-import resourceEntries from '../fixtures/resource-entries'
-import paintEntries from '../fixtures/paint-entries'
-import userTimingEntries from '../fixtures/user-timing-entries'
-import navigationEntries from '../fixtures/navigation-entries'
-
-export function mockGetEntriesByType() {
-  const _getEntriesByType = window.performance.getEntriesByType
-
-  window.performance.getEntriesByType = function(type) {
-    expect(['resource', 'paint', 'measure', 'navigation']).toContain(type)
-    if (type === 'resource') {
-      return resourceEntries
-    } else if (type === 'paint') {
-      return paintEntries
-    } else if (type === 'measure') {
-      return userTimingEntries
-    } else if (type === 'navigation') {
-      return navigationEntries
-    } else {
-      return []
-    }
+export default [
+  {
+    transferSize: 26941,
+    encodedBodySize: 105297,
+    decodedBodySize: 42687,
+    serverTiming: [
+      {
+        description: '',
+        duration: 4,
+        name: 'edge'
+      },
+      {
+        description: 'HIT',
+        duration: 0,
+        name: 'cdn-cache'
+      }
+    ]
   }
-
-  return function unMock() {
-    window.performance.getEntriesByType = _getEntriesByType
-  }
-}
+]

--- a/packages/rum-core/test/performance-monitoring/capture-hard-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-hard-navigation.spec.js
@@ -160,6 +160,20 @@ describe('Capture hard navigation', function() {
       ['http://ajax-filter.test'],
       transactionEnd
     )
+    const lastSpanContext = spans[spans.length - 1].context
+    expect(lastSpanContext).toEqual(
+      jasmine.objectContaining({
+        http: {
+          url: jasmine.any(String),
+          response: {
+            transfer_size: 420580,
+            encoded_body_size: 420379,
+            decoded_body_size: 420379
+          }
+        }
+      })
+    )
+
     expect(spans.map(mapSpan)).toEqual(spanSnapshot)
   })
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -365,15 +365,12 @@ describe('PerformanceMonitoring', function() {
       expect(promise).toBeDefined()
       promise
         .then(
-          () => {
-            unMock()
-          },
-          reason => {
+          () => unMock(),
+          reason =>
             fail(
               'Failed sending page load metrics so the server, reason: ' +
                 reason
             )
-          }
         )
         .then(() => done())
     })


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#190 
+ transfer_size - directly maps to the transferSize resource timing entry
+ encoded_body_size - maps to the encodedBodySize in resource timing entry. 
