### PR TITLE
Expose the Http Request method

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -93,6 +93,17 @@ This option sets the flush interval in *milliseconds* for these queues.
 
 NOTE: After each flush of the queue, the next flush isn't scheduled until an item is added to the queue.
 
+
+[function]
+[[http]]
+=== `http`
+
+* *Type:* Function
+* *Default:* ``
+
+Override the agents built-in method for sending data from the queue
+The function has the form of (method: string, url: string, data: string, headers: Object) => void
+
 [float]
 [[error-throttling]]
 === Error throttling

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -86,6 +86,10 @@ class ApmServer {
   }
 
   _makeHttpRequest(method, url, payload, headers) {
+    if (this._configService.get('http')) {
+      this._configService.get('http')(method, url, payload, headers)
+    }
+
     return new Promise(function(resolve, reject) {
       var xhr = new window.XMLHttpRequest()
       xhr[XHR_IGNORE] = true


### PR DESCRIPTION
Could elastic/apm-agent-rum-js#262 be solved with something as simple as exposing the `_makeHttpRequest` method through a config option? 