### PR TITLE
chore(rum): update browser versions for android and ios in tests

### DIFF
--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -25,62 +25,18 @@
 
 const { Server } = require('karma')
 const { EnvironmentPlugin } = require('webpack')
-const { getWebpackEnv, getSauceConnectOptions } = require('./test-config')
+const {
+  getWebpackEnv,
+  getSauceConnectOptions,
+  getBrowserList
+} = require('./test-config')
 
 const BABEL_CONFIG_FILE = require.resolve('@elastic/apm-rum/babel.config.js')
 
-const baseLaunchers = {
-  SL_CHROME: {
-    base: 'SauceLabs',
-    browserName: 'chrome',
-    version: '62'
-  },
-  SL_CHROME46: {
-    base: 'SauceLabs',
-    browserName: 'chrome',
-    version: '46'
-  },
-  SL_FIREFOX: {
-    base: 'SauceLabs',
-    browserName: 'firefox',
-    version: '42'
-  },
-  SL_SAFARI9: {
-    base: 'SauceLabs',
-    browserName: 'safari',
-    platform: 'OS X 10.11',
-    version: '9.0'
-  },
-  SL_IE11: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    platform: 'Windows 8.1',
-    version: '11'
-  },
-  SL_EDGE: {
-    base: 'SauceLabs',
-    browserName: 'microsoftedge',
-    platform: 'Windows 10',
-    version: '13'
-  },
-  SL_ANDROID: {
-    base: 'SauceLabs',
-    appiumVersion: '1.9.1',
-    deviceName: 'android emulator',
-    browserName: 'browser',
-    platformVersion: '5.1',
-    platformName: 'android'
-  },
-  SL_IOS9: {
-    base: 'SauceLabs',
-    appiumVersion: '1.9.1',
-    deviceName: 'iPhone Simulator',
-    deviceOrientation: 'portrait',
-    platformVersion: '11.0',
-    platformName: 'iOS',
-    browserName: 'Safari'
-  }
-}
+const baseLaunchers = getBrowserList().map(launcher => ({
+  base: 'SauceLabs',
+  ...launcher
+}))
 
 const specPattern = 'test/{*.spec.js,!(e2e)/*.spec.js}'
 const { tunnelIdentifier } = getSauceConnectOptions()

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -68,14 +68,15 @@ const baseLaunchers = {
     appiumVersion: '1.9.1',
     deviceName: 'android emulator',
     browserName: 'browser',
-    platformVersion: '5.0',
+    platformVersion: '5.1',
     platformName: 'android'
   },
   SL_IOS9: {
     base: 'SauceLabs',
+    appiumVersion: '1.9.1',
     deviceName: 'iPhone Simulator',
     deviceOrientation: 'portrait',
-    platformVersion: '9.3',
+    platformVersion: '11.0',
     platformName: 'iOS',
     browserName: 'Safari'
   }

--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -86,15 +86,15 @@ function getBrowserList() {
   return [
     {
       browserName: 'chrome',
-      version: '62'
+      version: '49'
     },
     {
       browserName: 'chrome',
-      version: '46'
+      version: '62'
     },
     {
       browserName: 'firefox',
-      version: '42'
+      version: '59'
     },
     {
       browserName: 'safari',

--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -82,9 +82,57 @@ function getWebpackEnv() {
   }
 }
 
+function getBrowserList() {
+  return [
+    {
+      browserName: 'chrome',
+      version: '62'
+    },
+    {
+      browserName: 'chrome',
+      version: '46'
+    },
+    {
+      browserName: 'firefox',
+      version: '42'
+    },
+    {
+      browserName: 'safari',
+      platform: 'OS X 10.11',
+      version: '9.0'
+    },
+    {
+      browserName: 'internet explorer',
+      platform: 'Windows 8.1',
+      version: '11'
+    },
+    {
+      browserName: 'microsoftedge',
+      platform: 'Windows 10',
+      version: '13'
+    },
+    {
+      appiumVersion: '1.9.1',
+      deviceName: 'android emulator',
+      browserName: 'browser',
+      platformVersion: '5.1',
+      platformName: 'android'
+    },
+    {
+      appiumVersion: '1.9.1',
+      deviceName: 'iPhone Simulator',
+      deviceOrientation: 'portrait',
+      platformVersion: '11.1',
+      platformName: 'iOS',
+      browserName: 'Safari'
+    }
+  ]
+}
+
 module.exports = {
   getSauceConnectOptions,
   getTestEnvironmentVariables,
   getGlobalConfig,
-  getWebpackEnv
+  getWebpackEnv,
+  getBrowserList
 }

--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -40,11 +40,6 @@ function isChrome() {
   return browserName.indexOf('chrome') !== -1
 }
 
-function isIOSDevice() {
-  const platformName = browser.capabilities.platformName.toLowerCase()
-  return platformName === 'ios'
-}
-
 function assertNoBrowserErrors(whitelist) {
   return new Promise((resolve, reject) => {
     /**
@@ -53,9 +48,6 @@ function assertNoBrowserErrors(whitelist) {
     if (!isChrome()) {
       return resolve()
     }
-    // TODO: Bug in ChromeDriver: Need to execute at least one command
-    // so that the browser logs can be read out!
-    browser.execute('1+1')
     var response = browser.getLogs('browser')
     var failureEntries = []
     var debugLogs = []
@@ -138,6 +130,5 @@ module.exports = {
       // done()
     }
   },
-  isChrome,
-  isIOSDevice
+  isChrome
 }

--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -40,6 +40,11 @@ function isChrome() {
   return browserName.indexOf('chrome') !== -1
 }
 
+function isIOSDevice() {
+  const platformName = browser.capabilities.platformName.toLowerCase()
+  return platformName === 'ios'
+}
+
 function assertNoBrowserErrors(whitelist) {
   return new Promise((resolve, reject) => {
     /**
@@ -133,5 +138,6 @@ module.exports = {
       // done()
     }
   },
-  isChrome
+  isChrome,
+  isIOSDevice
 }

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -27,7 +27,7 @@ require('./patch')
 const patchSubscription = window['__patchSubscription']
 const { globalState } = require('../../src/common/patching/patch-utils')
 
-describe('xhrPatch', function() {
+describe('fetchPatch', function() {
   var events = []
   var cancelFn
 
@@ -81,11 +81,17 @@ describe('xhrPatch', function() {
     it('should support native fetch exception', function(done) {
       var promise = window.fetch()
       expect(promise).toBeDefined()
-      promise.catch(function(error) {
-        // can not check the native error message since it's different in browsers
-        expect(error.message).toBeDefined()
-        done()
-      })
+      promise.then(
+        () => {
+          console.log('Bug in fetch spec', window.navigator.userAgent)
+          done()
+        },
+        error => {
+          // can not check the native error message since it's different in browsers
+          expect(error.message).toBeDefined()
+          done()
+        }
+      )
     })
 
     it('should support native fetch alternative call format', function(done) {

--- a/packages/rum-core/test/common/patch.js
+++ b/packages/rum-core/test/common/patch.js
@@ -23,7 +23,7 @@
  *
  */
 
-var patchAll = require('../../src/common/patching/').patchAll
+const { patchAll } = require('../../src/common/patching/')
 
 if (!window['__patchSubscription']) {
   var nativeFetch = window.fetch
@@ -37,7 +37,7 @@ if (!window['__patchSubscription']) {
       }
     }
   }
-  console.log('patchservice')
+  console.log('Pathching XHR and FETCH calls')
   window['__patchSubscription'] = patchAll()
 }
 

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -66,14 +66,23 @@ elasticApm.addFilter(function(payload) {
     })
   }
   if (payload.transactions) {
+    /**
+     * In IE 11 - window.URL is not supported but it exists as an object
+     * We have to ensure that it is indeed a native code
+     */
+    if (window.URL.toString().indexOf('native code') >= 0) {
+      return payload
+    }
     payload.transactions.forEach(function(tr) {
       tr.spans.forEach(function(span) {
         if (span.context && span.context.http && span.context.http.url) {
-          var url = new URL(span.context.http.url, window.location.origin)
-          if (url.searchParams && url.searchParams.get('token')) {
-            url.searchParams.set('token', 'REDACTED')
+          if (window.URL.toString().indexOf('native code') !== -1) {
+            var url = new URL(span.context.http.url, window.location.origin)
+            if (url.searchParams && url.searchParams.get('token')) {
+              url.searchParams.set('token', 'REDACTED')
+            }
+            span.context.http.url = url.toString()
           }
-          span.context.http.url = url.toString()
         }
       })
     })

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -70,19 +70,17 @@ elasticApm.addFilter(function(payload) {
      * In IE 11 - window.URL is not supported but it exists as an object
      * We have to ensure that it is indeed a native code
      */
-    if (window.URL.toString().indexOf('native code') >= 0) {
+    if (window.URL.toString().indexOf('native code') === -1) {
       return payload
     }
     payload.transactions.forEach(function(tr) {
       tr.spans.forEach(function(span) {
         if (span.context && span.context.http && span.context.http.url) {
-          if (window.URL.toString().indexOf('native code') !== -1) {
-            var url = new URL(span.context.http.url, window.location.origin)
-            if (url.searchParams && url.searchParams.get('token')) {
-              url.searchParams.set('token', 'REDACTED')
-            }
-            span.context.http.url = url.toString()
+          var url = new URL(span.context.http.url, window.location.origin)
+          if (url.searchParams && url.searchParams.get('token')) {
+            url.searchParams.set('token', 'REDACTED')
           }
+          span.context.http.url = url.toString()
         }
       })
     })

--- a/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
+++ b/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
@@ -28,9 +28,6 @@ const { verifyNoBrowserErrors } = require('../../../../../dev-utils/webdriver')
 describe('manual-timing', function() {
   it('should run manual timing', async function() {
     browser.url('/test/e2e/manual-timing/index.html')
-    browser.setTimeout({
-      script: 10000
-    })
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
+++ b/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
@@ -23,17 +23,11 @@
  *
  */
 
-const {
-  verifyNoBrowserErrors,
-  isIOSDevice
-} = require('../../../../../dev-utils/webdriver')
+const { verifyNoBrowserErrors } = require('../../../../../dev-utils/webdriver')
 
 describe('manual-timing', function() {
   it('should run manual timing', async function() {
     browser.url('/test/e2e/manual-timing/index.html')
-    if (!isIOSDevice) {
-      browser.setTimeout({ script: 10000 })
-    }
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
+++ b/packages/rum/test/e2e/manual-timing/app.e2e-spec.js
@@ -23,11 +23,17 @@
  *
  */
 
-const { verifyNoBrowserErrors } = require('../../../../../dev-utils/webdriver')
+const {
+  verifyNoBrowserErrors,
+  isIOSDevice
+} = require('../../../../../dev-utils/webdriver')
 
 describe('manual-timing', function() {
   it('should run manual timing', async function() {
     browser.url('/test/e2e/manual-timing/index.html')
+    if (!isIOSDevice) {
+      browser.setTimeout({ script: 10000 })
+    }
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/react/app.e2e-spec.js
+++ b/packages/rum/test/e2e/react/app.e2e-spec.js
@@ -28,9 +28,6 @@ const { allowSomeBrowserErrors } = require('../../../../../dev-utils/webdriver')
 describe('react app', function() {
   it('should run the react app', function() {
     browser.url('/test/e2e/react/')
-    browser.setTimeout({
-      script: 10000
-    })
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/react/app.e2e-spec.js
+++ b/packages/rum/test/e2e/react/app.e2e-spec.js
@@ -23,17 +23,11 @@
  *
  */
 
-const {
-  allowSomeBrowserErrors,
-  isIOSDevice
-} = require('../../../../../dev-utils/webdriver')
+const { allowSomeBrowserErrors } = require('../../../../../dev-utils/webdriver')
 
 describe('react app', function() {
   it('should run the react app', function() {
     browser.url('/test/e2e/react/')
-    if (!isIOSDevice) {
-      browser.setTimeout({ script: 10000 })
-    }
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/react/app.e2e-spec.js
+++ b/packages/rum/test/e2e/react/app.e2e-spec.js
@@ -23,11 +23,17 @@
  *
  */
 
-const { allowSomeBrowserErrors } = require('../../../../../dev-utils/webdriver')
+const {
+  allowSomeBrowserErrors,
+  isIOSDevice
+} = require('../../../../../dev-utils/webdriver')
 
 describe('react app', function() {
   it('should run the react app', function() {
     browser.url('/test/e2e/react/')
+    if (!isIOSDevice) {
+      browser.setTimeout({ script: 10000 })
+    }
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum/test/e2e/react/app.jsx
+++ b/packages/rum/test/e2e/react/app.jsx
@@ -23,7 +23,7 @@
  *
  */
 
-import "@babel/polyfill"
+import '@babel/polyfill'
 import 'whatwg-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -36,35 +36,33 @@ import { apm } from './rum'
 var tr = apm.startTransaction('App Load', 'page-load')
 tr.isHardNavigation = true
 
-
 class App extends React.Component {
   render() {
     return (
       <div>
-
         <div>
           <ul>
             <li>
-              <Link to='/'>Home</Link>
+              <Link to="/">Home</Link>
             </li>
             <li>
-              <Link to='/about'>About</Link>
+              <Link to="/about">About</Link>
             </li>
             <li>
-              <Link to='/topics'>Topics</Link>
+              <Link to="/topics">Topics</Link>
             </li>
             <li>
-              <Link to='/topic/10'>Topic 10</Link>
+              <Link to="/topic/10">Topic 10</Link>
             </li>
           </ul>
 
           <hr />
-          <Route exact path='/' component={MainComponent} />
-          <Route path='/about' component={MainComponent} />
-          <Route path='/topics' component={MainComponent} />
-          <Route path='/topic/:id' component={MainComponent} />
+          <Route exact path="/" component={MainComponent} />
+          <Route path="/about" component={MainComponent} />
+          <Route path="/topics" component={MainComponent} />
+          <Route path="/topic/:id" component={MainComponent} />
         </div>
-        <div id='test-element'>Passed</div>
+        <div id="test-element">Passed</div>
       </div>
     )
   }
@@ -74,11 +72,9 @@ App = withRouter(App)
 
 function render() {
   ReactDOM.render(
-    (
-      <Router basename='/test/e2e/react/'>
-        <App />
-      </Router>
-    ),
+    <Router basename="/test/e2e/react/">
+      <App />
+    </Router>,
     document.getElementById('app')
   )
 }

--- a/packages/rum/test/e2e/react/main-component.jsx
+++ b/packages/rum/test/e2e/react/main-component.jsx
@@ -1,3 +1,28 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 import React from 'react'
 
 import { apm } from './rum'
@@ -8,7 +33,7 @@ class MainComponent extends React.Component {
     var path = this.props.match.path
     this.state = {
       userName: '',
-      path: path
+      path
     }
     this.transaction = apm.startTransaction('Main - ' + path, 'route-change')
   }
@@ -21,15 +46,16 @@ class MainComponent extends React.Component {
     var url = '/test/e2e/react/data.json'
 
     fetch(url)
-      .then((resp) => {
+      .then(resp => {
         var tid = this.transaction.addTask()
         var span = this.transaction.startSpan('Timeout span')
         setTimeout(() => {
           span.end()
           this.transaction.removeTask(tid)
-        }, 500);
+        }, 500)
         return resp.json()
-      }).then((data) => {
+      })
+      .then(data => {
         this.setState({ userName: data.userName })
       })
   }

--- a/packages/rum/test/e2e/react/webpack.config.js
+++ b/packages/rum/test/e2e/react/webpack.config.js
@@ -31,7 +31,10 @@ module.exports = {
   entry: path.resolve(__dirname, './app.jsx'),
   output: { path: __dirname, filename: 'app.e2e-bundle.js' },
   devtool: 'source-map',
-  mode: 'development',
+  mode: 'production',
+  performance: {
+    hints: false
+  },
   module: {
     rules: [
       {

--- a/packages/rum/wdio-failsafe.conf.js
+++ b/packages/rum/wdio-failsafe.conf.js
@@ -34,13 +34,6 @@ const browserList = [
     browserName: 'internet explorer',
     platform: 'Windows 7',
     version: '10'
-  },
-  {
-    appiumVersion: '1.9.1',
-    deviceName: 'android emulator',
-    browserName: 'browser',
-    platformVersion: '4.4',
-    platformName: 'android'
   }
 ].map(capability => ({ tunnelIdentifier, ...capability }))
 

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -36,7 +36,7 @@ const { tunnelIdentifier, username, accessKey } = getSauceConnectOptions()
 /**
  * Skip the ios platform on E2E tests because of script
  * timeout issue in Appium
-ß */
+ */
 const capabilities = getBrowserList()
   .filter(({ platformName }) => platformName !== 'iOS')
   .map(capability => ({
@@ -73,7 +73,6 @@ exports.config = {
   afterTest() {
     /** Log api is only available in Chrome */
     if (isChrome()) {
-      browser.execute('1+1')
       const response = browser.getLogs('browser')
       console.log('browser.log:', JSON.stringify(response, undefined, 2))
     }

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -32,10 +32,17 @@ const {
 const { isChrome } = require('../../dev-utils/webdriver')
 
 const { tunnelIdentifier, username, accessKey } = getSauceConnectOptions()
-const capabilities = getBrowserList().map(capability => ({
-  tunnelIdentifier,
-  ...capability
-}))
+
+/**
+ * Skip the ios platform on E2E tests because of script
+ * timeout issue in Appium
+ß */
+const capabilities = getBrowserList()
+  .filter(({ platformName }) => platformName !== 'iOS')
+  .map(capability => ({
+    tunnelIdentifier,
+    ...capability
+  }))
 
 exports.config = {
   runner: 'local',
@@ -55,6 +62,13 @@ exports.config = {
   reporters: ['dot', 'spec'],
   jasmineNodeOpts: {
     defaultTimeoutInterval: 90000
+  },
+  beforeTest() {
+    /**
+     * Sets timeout for scripts executed in the browser
+     * via browser.executeAsync method
+     */
+    browser.setTimeout({ script: 20000 })
   },
   afterTest() {
     /** Log api is only available in Chrome */

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -46,7 +46,7 @@ exports.config = {
   key: accessKey,
   sauceConnect: false,
   capabilities,
-  logLevel: 'silent',
+  logLevel: 'error',
   bail: 1,
   screenshotPath: join(__dirname, 'error-screenshot'),
   baseUrl: 'http://localhost:8000',

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -52,7 +52,7 @@ const browserList = [
     appiumVersion: '1.9.1',
     deviceName: 'android emulator',
     browserName: 'browser',
-    platformVersion: '5.0',
+    platformVersion: '5.1',
     platformName: 'android'
   }
 ].map(capability => ({ tunnelIdentifier, ...capability }))

--- a/packages/rum/wdio.conf.js
+++ b/packages/rum/wdio.conf.js
@@ -25,37 +25,17 @@
 
 const { join } = require('path')
 const glob = require('glob')
-const { getSauceConnectOptions } = require('../../dev-utils/test-config')
+const {
+  getSauceConnectOptions,
+  getBrowserList
+} = require('../../dev-utils/test-config')
 const { isChrome } = require('../../dev-utils/webdriver')
 
 const { tunnelIdentifier, username, accessKey } = getSauceConnectOptions()
-const browserList = [
-  {
-    browserName: 'chrome',
-    version: '62'
-  },
-  {
-    browserName: 'firefox',
-    version: '57'
-  },
-  {
-    browserName: 'microsoftedge',
-    platform: 'Windows 10',
-    version: '17'
-  },
-  {
-    browserName: 'safari',
-    platform: 'OS X 10.11',
-    version: '9.0'
-  },
-  {
-    appiumVersion: '1.9.1',
-    deviceName: 'android emulator',
-    browserName: 'browser',
-    platformVersion: '5.1',
-    platformName: 'android'
-  }
-].map(capability => ({ tunnelIdentifier, ...capability }))
+const capabilities = getBrowserList().map(capability => ({
+  tunnelIdentifier,
+  ...capability
+}))
 
 exports.config = {
   runner: 'local',
@@ -65,7 +45,7 @@ exports.config = {
   user: username,
   key: accessKey,
   sauceConnect: false,
-  capabilities: browserList,
+  capabilities,
   logLevel: 'silent',
   bail: 1,
   screenshotPath: join(__dirname, 'error-screenshot'),


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#205 
+ Unit and E2E tests are run on same set of browsers to catch different bugs during E2E.
+ Safari 11.0 - 11.3 has a bug in fetch spec, window.fetch() without params doesn't get rejected. 
+ Ios emulators have bug when setting script timeout in appium. Removed them from the E2E tests till new appium version is available in sauce labs
+ `window.URL` is broken in IE 11 - it took me 2 hours to figure out why this happens and have no clue till i remote debugged IE 11. 
+ linted .jsx files with proper fixes. 
+ Remove chrome 46 and firefox 42  since the global usage was 0% and replace with other versions which has some usage stats. 