### PR TITLE
chore(rum): enable extended debugging and console logs for e2e tests

### DIFF
--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -85,7 +85,8 @@ function getBrowserList() {
   return [
     {
       browserName: 'chrome',
-      version: '49'
+      version: '49',
+      extendedDebugging: true
     },
     {
       browserName: 'chrome',
@@ -125,7 +126,12 @@ function getBrowserList() {
       platformName: 'iOS',
       browserName: 'Safari'
     }
-  ]
+  ].map(c => ({
+    ...c,
+    loggingPrefs: {
+      browser: 'INFO'
+    }
+  }))
 }
 
 module.exports = {

--- a/packages/rum/run-script.js
+++ b/packages/rum/run-script.js
@@ -142,6 +142,14 @@ function runE2eTests(config) {
 }
 
 function runSauceTests(serve = 'true') {
+  /**
+   * `console.logs` from the tests will be truncated when the process exits
+   * To avoid truncation, we flush the data from stdout before exiting the process
+   */
+  if (process.stdout.isTTY && process.stdout._handle) {
+    process.stdout._handle.setBlocking(true)
+  }
+
   let servers = []
   if (serve === 'true') {
     servers = serveE2e('./', 8000)
@@ -175,7 +183,9 @@ function runSauceTests(serve = 'true') {
       exitCode = 1
     } finally {
       servers.map(s => s.close())
-      sauceConnectProcess.close(() => process.exit(exitCode))
+      sauceConnectProcess.close(() => {
+        exitCode && process.exit(exitCode)
+      })
     }
   })
 }

--- a/packages/rum/test/e2e/utils.js
+++ b/packages/rum/test/e2e/utils.js
@@ -24,7 +24,7 @@
  */
 
 function checkDtInfo(payload) {
-  console.log('distributed tracing data', payload)
+  console.log('distributed tracing header value', payload)
   if (typeof payload.traceId !== 'string') {
     throw new Error('Wrong distributed tracing payload: ')
   }


### PR DESCRIPTION
+ fix #266 
+ We already print console logs when test fails, but to support older drivers/browsers, now extendedDebugging is enabled. Incase the browser logs are not printed, We can do a curl request to the below API to print to figure out the logs. 
```sh
curl https://<username>:<password>@eds.saucelabs.com/<testId>/console.json
```

+ set logging preferences for browser logs
+ do not truncate logs when process exits. 