### PR TITLE
fix(rum-core): hardcode agent name and version in service metadata

### DIFF
--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -103,8 +103,7 @@ function prepareConfig(defaultConfig) {
   const testConfig = defaultConfig.testConfig || {}
   const agentConfig = defaultConfig.globalConfigs.agentConfig || {}
   const { isTravis, sauceLabs: isSauce } = testConfig
-  const { agentName, agentVersion } = agentConfig
-  let buildId = `ApmJs-${agentName}@${agentVersion}`
+  let buildId = `ApmJs-${agentConfig.name}`
 
   if (isTravis) {
     buildId =

--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -52,8 +52,7 @@ function getGlobalConfig(packageName = 'rum') {
     agentConfig: {
       serverUrl: testEnv.serverUrl,
       serviceName: `test`,
-      agentName: `${packageName}`,
-      agentVersion: '0.0.1'
+      name: `${packageName}`
     },
     useMocks: false,
     mockApmServer: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9298,6 +9298,68 @@
         "ms": "^2.0.0"
       }
     },
+    "husky": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
+      "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.7",
+        "execa": "^1.0.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^6.0.0",
+        "is-ci": "^2.0.0",
+        "pkg-dir": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^4.0.1",
+        "run-node": "^1.0.0",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12078,6 +12140,15 @@
         "find-up": "^3.0.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "portfinder": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
@@ -13351,6 +13422,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -13448,6 +13525,12 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "send": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14233,16 +14233,6 @@
         }
       }
     },
-    "string-replace-loader": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-1.3.0.tgz",
-      "integrity": "sha512-zj8J2ELc5HWOYFkS3MaRMgaHu+mPTG/EfHHaFesJqXjpaKOAruaONEWt3/Em5Urc6n8qDlvabIN6umiU8lH4QA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "lodash": "^4"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/elastic/apm-agent-rum-js.git"
   },
   "scripts": {
+    "pre-commit": "lerna run version-check --stream",
     "prerelease": "npm test",
     "release": "lerna publish",
     "release-package": "node scripts/publish",
@@ -19,7 +20,7 @@
     "format": "eslint . --fix",
     "test": "lerna run test --stream --scope=$SCOPE --no-prefix",
     "serve": "lerna run serve",
-    "bundlesize": "lerna run --scope @elastic/apm-rum bundlesize  --stream"
+    "bundlesize": "lerna run bundlesize --stream"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "react-router-dom": "^4.2.2",
     "serve-index": "^1.9.1",
     "source-map": "^0.7.0",
-    "string-replace-loader": "^1.3.0",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "webdriverio": "^5.7.2",
     "webpack": "^4.27.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "eslint . --fix",
     "test": "lerna run test --stream --scope=$SCOPE --no-prefix",
     "serve": "lerna run serve",
-    "bundlesize": "lerna run --scope @elastic/apm-rum bundlesize"
+    "bundlesize": "lerna run --scope @elastic/apm-rum bundlesize  --stream"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/elastic/apm-agent-rum-js.git"
   },
   "scripts": {
-    "pre-commit": "lerna run version-check --stream",
     "prerelease": "npm test",
     "release": "lerna publish",
     "release-package": "node scripts/publish",
@@ -21,6 +20,11 @@
     "test": "lerna run test --stream --scope=$SCOPE --no-prefix",
     "serve": "lerna run serve",
     "bundlesize": "lerna run bundlesize --stream"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npx lerna run version-check --stream"
+    }
   },
   "author": "",
   "license": "MIT",
@@ -52,6 +56,7 @@
     "gh-release-assets": "^1.1.2",
     "glob": "^7.1.3",
     "http-server": "^0.10.0",
+    "husky": "^1.3.1",
     "jasmine": "^2.8.0",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -23,6 +23,7 @@
  *
  */
 
+import { version as agentVersion } from '../../package.json'
 const Queue = require('./queue')
 const throttle = require('./throttle')
 const { sanitizeString } = require('./utils')
@@ -65,8 +66,8 @@ class ApmServer {
       name: sanitizeString(cfg.get('serviceName'), stringLimit, true),
       version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
       agent: {
-        name: sanitizeString(cfg.get('agentName'), stringLimit),
-        version: sanitizeString(cfg.get('agentVersion'), stringLimit)
+        name: 'js-base',
+        version: agentVersion
       },
       language: {
         name: 'javascript'

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -23,7 +23,6 @@
  *
  */
 
-import { version as agentVersion } from '../../package.json'
 const Queue = require('./queue')
 const throttle = require('./throttle')
 const { sanitizeString } = require('./utils')
@@ -67,7 +66,7 @@ class ApmServer {
       version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
       agent: {
         name: 'js-base',
-        version: agentVersion
+        version: '4.0.1'
       },
       language: {
         name: 'javascript'

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -66,7 +66,7 @@ class ApmServer {
       version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
       agent: {
         name: 'js-base',
-        version: '4.0.1'
+        version: sanitizeString(cfg.agentVersion, stringLimit)
       },
       language: {
         name: 'javascript'

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -66,7 +66,7 @@ class ApmServer {
       version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
       agent: {
         name: 'js-base',
-        version: sanitizeString(cfg.agentVersion, stringLimit)
+        version: sanitizeString(cfg.version, stringLimit)
       },
       language: {
         name: 'javascript'

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -69,8 +69,6 @@ class Config {
       serviceName: '',
       serviceVersion: '',
       environment: '',
-      agentName: 'js-base',
-      agentVersion: '%%agent-version%%',
       serverUrl: 'http://localhost:8200',
       serverUrlPrefix: '/intake/v2/rum/events',
       active: true,

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -114,6 +114,11 @@ class Config {
 
     this._changeSubscription = new Subscription()
     this.filters = []
+    /**
+     * Packages that uses rum-core under the hood must override
+     * the version via setVersion
+     */
+    this.version = ''
   }
 
   init() {
@@ -123,6 +128,10 @@ class Config {
 
   isActive() {
     return this.get('active')
+  }
+
+  setVersion(version) {
+    this.version = version
   }
 
   addFilter(cb) {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -26,6 +26,7 @@
 const ApmServer = require('../../src/common/apm-server')
 const Transaction = require('../../src/performance-monitoring/transaction')
 const { createServiceFactory } = require('../')
+const { version: agentVersion } = require('../../../rum/package.json')
 
 function generateTransaction(count) {
   var result = []
@@ -371,13 +372,14 @@ describe('ApmServer', function() {
       environment: 'staging'
     })
 
+    /** To catch agent version mismatch during release */
     expect(apmServer.createServiceObject()).toEqual({
       name: 'test',
       version: '0.0.1',
       environment: 'staging',
       agent: {
         name: 'js-base',
-        version: jasmine.stringMatching(/^([0-9]+)\.([0-9]+)\.([0-9]+)/)
+        version: agentVersion
       },
       language: { name: 'javascript' }
     })

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -368,16 +368,17 @@ describe('ApmServer', function() {
     configService.setConfig({
       serviceName: 'test',
       serviceVersion: '0.0.1',
-      environment: 'staging',
-      agentName: 'rum',
-      agentVersion: '3.0.0'
+      environment: 'staging'
     })
 
     expect(apmServer.createServiceObject()).toEqual({
       name: 'test',
       version: '0.0.1',
       environment: 'staging',
-      agent: { name: 'rum', version: '3.0.0' },
+      agent: {
+        name: 'js-base',
+        version: jasmine.stringMatching(/^([0-9]+)\.([0-9]+)\.([0-9]+)/)
+      },
       language: { name: 'javascript' }
     })
   })

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -26,7 +26,6 @@
 const ApmServer = require('../../src/common/apm-server')
 const Transaction = require('../../src/performance-monitoring/transaction')
 const { createServiceFactory } = require('../')
-const { version: agentVersion } = require('../../../rum/package.json')
 
 function generateTransaction(count) {
   var result = []
@@ -372,6 +371,8 @@ describe('ApmServer', function() {
       environment: 'staging'
     })
 
+    configService.setVersion('4.0.1')
+
     /** To catch agent version mismatch during release */
     expect(apmServer.createServiceObject()).toEqual({
       name: 'test',
@@ -379,7 +380,7 @@ describe('ApmServer', function() {
       environment: 'staging',
       agent: {
         name: 'js-base',
-        version: agentVersion
+        version: '4.0.1'
       },
       language: { name: 'javascript' }
     })

--- a/packages/rum/babel-version-plugin.js
+++ b/packages/rum/babel-version-plugin.js
@@ -1,0 +1,62 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const { transformSync } = require('@babel/core')
+const APM_BASE_CODE = require('./src/apm-base')
+const { version: agentVersion } = require('./package.json')
+
+const pass = () => console.log('Agent version matches with build version')
+const fail = version => {
+  throw new Error(
+    `Agent version ${agentVersion} does not match with build version - ${version}`
+  )
+}
+const versionPlugin = ({ types: t }) => {
+  return {
+    name: 'babel-version-plugin',
+    visitor: {
+      MemberExpression(path) {
+        const property = path.get('property')
+        const name = property.node.name
+        if (t.isIdentifier(property) && name === 'setVersion') {
+          const args = path.parentPath.get('arguments')
+          if (args.length > 0 && t.isStringLiteral(args[0])) {
+            const version = args[0].node.value
+            if (version !== agentVersion) {
+              fail(version)
+              process.exit(1)
+            } else {
+              pass()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+transformSync(APM_BASE_CODE, {
+  plugins: [versionPlugin]
+})

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "version-check": "node babel-version-plugin.js",
     "build": "webpack",
     "build:dev": "webpack -w",
     "build:e2e": "npm run script buildE2eBundles",

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -34,10 +34,6 @@ class ApmBase {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
       var configService = this.serviceFactory.getService('ConfigService')
-      configService.setConfig({
-        agentName: 'js-base',
-        agentVersion: '%%agent-version%%'
-      })
       configService.setConfig(config)
       this.serviceFactory.init()
       var errorLogging = this.serviceFactory.getService('ErrorLogging')

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -34,6 +34,10 @@ class ApmBase {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
       var configService = this.serviceFactory.getService('ConfigService')
+      /**
+       * Set Agent version to be sent as part of metadata to the APM Server
+       */
+      configService.setVersion('4.0.1')
       configService.setConfig(config)
       this.serviceFactory.init()
       var errorLogging = this.serviceFactory.getService('ErrorLogging')

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -24,7 +24,6 @@
  */
 
 const path = require('path')
-const { version: agentVersion } = require('./package.json')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
 
@@ -53,17 +52,6 @@ const baseConfig = {
         test: /\.js$/,
         use: {
           loader: 'babel-loader'
-        }
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'string-replace-loader',
-          options: {
-            search: '%%agent-version%%',
-            replace: agentVersion
-          }
         }
       }
     ]


### PR DESCRIPTION
+ Two reasons
    - Its possible to break the APM UI by simply changing the name of the agent 
    - Be consistent with other agents

+ One more issue with our current approach is that, When users use our package directly instead of our distribution, Our agent name will never be changed unless the user builds it locally using our webpack config due to the way we replace the version using string-replace-load which is a bug. 

```js
const rumjs = require('elastic-apm-rum')


// application code


// user builds the bundle using webpack, parcel or whatever toolchain

// bundle would still contains
agentVersion: '%%agent-version%%',

```