### PR TITLE
perf(rum): avoid setting config twice during agent initialization

### DIFF
--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -34,10 +34,6 @@ class ApmBase {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
       var configService = this.serviceFactory.getService('ConfigService')
-      configService.setConfig({
-        agentName: 'js-base',
-        agentVersion: '%%agent-version%%'
-      })
       configService.setConfig(config)
       this.serviceFactory.init()
       var errorLogging = this.serviceFactory.getService('ErrorLogging')


### PR DESCRIPTION
+ Small optimisation to remove setting the config twice during initialisation. We already have them as defaults in the config-service and this does not provide any value. 