### PR TITLE
[docs] CORS documentation

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -19,6 +19,10 @@ You will also need to {apm-server-ref-v}/rum.html[enable frontend endpoints in t
 [[getting-started]]
 == Getting started
 
+* <<using-package-managers>>
+* <<using-script-tags>>
+* <<configuring-cors>>
+
 [float]
 [[using-package-managers]]
 === Using Package Managers
@@ -71,7 +75,7 @@ https://unpkg.com/@elastic/apm-rum/dist/bundles/elastic-apm-rum.umd.min.js[UNPKG
 NOTE: Currently our minified JavaScript bundle is about 16KB (gzipped).
 
 [float]
-[[Configuring CORS]]
+[[configuring-cors]]
 === Configuring CORS
 
 If APM Server is deployed in an origin different than the page's origin,

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -76,22 +76,37 @@ NOTE: Currently our minified JavaScript bundle is about 16KB (gzipped).
 
 If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
+To configure CORS, simply:
 
-TIP: To learn more about CORS, and why this process is necessary, see the MDN page on
-https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing].
+1. {apm-server-ref-v}/configuration-rum.html[Enable RUM support] in APM Server.
+2. Adjust the {apm-server-ref-v}/configuration-rum.html#_literal_allow_origins_literal[`apm-server.rum.allow_origins`] configuration.
+By default, APM Server allows all origins.
 
-To configure CORS,
-//configuration goes here
+[float]
+==== How CORS works
 
-When using this setup,
-the RUM agent will send an `HTTP OPTIONS` request prior to making the original `POST` request.
-This `OPTIONS` request will ensure all headers and `HTTP` methods are supported,
-and that the origin is allowed. 
+When the RUM agent makes it's initial `POST` request, the browser will check to see if it is a cross-origin request.
+If it is, the browser automatically makes a preflight `OPTIONS` request to the server to ensure the original `POST` request is allowed.
+If this `OPTIONS` check passes, then the original `POST` request is allowed.
 This request will fail if RUM support is not configured in the APM Server.
-See {apm-server-ref-v}/configuration-rum.html[Set up Real User Monitoring (RUM) support]
-for instructions on how to enable RUM support.
-By default, APM Server allows all origins:
-{apm-server-ref-v}/configuration-rum.html#_literal_allow_origins_literal[`apm-server.rum.allow_origins: ['*']`].
 
-// should we also link to/talk about `distributeTracingOrigins`?
-// <<`distributedTracingOrigins`,distributed-tracing-origins>>
+If you use a proxy, the preflight request headers may be necessary for your configuration:
+
+[source,js]
+----
+Access-Control-Request-Headers: Content-Type
+Access-Control-Request-Method: POST
+Origin: [request-origin]
+----
+
+The response should include these headers:
+
+[source,js]
+----
+Access-Control-Allow-Headers: Content-Type
+Access-Control-Allow-Methods: POST, OPTIONS
+Access-Control-Allow-Origin: [request-origin]
+----
+
+TIP: To learn more about CORS, see the MDN page on
+https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -69,3 +69,29 @@ https://unpkg.com/@elastic/apm-rum/dist/bundles/elastic-apm-rum.umd.min.js[UNPKG
 ----
 
 NOTE: Currently our minified JavaScript bundle is about 16KB (gzipped).
+
+[float]
+[[Configuring CORS]]
+=== Configuring CORS
+
+If APM Server is deployed in an origin different than the page's origin,
+you will need to configure Cross-Origin Resource Sharing (CORS).
+
+TIP: To learn more about CORS, and why this process is necessary, see the MDN page on
+https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing].
+
+To configure CORS,
+//configuration goes here
+
+When using this setup,
+the RUM agent will send an `HTTP OPTIONS` request prior to making the original `POST` request.
+This `OPTIONS` request will ensure all headers and `HTTP` methods are supported,
+and that the origin is allowed. 
+This request will fail if RUM support is not configured in the APM Server.
+See {apm-server-ref-v}/configuration-rum.html[Set up Real User Monitoring (RUM) support]
+for instructions on how to enable RUM support.
+By default, APM Server allows all origins:
+{apm-server-ref-v}/configuration-rum.html#_literal_allow_origins_literal[`apm-server.rum.allow_origins: ['*']`].
+
+// should we also link to/talk about `distributeTracingOrigins`?
+// <<`distributedTracingOrigins`,distributed-tracing-origins>>


### PR DESCRIPTION
CORS documentation! Closes #66:
- [x] Explain why this process is necessary
- [x] Mention that users need to configure the `allow_origins ` in their APM server configuration
- [x] Reference [APM Server - RUM configuration](https://www.elastic.co/guide/en/apm/server/current/configuration-rum.html)
- [x] Mention that the preflight request will fail if RUM endpoint is disabled on the APM server.
- [x] Mention which cross-origin headers are sent and received (browser <--> apm server), this is useful for configuring proxies.
---
~I have some questions:~
* ~Where can I find the cross-origin headers to complete the last checkbox above?~
* ~It's not immediately clear to me if any configuration needs to be done in the rum agent itself, or if all configuration is done in the Server?~
* ~Should we mention the `distributeTracingOrigins` config option here as well? If so, what's important?~
