### PR TITLE
feat(rum-core): capture history.pushState calls as transactions

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -37,6 +37,11 @@ const FETCH_SOURCE = 'fetch'
 const XMLHTTPREQUEST_SOURCE = 'XMLHttpRequest.send'
 
 /**
+ * History sources
+ */
+const HISTORY_PUSHSTATE = 'history.pushState'
+
+/**
  * Event listener methods
  */
 const ADD_EVENT_LISTENER_STR = 'addEventListener'
@@ -55,6 +60,11 @@ const RESOURCE_INITIATOR_TYPES = [
   'beacon',
   'iframe'
 ]
+
+/**
+ * The amount of time it is allowed for a transaction to be reused in another startTransaction
+ */
+const REUSABILITY_THRESHOLD = 10000
 
 /**
  * Maximum duration of the span that is used to decide if the span is valid - 300 secs / 5 mins
@@ -76,5 +86,7 @@ export {
   REMOVE_EVENT_LISTENER_STR,
   RESOURCE_INITIATOR_TYPES,
   SPAN_THRESHOLD,
-  KEYWORD_LIMIT
+  KEYWORD_LIMIT,
+  HISTORY_PUSHSTATE,
+  REUSABILITY_THRESHOLD
 }

--- a/packages/rum-core/src/opentracing/tracer.js
+++ b/packages/rum-core/src/opentracing/tracer.js
@@ -74,7 +74,7 @@ class Tracer extends otTracer {
     var span
     var currentTransaction = this.transactionService.getCurrentTransaction()
 
-    if (currentTransaction && !currentTransaction.ended) {
+    if (currentTransaction) {
       span = this.transactionService.startSpan(name, undefined, spanOptions)
     } else {
       span = this.transactionService.startTransaction(

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -36,7 +36,8 @@ import {
   SCHEDULE,
   INVOKE,
   XMLHTTPREQUEST_SOURCE,
-  FETCH_SOURCE
+  FETCH_SOURCE,
+  HISTORY_PUSHSTATE
 } from '../common/constants'
 import {
   truncateModel,
@@ -122,6 +123,12 @@ class PerformanceMonitoring {
           transactionService.removeTask(task.id)
         }
       }
+
+      if (event === INVOKE && task.source === HISTORY_PUSHSTATE) {
+        transactionService.startTransaction(task.data.title, 'route-change', {
+          canReuse: true
+        })
+      }
     }
   }
 
@@ -202,6 +209,7 @@ class PerformanceMonitoring {
         browserResponsivenessInterval,
         buffer
       )
+
       if (!wasBrowserResponsive) {
         performanceMonitoring._logginService.debug(
           'Transaction was discarded! browser was not responsive enough during the transaction.',

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -35,6 +35,8 @@ import {
   removeInvalidChars
 } from '../common/utils'
 
+import { REUSABILITY_THRESHOLD } from '../common/constants'
+
 class Transaction extends SpanBase {
   constructor(name, type, options) {
     super(name, type, options)
@@ -80,10 +82,18 @@ class Transaction extends SpanBase {
     this.addMarks({ custom })
   }
 
+  canReuse(threshold = REUSABILITY_THRESHOLD) {
+    return (
+      !!this.options.canReuse &&
+      !this.ended &&
+      performance.now() - this._start < threshold
+    ) // To avoid a stale transaction capture everything
+  }
+
   redefine(name, type, options) {
     this.name = name
     this.type = type
-    this.options = options
+    this.options = extend(this.options, options)
   }
 
   startSpan(name, type, options) {

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -591,6 +591,7 @@ describe('PerformanceMonitoring', function() {
       window['__fetchDelegate'] = undefined
     })
   }
+
   it('should add xhr tasks', function(done) {
     var fn = performanceMonitoring.getXhrPatchSubFn()
     var transactionService = performanceMonitoring._transactionService
@@ -617,5 +618,27 @@ describe('PerformanceMonitoring', function() {
     expect(task.id).toBeDefined()
     expect(tr._scheduledTasks).toEqual(['task1'])
     req.send()
+  })
+
+  it('should create Transactions on history.pushState', function() {
+    var fn = performanceMonitoring.getXhrPatchSubFn()
+    performanceMonitoring.cancelPatchSub = patchSub.subscribe(function(
+      event,
+      task
+    ) {
+      fn(event, task)
+    })
+    var transactionService = performanceMonitoring._transactionService
+
+    spyOn(transactionService, 'startTransaction').and.callThrough()
+
+    history.pushState(undefined, 'test', 'test')
+
+    expect(transactionService.startTransaction).toHaveBeenCalledWith(
+      'test',
+      'route-change',
+      { canReuse: true }
+    )
+    performanceMonitoring.cancelPatchSub()
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -118,7 +118,7 @@ describe('TransactionService', function() {
 
     transactionService.startSpan('testSpan', 'testtype')
     var trans = transactionService.getCurrentTransaction()
-    expect(trans.name).toBe('ZoneTransaction')
+    expect(trans.name).toBe('Unknown')
     transactionService.startTransaction('transaction', 'transaction')
     expect(trans.name).toBe('transaction')
   })
@@ -180,7 +180,9 @@ describe('TransactionService', function() {
     var tr = transactionService.sendPageLoadMetrics('test')
 
     transactionService = new TransactionService(logger, config)
-    var zoneTr = new Transaction('ZoneTransaction', 'zone-transaction')
+    var zoneTr = new Transaction('test-name', 'test-type', {
+      canReuse: true
+    })
     transactionService.setCurrentTransaction(zoneTr)
 
     var pageLoadTr = transactionService.sendPageLoadMetrics('new tr')
@@ -265,7 +267,7 @@ describe('TransactionService', function() {
       done()
     })
 
-    var zoneTr = new Transaction('ZoneTransaction', 'zone-transaction')
+    var zoneTr = new Transaction('test', 'test-transaction')
     transactionService.setCurrentTransaction(zoneTr)
     var span = zoneTr.startSpan('GET http://example.com', 'external.http')
     span.end()

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -201,4 +201,25 @@ describe('transaction.Transaction', function() {
     span = transaction.startSpan('name', 'type', { parentId: 'test-parent-id' })
     expect(span.parentId).toBe('test-parent-id')
   })
+
+  it('should calculate reusability', function() {
+    var transaction = new Transaction('transaction', 'transaction')
+    expect(transaction.canReuse()).toBe(false)
+
+    transaction = new Transaction('transaction', 'transaction', {
+      canReuse: true
+    })
+    expect(transaction.canReuse()).toBe(true)
+
+    transaction.end()
+    expect(transaction.canReuse()).toBe(false)
+
+    transaction = new Transaction('transaction', 'transaction', {
+      canReuse: true
+    })
+    expect(transaction.canReuse()).toBe(true)
+
+    transaction._start = transaction._start - 10000
+    expect(transaction.canReuse()).toBe(false)
+  })
 })

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -176,7 +176,7 @@ describe('ApmBase', function() {
     req.send()
     tr = apmBase.getCurrentTransaction()
     expect(tr).toBeDefined()
-    expect(tr.name).toBe('ZoneTransaction')
+    expect(tr.name).toBe('Unknown')
   })
 
   it('should patch xhr when not active', function(done) {


### PR DESCRIPTION
This is part of the effort to [capture route change transactions](https://github.com/elastic/apm-agent-rum-js/issues/90). 

- patch history API
- refactoring of `TransactionService.startTransaction`
- introduce transaction reusability