### PR TITLE
fix(rum-core): In truncate check for empty values

### DIFF
--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -99,7 +99,12 @@ function truncate(
   required = false,
   placeholder = 'N/A'
 ) {
-  if (required && !value) {
+  /*
+    The request will fail if we set a string placeholder
+    when the apm server expects a number.
+    However, if this happens it must be a bug.
+  */
+  if (required && isEmpty(value)) {
     value = placeholder
   }
   if (typeof value === 'string') {
@@ -108,13 +113,13 @@ function truncate(
   return value
 }
 
-function checkFalsyValue(value) {
-  return value == null || value === ''
+function isEmpty(value) {
+  return value == null || value === '' || typeof value === 'undefined'
 }
 
 function replaceValue(target, key, currModel) {
   const value = truncate(target[key], currModel[0], currModel[1])
-  if (checkFalsyValue(value)) {
+  if (isEmpty(value)) {
     delete target[key]
     return
   }


### PR DESCRIPTION
instead of falsy values when checking required fields. 

Checking for falsy doesn't work for `0` which is a valid value for a required field but we instead try to use the placeholder.