### PR TITLE
fix(rum-core): apply truncation on keyword fields in payload

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -25,7 +25,7 @@
 
 import Queue from './queue'
 import throttle from './throttle'
-import { sanitizeString } from './utils'
+import { truncateMetadata } from './truncate'
 import NDJSON from './ndjson'
 import { XHR_IGNORE } from './patching/patch-utils'
 
@@ -60,23 +60,21 @@ class ApmServer {
     this.initTransactionQueue()
   }
 
-  createServiceObject() {
+  createMetaData() {
     const cfg = this._configService
-    const stringLimit = cfg.get('serverStringLimit')
-
-    const serviceObject = {
-      name: sanitizeString(cfg.get('serviceName'), stringLimit, true),
-      version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
+    const service = {
+      name: cfg.get('serviceName'),
+      version: cfg.get('serviceVersion'),
       agent: {
         name: 'js-base',
-        version: sanitizeString(cfg.version, stringLimit)
+        version: cfg.version
       },
       language: {
         name: 'javascript'
       },
-      environment: sanitizeString(cfg.get('environment'), stringLimit)
+      environment: cfg.get('environment')
     }
-    return serviceObject
+    return truncateMetadata({ service })
   }
 
   _postJson(endPoint, payload) {

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -234,10 +234,9 @@ class ApmServer {
     if (data.length === 0) {
       return
     }
-    const payload = {
-      service: this.createServiceObject(),
-      data
-    }
+    const { service } = this.createMetaData()
+    const payload = { service, data }
+
     const filteredPayload = this._configService.applyFilters(payload)
     if (!filteredPayload) {
       this._loggingService.warn('Dropped payload due to filtering!')

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -25,9 +25,9 @@
 
 import Queue from './queue'
 import throttle from './throttle'
-import { truncateMetadata } from './truncate'
 import NDJSON from './ndjson'
 import { XHR_IGNORE } from './patching/patch-utils'
+import { truncateModel, METADATA_MODEL } from './truncate'
 
 class ApmServer {
   constructor(configService, loggingService) {
@@ -62,19 +62,21 @@ class ApmServer {
 
   createMetaData() {
     const cfg = this._configService
-    const service = {
-      name: cfg.get('serviceName'),
-      version: cfg.get('serviceVersion'),
-      agent: {
-        name: 'js-base',
-        version: cfg.version
-      },
-      language: {
-        name: 'javascript'
-      },
-      environment: cfg.get('environment')
+    const metadata = {
+      service: {
+        name: cfg.get('serviceName'),
+        version: cfg.get('serviceVersion'),
+        agent: {
+          name: 'js-base',
+          version: cfg.version
+        },
+        language: {
+          name: 'javascript'
+        },
+        environment: cfg.get('environment')
+      }
     }
-    return truncateMetadata({ service })
+    return truncateModel(METADATA_MODEL, metadata)
   }
 
   _postJson(endPoint, payload) {

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -23,15 +23,8 @@
  *
  */
 
-import {
-  getCurrentScript,
-  sanitizeString,
-  setTag,
-  merge,
-  getDtHeaderValue
-} from './utils'
+import { getCurrentScript, setTag, merge, getDtHeaderValue } from './utils'
 import Subscription from '../common/subscription'
-import { serverStringLimit } from './constants'
 
 function getConfigFromScript() {
   var script = getCurrentScript()
@@ -99,8 +92,6 @@ class Config {
       flushInterval: 500,
 
       sendPageLoadTransaction: true,
-
-      serverStringLimit,
 
       distributedTracing: true,
       distributedTracingOrigins: [],
@@ -190,19 +181,15 @@ class Config {
   setUserContext(userContext = {}) {
     const context = {}
     const { id, username, email } = userContext
-    const serverStringLimit = this.get('serverStringLimit')
 
-    if (typeof id === 'number') {
+    if (typeof id === 'number' || typeof id === 'string') {
       context.id = id
     }
-    if (typeof id === 'string') {
-      context.id = sanitizeString(id, serverStringLimit)
-    }
     if (typeof username === 'string') {
-      context.username = sanitizeString(username, serverStringLimit)
+      context.username = username
     }
     if (typeof email === 'string') {
-      context.email = sanitizeString(email, serverStringLimit)
+      context.email = email
     }
     this.set('context.user', context)
   }

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -64,7 +64,7 @@ const SPAN_THRESHOLD = 5 * 60 * 1000
 /**
  * Others
  */
-const serverStringLimit = 1024
+const KEYWORD_LIMIT = 1024
 
 export {
   SCHEDULE,
@@ -76,5 +76,5 @@ export {
   REMOVE_EVENT_LISTENER_STR,
   RESOURCE_INITIATOR_TYPES,
   SPAN_THRESHOLD,
-  serverStringLimit
+  KEYWORD_LIMIT
 }

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  *
  */
-const { KEYWORD_LIMIT } = require('./constants')
+import { KEYWORD_LIMIT } from './constants'
 
 /**
  * All models value holds the arrary of form
@@ -143,7 +143,7 @@ function truncateModel(model = {}, target, childTarget = target) {
   return target
 }
 
-module.exports = {
+export {
   truncate,
   truncateModel,
   SPAN_MODEL,

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -34,6 +34,9 @@ const METADATA_MODEL = {
   service: {
     name: [KEYWORD_LIMIT, true],
     version: [],
+    agent: {
+      version: []
+    },
     environment: []
   }
 }

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -1,0 +1,159 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+const { KEYWORD_LIMIT } = require('./constants')
+
+/**
+ * All models value holds the arrary of form
+ * [ limit, required, placeholder]
+ *
+ * Defaults are not represented in the array to reduce the size
+ */
+const METADATA_MODEL = {
+  service: {
+    name: [KEYWORD_LIMIT, true],
+    version: [KEYWORD_LIMIT],
+    environment: [KEYWORD_LIMIT]
+  }
+}
+
+const CONTEXT_COMMON = {
+  user: {
+    id: [KEYWORD_LIMIT],
+    email: [KEYWORD_LIMIT],
+    username: [KEYWORD_LIMIT]
+  },
+  tags: {
+    '*': [KEYWORD_LIMIT]
+  }
+}
+
+const SPAN_MODEL = {
+  name: [KEYWORD_LIMIT, true],
+  type: [KEYWORD_LIMIT, true],
+  subtype: [KEYWORD_LIMIT],
+  action: [KEYWORD_LIMIT],
+  id: [KEYWORD_LIMIT, true],
+  trace_id: [KEYWORD_LIMIT, true],
+  parent_id: [KEYWORD_LIMIT, true],
+  transaction_id: [KEYWORD_LIMIT, true],
+  duration: [KEYWORD_LIMIT, true],
+  context: CONTEXT_COMMON
+}
+
+const TRANSACTION_MODEL = {
+  name: [KEYWORD_LIMIT],
+  type: [KEYWORD_LIMIT, true],
+  id: [KEYWORD_LIMIT, true],
+  trace_id: [KEYWORD_LIMIT, true],
+  parent_id: [KEYWORD_LIMIT, true],
+  span_count: {
+    started: [KEYWORD_LIMIT, true]
+  },
+  context: CONTEXT_COMMON
+}
+
+const ERROR_MODEL = {
+  id: [KEYWORD_LIMIT, true],
+  trace_id: [KEYWORD_LIMIT],
+  transaction_id: [KEYWORD_LIMIT],
+  parent_id: [KEYWORD_LIMIT],
+  culprit: [KEYWORD_LIMIT],
+  exception: {
+    type: [KEYWORD_LIMIT]
+  },
+  transaction: {
+    type: [KEYWORD_LIMIT]
+  },
+  context: CONTEXT_COMMON
+}
+
+function truncate(value, limit, required = false, placeholder = 'N/A') {
+  if (required && !value) {
+    value = placeholder
+  }
+  if (typeof value === 'string') {
+    return value.substr(0, limit)
+  }
+  return value
+}
+
+function truncateModel(model = {}, target, childTarget = target) {
+  const keys = Object.keys(model)
+  for (let i = 0; i < keys.length; i++) {
+    const currKey = keys[i]
+    const value = model[currKey]
+    if (!Array.isArray(value)) {
+      truncateModel(value, target, childTarget[currKey])
+    } else {
+      /**
+       * To avoid traversing the target object, we keep a reference to
+       * the current depth inorder to get the value associated with the key
+       * and set the truncated value in target object
+       *
+       * when the key is '*', Apply truncation to all the keys in current level
+       */
+      if (currKey === '*') {
+        Object.keys(childTarget).forEach(key => {
+          if (childTarget[key]) {
+            childTarget[key] = truncate(childTarget[key], value[0], value[1])
+          }
+        })
+      } else {
+        if (childTarget[currKey]) {
+          childTarget[currKey] = truncate(
+            childTarget[currKey],
+            value[0],
+            value[1]
+          )
+        }
+      }
+    }
+  }
+  return target
+}
+
+function truncateMetadata(metadata) {
+  return truncateModel(METADATA_MODEL, metadata)
+}
+
+function truncateSpan(span) {
+  return truncateModel(SPAN_MODEL, span)
+}
+
+function truncateTransaction(transaction) {
+  return truncateModel(TRANSACTION_MODEL, transaction)
+}
+
+function truncateError(error) {
+  return truncateModel(ERROR_MODEL, error)
+}
+
+module.exports = {
+  truncate,
+  truncateMetadata,
+  truncateSpan,
+  truncateTransaction,
+  truncateError
+}

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -59,7 +59,6 @@ const SPAN_MODEL = {
   trace_id: [KEYWORD_LIMIT, true],
   parent_id: [KEYWORD_LIMIT, true],
   transaction_id: [KEYWORD_LIMIT, true],
-  duration: [KEYWORD_LIMIT, true],
   subtype: [],
   action: [],
   context: CONTEXT_COMMON
@@ -74,7 +73,6 @@ const TRANSACTION_MODEL = {
   span_count: {
     started: [KEYWORD_LIMIT, true]
   },
-  duration: [KEYWORD_LIMIT, true],
   context: CONTEXT_COMMON
 }
 

--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -33,63 +33,69 @@ const { KEYWORD_LIMIT } = require('./constants')
 const METADATA_MODEL = {
   service: {
     name: [KEYWORD_LIMIT, true],
-    version: [KEYWORD_LIMIT],
-    environment: [KEYWORD_LIMIT]
+    version: [],
+    environment: []
   }
 }
 
 const CONTEXT_COMMON = {
   user: {
-    id: [KEYWORD_LIMIT],
-    email: [KEYWORD_LIMIT],
-    username: [KEYWORD_LIMIT]
+    id: [],
+    email: [],
+    username: []
   },
   tags: {
-    '*': [KEYWORD_LIMIT]
+    '*': []
   }
 }
 
 const SPAN_MODEL = {
   name: [KEYWORD_LIMIT, true],
   type: [KEYWORD_LIMIT, true],
-  subtype: [KEYWORD_LIMIT],
-  action: [KEYWORD_LIMIT],
   id: [KEYWORD_LIMIT, true],
   trace_id: [KEYWORD_LIMIT, true],
   parent_id: [KEYWORD_LIMIT, true],
   transaction_id: [KEYWORD_LIMIT, true],
   duration: [KEYWORD_LIMIT, true],
+  subtype: [],
+  action: [],
   context: CONTEXT_COMMON
 }
 
 const TRANSACTION_MODEL = {
-  name: [KEYWORD_LIMIT],
+  name: [],
+  parent_id: [],
   type: [KEYWORD_LIMIT, true],
   id: [KEYWORD_LIMIT, true],
   trace_id: [KEYWORD_LIMIT, true],
-  parent_id: [KEYWORD_LIMIT, true],
   span_count: {
     started: [KEYWORD_LIMIT, true]
   },
+  duration: [KEYWORD_LIMIT, true],
   context: CONTEXT_COMMON
 }
 
 const ERROR_MODEL = {
   id: [KEYWORD_LIMIT, true],
-  trace_id: [KEYWORD_LIMIT],
-  transaction_id: [KEYWORD_LIMIT],
-  parent_id: [KEYWORD_LIMIT],
-  culprit: [KEYWORD_LIMIT],
+  trace_id: [],
+  transaction_id: [],
+  parent_id: [],
+  culprit: [],
   exception: {
-    type: [KEYWORD_LIMIT]
+    type: []
   },
   transaction: {
-    type: [KEYWORD_LIMIT]
+    type: []
   },
   context: CONTEXT_COMMON
 }
 
-function truncate(value, limit, required = false, placeholder = 'N/A') {
+function truncate(
+  value,
+  limit = KEYWORD_LIMIT,
+  required = false,
+  placeholder = 'N/A'
+) {
   if (required && !value) {
     value = placeholder
   }
@@ -116,17 +122,19 @@ function truncateModel(model = {}, target, childTarget = target) {
        */
       if (currKey === '*') {
         Object.keys(childTarget).forEach(key => {
-          if (childTarget[key]) {
-            childTarget[key] = truncate(childTarget[key], value[0], value[1])
+          const truncatedValue = truncate(childTarget[key], value[0], value[1])
+          if (truncatedValue) {
+            childTarget[key] = truncatedValue
           }
         })
       } else {
-        if (childTarget[currKey]) {
-          childTarget[currKey] = truncate(
-            childTarget[currKey],
-            value[0],
-            value[1]
-          )
+        const truncatedValue = truncate(
+          childTarget[currKey],
+          value[0],
+          value[1]
+        )
+        if (truncatedValue) {
+          childTarget[currKey] = truncatedValue
         }
       }
     }
@@ -134,26 +142,11 @@ function truncateModel(model = {}, target, childTarget = target) {
   return target
 }
 
-function truncateMetadata(metadata) {
-  return truncateModel(METADATA_MODEL, metadata)
-}
-
-function truncateSpan(span) {
-  return truncateModel(SPAN_MODEL, span)
-}
-
-function truncateTransaction(transaction) {
-  return truncateModel(TRANSACTION_MODEL, transaction)
-}
-
-function truncateError(error) {
-  return truncateModel(ERROR_MODEL, error)
-}
-
 module.exports = {
   truncate,
-  truncateMetadata,
-  truncateSpan,
-  truncateTransaction,
-  truncateError
+  truncateModel,
+  SPAN_MODEL,
+  TRANSACTION_MODEL,
+  ERROR_MODEL,
+  METADATA_MODEL
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -23,7 +23,6 @@
  *
  */
 
-import { serverStringLimit } from './constants'
 import Url from '../common/url'
 import rng from 'uuid/lib/rng-browser'
 
@@ -135,47 +134,21 @@ function isPlatformSupported() {
   )
 }
 
-function sanitizeString(
-  value,
-  limit = serverStringLimit,
-  required = false,
-  placeholder = 'NA'
-) {
-  if (typeof value === 'number') {
-    value = String(value)
-  }
-  if (required && !value) {
-    value = placeholder
-  }
-  if (value) {
-    return String(value).substr(0, limit)
-  } else {
-    return value
-  }
-}
-
+/**
+ * Convert values of the tag to be string to be compatible
+ * with the apm server prior to <6.7 version
+ *
+ * TODO: Remove string conversion in the next major release since
+ * support for boolean and number in the APM server has landed in 6.7
+ * https://github.com/elastic/apm-server/pull/1712/
+ */
 function setTag(key, value, obj) {
   if (!obj || !key) return
   var skey = removeInvalidChars(key)
-  obj[skey] = sanitizeString(value, serverStringLimit)
-  return obj
-}
-
-function sanitizeObjectStrings(obj, limit, required, placeholder) {
-  if (!obj) return obj
-  if (typeof obj === 'string') {
-    return sanitizeString(obj, limit, required, placeholder)
+  if (value) {
+    value = String(value)
   }
-  var keys = Object.keys(obj)
-  keys.forEach(function(k) {
-    var value = obj[k]
-    if (typeof value === 'string') {
-      value = sanitizeString(obj[k], limit, required, placeholder)
-    } else if (typeof value === 'object') {
-      value = sanitizeObjectStrings(value, limit, required, placeholder)
-    }
-    obj[k] = value
-  })
+  obj[skey] = value
   return obj
 }
 
@@ -374,8 +347,6 @@ export {
   generateRandomId,
   rng,
   checkSameOrigin,
-  sanitizeString,
-  sanitizeObjectStrings,
   setTag,
   stripQueryStringFromUrl,
   find,

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -24,12 +24,8 @@
  */
 
 import StackTraceService from './stack-trace-service'
-import {
-  getPageMetadata,
-  sanitizeString,
-  generateRandomId,
-  merge
-} from '../common/utils'
+import { getPageMetadata, generateRandomId, merge } from '../common/utils'
+import { truncateError } from '../common/truncate'
 
 class ErrorLogging {
   constructor(apmServer, configService, loggingService, transactionService) {
@@ -45,14 +41,13 @@ class ErrorLogging {
 
   // errorEvent = {message, filename, lineno, colno, error}
   createErrorDataModel(errorEvent) {
-    var filePath = this._stackTraceService.cleanFilePath(errorEvent.filename)
-    var fileName = this._stackTraceService.filePathToFileName(filePath)
-    var culprit
-    var frames = this._stackTraceService.createStackTraces(errorEvent)
-    frames = this._stackTraceService.filterInvalidFrames(frames)
+    const filePath = this._stackTraceService.cleanFilePath(errorEvent.filename)
+    const frames = this._stackTraceService.createStackTraces(errorEvent)
+    const filteredFrames = this._stackTraceService.filterInvalidFrames(frames)
+    let fileName = this._stackTraceService.filePathToFileName(filePath)
 
-    if (!fileName && frames.length) {
-      var lastFrame = frames[frames.length - 1]
+    if (!fileName && filteredFrames.length) {
+      var lastFrame = filteredFrames[filteredFrames.length - 1]
       if (lastFrame.filename) {
         fileName = lastFrame.filename
       } else {
@@ -61,15 +56,16 @@ class ErrorLogging {
       }
     }
 
+    let culprit
     if (this._stackTraceService.isFileInline(filePath)) {
       culprit = '(inline script)'
     } else {
       culprit = fileName
     }
 
-    var message =
+    const message =
       errorEvent.message || (errorEvent.error && errorEvent.error.message)
-    var errorType = errorEvent.error ? errorEvent.error.name : undefined
+    let errorType = errorEvent.error ? errorEvent.error.name : undefined
     if (!errorType) {
       /**
        * Try to extract type from message formatted like
@@ -82,27 +78,26 @@ class ErrorLogging {
       }
     }
 
-    var configContext = this._configService.get('context')
-    var stringLimit = this._configService.get('serverStringLimit')
-    var errorContext
-    if (errorEvent.error && typeof errorEvent.error === 'object') {
+    const configContext = this._configService.get('context')
+    let errorContext
+    if (typeof errorEvent.error === 'object') {
       errorContext = this._getErrorProperties(errorEvent.error)
     }
-    var browserMetadata = getPageMetadata()
-    var context = merge({}, browserMetadata, configContext, errorContext)
+    const browserMetadata = getPageMetadata()
+    const context = merge({}, browserMetadata, configContext, errorContext)
 
-    var errorObject = {
+    const errorObject = {
       id: generateRandomId(),
-      culprit: sanitizeString(culprit),
+      culprit,
       exception: {
-        message: sanitizeString(message, undefined, true),
-        stacktrace: frames,
-        type: sanitizeString(errorType, stringLimit, false)
+        message,
+        stacktrace: filteredFrames,
+        type: errorType
       },
       context
     }
 
-    var currentTransaction = this._transactionService.getCurrentTransaction()
+    const currentTransaction = this._transactionService.getCurrentTransaction()
     if (currentTransaction) {
       errorObject.trace_id = currentTransaction.traceId
       errorObject.parent_id = currentTransaction.id
@@ -112,7 +107,7 @@ class ErrorLogging {
         sampled: currentTransaction.sampled
       }
     }
-    return errorObject
+    return truncateError(errorObject)
   }
 
   logErrorEvent(errorEvent, sendImmediately) {

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -25,7 +25,7 @@
 
 import StackTraceService from './stack-trace-service'
 import { getPageMetadata, generateRandomId, merge } from '../common/utils'
-import { truncateError } from '../common/truncate'
+import { truncateModel, ERROR_MODEL } from '../common/truncate'
 
 class ErrorLogging {
   constructor(apmServer, configService, loggingService, transactionService) {
@@ -107,7 +107,7 @@ class ErrorLogging {
         sampled: currentTransaction.sampled
       }
     }
-    return truncateError(errorObject)
+    return truncateModel(ERROR_MODEL, errorObject)
   }
 
   logErrorEvent(errorEvent, sendImmediately) {

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -38,7 +38,11 @@ import {
   XMLHTTPREQUEST_SOURCE,
   FETCH_SOURCE
 } from '../common/constants'
-import { truncateSpan, truncateTransaction } from '../common/truncate'
+import {
+  truncateModel,
+  SPAN_MODEL,
+  TRANSACTION_MODEL
+} from '../common/truncate'
 
 class PerformanceMonitoring {
   constructor(apmServer, configService, loggingService, transactionService) {
@@ -245,7 +249,7 @@ class PerformanceMonitoring {
     const transactionStart = transaction._start
 
     const spans = transaction.spans.map(function(span) {
-      const spanModel = {
+      const spanData = {
         id: span.id,
         transaction_id: transaction.id,
         parent_id: span.parentId || transaction.id,
@@ -259,12 +263,12 @@ class PerformanceMonitoring {
         duration: span.duration(),
         context: span.context
       }
-      return truncateSpan(spanModel)
+      return truncateModel(SPAN_MODEL, spanData)
     })
 
     var context = merge({}, configContext, transaction.context)
 
-    const transactionModel = {
+    const transactionData = {
       id: transaction.id,
       trace_id: transaction.traceId,
       name: transaction.name,
@@ -278,7 +282,7 @@ class PerformanceMonitoring {
       },
       sampled: transaction.sampled
     }
-    return truncateTransaction(transactionModel)
+    return truncateModel(TRANSACTION_MODEL, transactionData)
   }
 
   createTransactionPayload(transaction) {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -343,7 +343,7 @@ describe('ApmServer', function() {
     expect(apmServer._postJson).not.toHaveBeenCalled()
   })
 
-  it('should set service object from config along with defaults', () => {
+  it('should set metadata from config along with defaults', () => {
     configService.setConfig({
       serviceName: 'test',
       serviceVersion: '0.0.1',
@@ -353,7 +353,8 @@ describe('ApmServer', function() {
     configService.setVersion('4.0.1')
 
     /** To catch agent version mismatch during release */
-    expect(apmServer.createServiceObject()).toEqual({
+    const { service } = apmServer.createMetaData()
+    expect(service).toEqual({
       name: 'test',
       version: '0.0.1',
       environment: 'staging',
@@ -371,9 +372,9 @@ describe('ApmServer', function() {
     var result = apmServer.ndjsonTransactions(trs)
     /* eslint-disable max-len */
     var expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","subType":"NA","action":"NA","sync":false,"start":10,"duration":10}}\n'
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n'
     ]
     expect(result).toEqual(expected)
   })

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -145,32 +145,17 @@ describe('ConfigService', function() {
 
   it('should addTags', function() {
     var date = new Date()
-    configService.addTags({
+    const tags = {
       test: 'test',
       no: 1,
       'test.test': 'test',
       obj: { just: 'object' },
       date
-    })
-    var tags = configService.get('context.tags')
-    expect(tags).toEqual({
+    }
+    configService.addTags(tags)
+    const contextTags = configService.get('context.tags')
+    expect(contextTags).toEqual({
       test: 'test',
-      no: '1',
-      test_test: 'test',
-      obj: '[object Object]',
-      date: String(date)
-    })
-
-    configService.addTags({
-      test: undefined,
-      no: 1,
-      'test.test': 'test',
-      obj: { just: 'object' },
-      date
-    })
-    tags = configService.get('context.tags')
-    expect(tags).toEqual({
-      test: undefined,
       no: '1',
       test_test: 'test',
       obj: '[object Object]',

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -23,7 +23,7 @@
  *
  */
 
-const { truncate, truncateModel } = require('../../src/common/truncate')
+import { truncate, truncateModel } from '../../src/common/truncate'
 
 /**
  * Dummy models to make the testing easier

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -57,7 +57,6 @@ const getSpanModel = limit => ({
   trace_id: [limit, true],
   parent_id: [limit, true],
   transaction_id: [limit, true],
-  duration: [limit, true],
   context: getContextModel(limit)
 })
 
@@ -70,7 +69,6 @@ const getTransactionModel = limit => ({
   span_count: {
     started: [limit, true]
   },
-  duration: [limit, true],
   context: getContextModel(limit)
 })
 const getErrorModel = limit => ({

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -32,6 +32,9 @@ const getMetadataModel = limit => ({
   service: {
     name: [limit, true],
     version: [limit],
+    agent: {
+      version: [limit]
+    },
     environment: [limit]
   }
 })
@@ -103,6 +106,9 @@ describe('Truncate', () => {
       service: {
         name: '',
         version: generateStr('b', 7),
+        agent: {
+          version: '2.0.1'
+        },
         environment: 'development'
       }
     }
@@ -112,6 +118,9 @@ describe('Truncate', () => {
       service: {
         name: 'N/A',
         version: 'bbb',
+        agent: {
+          version: '2.0'
+        },
         environment: 'dev'
       }
     })

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -1,0 +1,256 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const {
+  truncate,
+  truncateMetadata,
+  truncateTransaction,
+  truncateSpan,
+  truncateError
+} = require('../../src/common/truncate')
+
+xdescribe('Truncate', () => {
+  function generateStr(ch, length) {
+    return new Array(length + 1).join(ch)
+  }
+
+  it('truncate values with options', () => {
+    expect(truncate('', undefined, true)).toEqual('N/A')
+    expect(truncate(generateStr('ab', 5), 2)).toEqual('ab')
+    const placeHolder = 'dummyplaceholder'
+    expect(truncate('', undefined, true, placeHolder)).toEqual(placeHolder)
+  })
+
+  it('truncate metadata', () => {
+    const metadata = {
+      service: {
+        name: '',
+        version: 2.0,
+        agent: {
+          name: generateStr('a', 5),
+          version: 3
+        },
+        environment: 'dev'
+      }
+    }
+
+    const filtered = truncateMetadata(metadata)
+
+    expect(filtered).toEqual({
+      service: {
+        name: 'N/A',
+        version: 2.0,
+        agent: {
+          name: 'aaa',
+          version: 3
+        },
+        environment: 'dev'
+      }
+    })
+  })
+
+  it('truncate transaction', () => {
+    const keywordLen = 11
+    const transaction = {
+      id: 'abc123',
+      trace_id: generateStr('a', keywordLen),
+      name: generateStr('b', keywordLen),
+      type: generateStr('c', keywordLen),
+      duration: 200.5,
+      spans: [],
+      context: {
+        user: {
+          id: generateStr('d', keywordLen),
+          email: generateStr('e', keywordLen),
+          username: generateStr('f', keywordLen)
+        },
+        tags: {
+          key: generateStr('g', keywordLen)
+        }
+      },
+      marks: {
+        agent: {
+          timeToFirstByte: 100,
+          domInteractive: 150,
+          domComplete: 200
+        }
+      },
+      span_count: {
+        started: 10
+      },
+      sampled: true
+    }
+
+    const stringLimit = 5
+    const filtered = truncateTransaction(transaction)
+
+    expect(filtered).toEqual({
+      id: 'abc12',
+      trace_id: generateStr('a', stringLimit),
+      name: generateStr('b', stringLimit),
+      type: generateStr('c', stringLimit),
+      duration: 200.5,
+      spans: [],
+      context: {
+        user: {
+          id: generateStr('d', stringLimit),
+          email: generateStr('e', stringLimit),
+          username: generateStr('f', stringLimit)
+        },
+        tags: {
+          key: generateStr('g', stringLimit)
+        }
+      },
+      marks: {
+        agent: {
+          timeToFirstByte: 100,
+          domInteractive: 150,
+          domComplete: 200
+        }
+      },
+      span_count: {
+        started: 10
+      },
+      sampled: true
+    })
+  })
+
+  it('truncate spans', () => {
+    const keywordLen = 11
+    const span = {
+      id: '123abc',
+      transaction_id: generateStr('a', keywordLen),
+      parent_id: generateStr('b', keywordLen),
+      trace_id: generateStr('c', keywordLen),
+      name: generateStr('d', keywordLen),
+      type: generateStr('e', keywordLen),
+      sync: false,
+      start: 500,
+      duration: 700.02,
+      context: {
+        user: {
+          id: generateStr('f', keywordLen),
+          email: generateStr('g', keywordLen),
+          username: generateStr('h', keywordLen)
+        },
+        page: {
+          referer: 'blah',
+          url: 'http://a.com/script.js'
+        }
+      }
+    }
+
+    const stringLimit = 7
+    const filtered = truncateSpan(span)
+
+    expect(filtered).toEqual({
+      id: '123abc',
+      transaction_id: generateStr('a', stringLimit),
+      parent_id: generateStr('b', stringLimit),
+      trace_id: generateStr('c', stringLimit),
+      name: generateStr('d', stringLimit),
+      type: generateStr('e', stringLimit),
+      sync: false,
+      start: 500,
+      duration: 700.02,
+      context: {
+        user: {
+          id: generateStr('f', stringLimit),
+          email: generateStr('g', stringLimit),
+          username: generateStr('h', stringLimit)
+        },
+        page: {
+          referer: 'blah',
+          url: 'http://a.com/script.js'
+        }
+      }
+    })
+  })
+
+  it('truncate error', () => {
+    const keywordLen = 15
+
+    const error = {
+      id: '',
+      culprit: generateStr('a', keywordLen),
+      exception: {
+        message: generateStr('b', keywordLen),
+        stacktrace: [
+          {
+            filename: generateStr('c', keywordLen),
+            lineno: 123
+          },
+          {
+            filename: generateStr('d', keywordLen),
+            lineno: 200
+          }
+        ],
+        type: generateStr('e', keywordLen)
+      },
+      context: {
+        user: {
+          id: generateStr('f', keywordLen),
+          email: generateStr('g', keywordLen),
+          username: generateStr('h', keywordLen)
+        },
+        tags: {
+          foo: generateStr('i', keywordLen)
+        }
+      }
+    }
+
+    const stringLimit = 10
+    const filtered = truncateError(error)
+
+    expect(filtered).toEqual({
+      id: 'N/A',
+      culprit: generateStr('a', stringLimit),
+      exception: {
+        message: generateStr('b', keywordLen),
+        stacktrace: [
+          {
+            filename: generateStr('c', keywordLen),
+            lineno: 123
+          },
+          {
+            filename: generateStr('d', keywordLen),
+            lineno: 200
+          }
+        ],
+        type: generateStr('e', stringLimit)
+      },
+      context: {
+        user: {
+          id: generateStr('f', stringLimit),
+          email: generateStr('g', stringLimit),
+          username: generateStr('h', stringLimit)
+        },
+        tags: {
+          foo: generateStr('i', stringLimit)
+        }
+      }
+    })
+  })
+})

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -96,6 +96,11 @@ describe('Truncate', () => {
     expect(truncate(generateStr('ab', 5), 2)).toEqual('ab')
     const placeHolder = 'dummyplaceholder'
     expect(truncate('', undefined, true, placeHolder)).toEqual(placeHolder)
+    expect(truncate(undefined, undefined, true, placeHolder)).toEqual(
+      placeHolder
+    )
+    expect(truncate(undefined)).toBeUndefined()
+    expect(truncate(null)).toEqual(null)
   })
 
   it('truncate metadata', () => {
@@ -203,6 +208,8 @@ describe('Truncate', () => {
       name: generateStr('d', keywordLen),
       type: generateStr('e', keywordLen),
       sync: false,
+      subType: undefined,
+      action: undefined,
       start: 500,
       duration: 700.02,
       context: {

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -69,62 +69,6 @@ describe('lib/utils', function() {
     html.removeChild(script)
   })
 
-  describe('sanitizeString', function() {
-    it('should sanitize', function() {
-      expect(utils.sanitizeString()).toBe(undefined)
-      expect(utils.sanitizeString(null, 10)).toBe(null)
-      expect(utils.sanitizeString(null, 10, true)).toBe('NA')
-      expect(utils.sanitizeString(undefined, 10, true)).toBe('NA')
-      expect(utils.sanitizeString(undefined, 5, true, 'no string')).toBe(
-        'no st'
-      )
-      expect(utils.sanitizeString('justlong', 5, true, 'no string')).toBe(
-        'justl'
-      )
-      expect(
-        utils.sanitizeString('justlong', undefined, true, 'no string')
-      ).toBe('justlong')
-      expect(utils.sanitizeString('just', 5, true, 'no string')).toBe('just')
-      expect(
-        utils.sanitizeString(
-          { what: 'This is an object' },
-          5,
-          true,
-          'no string'
-        )
-      ).toBe('[obje')
-      expect(utils.sanitizeString(0, 5, true, 'no string')).toBe('0')
-      expect(utils.sanitizeString(1, 5, true, 'no string')).toBe('1')
-    })
-
-    it('should sanitize objects', function() {
-      var result = utils.sanitizeObjectStrings(
-        {
-          string: 'string',
-          null: null,
-          undefined,
-          number: 1,
-          object: {
-            string: 'string'
-          }
-        },
-        3
-      )
-
-      expect(result).toEqual({
-        string: 'str',
-        null: null,
-        undefined,
-        number: 1,
-        object: {
-          string: 'str'
-        }
-      })
-
-      expect(utils.sanitizeObjectStrings('test', 3)).toBe('tes')
-    })
-  })
-
   it('should getNavigationTimingMarks', function() {
     var marks = utils.getNavigationTimingMarks()
     expect(marks.fetchStart).toBeGreaterThanOrEqual(0)

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -61,14 +61,11 @@ describe('PerformanceMonitoring', function() {
     var payload = performanceMonitoring.convertTransactionsToServerModel([tr])
     var promise = apmServer.sendTransactions(payload)
     expect(promise).toBeDefined()
-    promise.then(
-      function() {
-        done()
-      },
-      function(reason) {
+    promise
+      .catch(reason => {
         fail('Failed sending transactions to the server, reason: ' + reason)
-      }
-    )
+      })
+      .then(() => done())
   })
 
   it('should group small continuously similar spans up until the last one', function() {
@@ -306,15 +303,19 @@ describe('PerformanceMonitoring', function() {
       var payload = performanceMonitoring.convertTransactionsToServerModel([tr])
       var promise = apmServer.sendTransactions(payload)
       expect(promise).toBeDefined()
-      promise.then(
-        function() {
-          window.performance.getEntriesByType = _getEntriesByType
-          done()
-        },
-        function(reason) {
-          fail('Failed sending transactions to the server, reason: ' + reason)
-        }
-      )
+      promise
+        .then(
+          () => {
+            window.performance.getEntriesByType = _getEntriesByType
+          },
+          reason => {
+            fail(
+              'Failed sending page load metrics so the server, reason: ' +
+                reason
+            )
+          }
+        )
+        .then(() => done())
     })
     transactionService.sendPageLoadMetrics('resource-test')
   })


### PR DESCRIPTION
+ Alternative implementation of https://github.com/elastic/apm-agent-rum-js/pull/199
+ fixes elastic/apm-agent-rum-js#61 
+ Minor refactoring on the corresponding files. 
+ All the undefined and null values are removed from the server payload to reduce the payload size. This is done using required field in truncation.