### PR TITLE
Update changelog 4.0.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 4.0.0 (2019-03-11)
+
+### Features
+
+* **rum-core:** add service env to metadata payload ([#198](https://github.com/elastic/apm-agent-rum-js/issues/198)) ([adc038b](https://github.com/elastic/apm-agent-rum-js/commit/adc038b))
+* **rum-core:** Add task API ([#194](https://github.com/elastic/apm-agent-rum-js/issues/194)) ([0153229](https://github.com/elastic/apm-agent-rum-js/commit/0153229))
+* **rum-core:** measure all resource entries in page load ([#173](https://github.com/elastic/apm-agent-rum-js/issues/173)) ([7cd4e0d](https://github.com/elastic/apm-agent-rum-js/commit/7cd4e0d))
+
+
+### Performance Improvements
+
+* **rum-core:** avoid url parsing on resource timing entries ([#174](https://github.com/elastic/apm-agent-rum-js/issues/174)) ([54ea6b9](https://github.com/elastic/apm-agent-rum-js/commit/54ea6b9))
+
+
+### BREAKING CHANGES
+
+* move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)
+* Rename the final JS bundles (#202) ([68b37d](https://github.com/elastic/apm-agent-rum-js/commit/68b37d))
+* resolve main field to source file (#179) ([923405](https://github.com/elastic/apm-agent-rum-js/commit/923405))
+
 <a name="3.0.0"></a>
 # [3.0.0](https://github.com/elastic/apm-agent-js-base/compare/v2.3.0...v3.0.0) (2019-01-29)
 

--- a/packages/rum-core/CHANGELOG.md
+++ b/packages/rum-core/CHANGELOG.md
@@ -18,13 +18,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **rum-core:** avoid url parsing on resource timing entries ([#174](https://github.com/elastic/apm-agent-rum-js/issues/174)) ([54ea6b9](https://github.com/elastic/apm-agent-rum-js/commit/54ea6b9))
 
 
-* BREAKING CHANGE: move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)
-
-
 ### BREAKING CHANGES
 
-* Dropping the support for IE 10 and android 4* versions. Bundling condigurations and testing environments are changed to reflect the same
-
-* parallelize the e2e tests and use single tunnel
-
-* update contributing.md
+* move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)

--- a/packages/rum/CHANGELOG.md
+++ b/packages/rum/CHANGELOG.md
@@ -10,14 +10,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **rum-core:** Add task API ([#194](https://github.com/elastic/apm-agent-rum-js/issues/194)) ([0153229](https://github.com/elastic/apm-agent-rum-js/commit/0153229))
 
-
-* BREAKING CHANGE: move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)
-
-
 ### BREAKING CHANGES
 
-* Dropping the support for IE 10 and android 4* versions. Bundling condigurations and testing environments are changed to reflect the same
-
-* parallelize the e2e tests and use single tunnel
-
-* update contributing.md
+* move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)

--- a/packages/rum/CHANGELOG.md
+++ b/packages/rum/CHANGELOG.md
@@ -13,3 +13,5 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### BREAKING CHANGES
 
 * move IE 10 and Android 4 to unsupported list (#196) ([16f4440](https://github.com/elastic/apm-agent-rum-js/commit/16f4440)), closes [#196](https://github.com/elastic/apm-agent-rum-js/issues/196)
+* Rename the final JS bundles (#202) ([68b37d](https://github.com/elastic/apm-agent-rum-js/commit/68b37d))
+* resolve main field to source file (#179) ([923405](https://github.com/elastic/apm-agent-rum-js/commit/923405))


### PR DESCRIPTION
+ The breaking changes commit was sqaushed and the commit body was all over the changelog.  Other breaking changes commits did not have commit . body and it wasn't captured in breaking changes 

+ . Updated the master changelog manually till we find a good solution to automate that. 