### PR TITLE
chore(rum-core): remove functions from transaction-service

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -72,9 +72,11 @@ const REUSABILITY_THRESHOLD = 10000
 const SPAN_THRESHOLD = 5 * 60 * 1000
 
 /**
- * Transaction Type
+ * Transaction & Span - Name & Types
  */
 const PAGE_LOAD = 'page-load'
+const NAME_UNKNOWN = 'Unknown'
+const TYPE_CUSTOM = 'custom'
 
 /**
  * Others
@@ -94,5 +96,7 @@ export {
   REUSABILITY_THRESHOLD,
   SPAN_THRESHOLD,
   PAGE_LOAD,
+  NAME_UNKNOWN,
+  TYPE_CUSTOM,
   KEYWORD_LIMIT
 }

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -24,14 +24,15 @@
  */
 
 import { isUndefined, generateRandomId, setLabel, merge } from '../common/utils'
+import { NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
 
 class SpanBase {
   // context
 
-  constructor(name, type, options) {
-    this.options = options || {}
-    this.name = name || this.options.name || 'Unknown'
-    this.type = type || this.options.type || 'custom'
+  constructor(name = NAME_UNKNOWN, type = TYPE_CUSTOM, options = {}) {
+    this.options = options
+    this.name = name
+    this.type = type
     this.id = this.options.id || generateRandomId(16)
     this.traceId = this.options.traceId
     this.sampled = this.options.sampled

--- a/packages/rum-core/src/performance-monitoring/span.js
+++ b/packages/rum-core/src/performance-monitoring/span.js
@@ -23,9 +23,9 @@
  *
  */
 
-import BaseSpan from './span-base'
+import SpanBase from './span-base'
 
-class Span extends BaseSpan {
+class Span extends SpanBase {
   constructor(name, type, options) {
     super(name, type, options)
     this.parentId = this.options.parentId

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -105,7 +105,7 @@ class TransactionService {
   }
 
   createPerfOptions(options) {
-    var config = this._config.config
+    const config = this._config.config
     return extend(
       {
         pageLoadTraceId: config.pageLoadTraceId,
@@ -170,8 +170,8 @@ class TransactionService {
     this._logger.debug('TransactionService.startTransaction', tr)
 
     tr.onEnd = () => {
-      return Promise.resolve()
-        .then(() => {
+      return Promise.resolve().then(
+        () => {
           this._logger.debug('TransactionService transaction finished', tr)
           if (this.shouldIgnoreTransaction(tr.name)) {
             return
@@ -190,8 +190,9 @@ class TransactionService {
           } else {
             this.add(tr)
           }
-        })
-        .catch(err => this._logger.debug(err))
+        },
+        err => this._logger.debug(err)
+      )
     }
     return tr
   }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -25,7 +25,7 @@
 
 import Transaction from './transaction'
 import { extend, getPageLoadMarks } from '../common/utils'
-import { PAGE_LOAD } from '../common/constants'
+import { PAGE_LOAD, NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
 import Subscription from '../common/subscription'
 import { captureHardNavigation } from './capture-hard-navigation'
 
@@ -34,25 +34,16 @@ class TransactionService {
     if (typeof config === 'undefined') {
       logger.debug('TransactionService: config is not provided')
     }
-
     this._config = config
     this._logger = logger
-    this.marks = {}
     this.currentTransaction = undefined
     this._subscription = new Subscription()
     this._alreadyCapturedPageLoad = false
   }
 
-  shouldCreateTransaction() {
-    return this._config.isActive()
-  }
-
   ensureCurrentTransaction(options) {
     if (!options) {
       options = this.createPerfOptions()
-    }
-    if (!this.shouldCreateTransaction()) {
-      return
     }
     var tr = this.getCurrentTransaction()
     if (tr) {
@@ -74,10 +65,6 @@ class TransactionService {
   }
 
   createTransaction(name, type, options) {
-    if (!this.shouldCreateTransaction()) {
-      return
-    }
-
     var tr = new Transaction(name, type, options)
     this.setCurrentTransaction(tr)
     if (options.checkBrowserResponsiveness) {
@@ -93,32 +80,23 @@ class TransactionService {
       this._logger.debug('browserResponsivenessInterval is undefined!')
       return
     }
-    this.runOuter(function() {
-      var id = setInterval(function() {
-        if (transaction.ended) {
-          window.clearInterval(id)
-        } else {
-          transaction.browserResponsivenessCounter++
-        }
-      }, interval)
-    })
-  }
 
-  sendPageLoadMetrics(name) {
-    var tr = this.startTransaction(name, PAGE_LOAD)
-    tr.detectFinish()
-    return tr
+    const id = setInterval(function() {
+      if (transaction.ended) {
+        window.clearInterval(id)
+      } else {
+        transaction.browserResponsivenessCounter++
+      }
+    }, interval)
   }
 
   capturePageLoadMetrics(tr) {
-    var self = this
-    var capturePageLoad = self._config.get('capturePageLoad')
+    var capturePageLoad = this._config.get('capturePageLoad')
     if (
       capturePageLoad &&
-      !self._alreadyCapturedPageLoad &&
+      !this._alreadyCapturedPageLoad &&
       tr.isHardNavigation
     ) {
-      tr.addMarks(self.marks)
       captureHardNavigation(tr)
       tr.addMarks(getPageLoadMarks())
       self._alreadyCapturedPageLoad = true
@@ -133,7 +111,6 @@ class TransactionService {
         pageLoadTraceId: config.pageLoadTraceId,
         pageLoadSampled: config.pageLoadSampled,
         pageLoadSpanId: config.pageLoadSpanId,
-        pageLoadTransactionName: config.pageLoadTransactionName,
         transactionSampleRate: config.transactionSampleRate,
         checkBrowserResponsiveness: config.checkBrowserResponsiveness
       },
@@ -142,45 +119,41 @@ class TransactionService {
   }
 
   startTransaction(name, type, options) {
-    var self = this
     var perfOptions = this.createPerfOptions(options)
 
     if (!type) {
-      type = 'custom'
+      type = TYPE_CUSTOM
     }
 
     if (!name) {
-      name = 'Unknown'
+      name = NAME_UNKNOWN
     }
 
     var tr = this.getCurrentTransaction()
 
-    if (tr) {
-      if (tr.canReuse()) {
-        /*
-         * perfOptions could also have `canReuse:true` in which case we
-         * allow a redefinition until there's a call that doesn't have that
-         * or the threshold is exceeded.
-         */
-
-        this._logger.debug(
-          'Redefining the current transaction',
-          tr,
-          name,
-          type,
-          perfOptions
-        )
-        tr.redefine(name, type, perfOptions)
-      } else {
-        this._logger.debug('Ending old transaction', tr)
-        tr.end()
-        tr = this.createTransaction(name, type, perfOptions)
-      }
-    } else {
+    if (!tr) {
       tr = this.createTransaction(name, type, perfOptions)
-      if (!tr) {
-        return
-      }
+    }
+
+    if (tr.canReuse()) {
+      /*
+       * perfOptions could also have `canReuse:true` in which case we
+       * allow a redefinition until there's a call that doesn't have that
+       * or the threshold is exceeded.
+       */
+
+      this._logger.debug(
+        'Redefining the current transaction',
+        tr,
+        name,
+        type,
+        perfOptions
+      )
+      tr.redefine(name, type, perfOptions)
+    } else {
+      this._logger.debug('Ending old transaction', tr)
+      tr.end()
+      tr = this.createTransaction(name, type, perfOptions)
     }
 
     if (type === PAGE_LOAD) {
@@ -192,48 +165,35 @@ class TransactionService {
       if (perfOptions.pageLoadSampled) {
         tr.sampled = perfOptions.pageLoadSampled
       }
-
-      if (tr.name === 'Unknown' && perfOptions.pageLoadTransactionName) {
-        tr.name = perfOptions.pageLoadTransactionName
-      }
     }
 
     this._logger.debug('TransactionService.startTransaction', tr)
-    tr.onEnd = function() {
-      self.applyAsync(function() {
-        self._logger.debug('TransactionService transaction finished', tr)
-        if (!self.shouldIgnoreTransaction(tr.name)) {
+
+    tr.onEnd = () => {
+      return Promise.resolve()
+        .then(() => {
+          this._logger.debug('TransactionService transaction finished', tr)
+          if (this.shouldIgnoreTransaction(tr.name)) {
+            return
+          }
           if (type === PAGE_LOAD) {
-            if (
-              tr.name === 'Unknown' &&
-              self._config.get('pageLoadTransactionName')
-            ) {
-              tr.name = self._config.get('pageLoadTransactionName')
+            const pageLoadTransactionName = this._config.get(
+              'pageLoadTransactionName'
+            )
+            if (tr.name === NAME_UNKNOWN && pageLoadTransactionName) {
+              tr.name = pageLoadTransactionName
             }
-            var captured = self.capturePageLoadMetrics(tr)
+            const captured = this.capturePageLoadMetrics(tr)
             if (captured) {
-              self.add(tr)
+              this.add(tr)
             }
           } else {
-            self.add(tr)
+            this.add(tr)
           }
-        }
-      })
+        })
+        .catch(err => this._logger.debug(err))
     }
     return tr
-  }
-
-  applyAsync(fn, applyThis, applyArgs) {
-    return this.runOuter(function() {
-      return Promise.resolve().then(
-        function() {
-          return fn.apply(applyThis, applyArgs)
-        },
-        function(reason) {
-          console.log(reason)
-        }
-      )
-    })
   }
 
   shouldIgnoreTransaction(transactionName) {
@@ -263,10 +223,6 @@ class TransactionService {
   }
 
   add(transaction) {
-    if (!this._config.isActive()) {
-      return
-    }
-
     this._subscription.applyAll(this, [transaction])
     this._logger.debug('TransactionService.add', transaction)
   }
@@ -298,10 +254,6 @@ class TransactionService {
       tr.detectFinish()
       this._logger.debug('TransactionService.detectFinish')
     }
-  }
-
-  runOuter(fn, applyThis, applyArgs) {
-    return fn.apply(applyThis, applyArgs)
   }
 }
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -111,6 +111,7 @@ class TransactionService {
         pageLoadTraceId: config.pageLoadTraceId,
         pageLoadSampled: config.pageLoadSampled,
         pageLoadSpanId: config.pageLoadSpanId,
+        pageLoadTransactionName: config.pageLoadTransactionName,
         transactionSampleRate: config.transactionSampleRate,
         checkBrowserResponsiveness: config.checkBrowserResponsiveness
       },
@@ -119,7 +120,7 @@ class TransactionService {
   }
 
   startTransaction(name, type, options) {
-    var perfOptions = this.createPerfOptions(options)
+    const perfOptions = this.createPerfOptions(options)
 
     if (!type) {
       type = TYPE_CUSTOM
@@ -165,6 +166,13 @@ class TransactionService {
       if (perfOptions.pageLoadSampled) {
         tr.sampled = perfOptions.pageLoadSampled
       }
+      /**
+       * Retriving the name before transaction ends should reflect
+       * the correctg page load transaction name
+       */
+      if (tr.name === NAME_UNKNOWN && perfOptions.pageLoadTransactionName) {
+        tr.name = perfOptions.pageLoadTransactionName
+      }
     }
 
     this._logger.debug('TransactionService.startTransaction', tr)
@@ -177,6 +185,10 @@ class TransactionService {
             return
           }
           if (type === PAGE_LOAD) {
+            /**
+             * Setting the name via configService.setConfig after transaction
+             * has started should also reflect the correct name.
+             */
             const pageLoadTransactionName = this._config.get(
               'pageLoadTransactionName'
             )

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -388,7 +388,8 @@ describe('PerformanceMonitoring', function() {
         )
         .then(() => done())
     })
-    transactionService.sendPageLoadMetrics('resource-test')
+    const tr = transactionService.startTransaction('resource-test', 'page-load')
+    tr.detectFinish()
   })
 
   it('should filter out empty transactions', function() {

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -65,30 +65,6 @@ describe('TransactionService', function() {
     ).toHaveBeenCalledWith('test-span', 'test-span', { test: 'passed' })
   })
 
-  it('should not start span when performance monitoring is disabled', function() {
-    config.set('active', false)
-    transactionService = new TransactionService(logger, config)
-    var tr = new Transaction('transaction', 'transaction')
-    spyOn(tr, 'startSpan').and.callThrough()
-    transactionService.setCurrentTransaction(tr)
-    transactionService.startSpan('test-span', 'test-span')
-    expect(
-      transactionService.getCurrentTransaction().startSpan
-    ).not.toHaveBeenCalled()
-  })
-
-  it('should not start transaction when performance monitoring is disabled', function() {
-    config.set('active', false)
-    transactionService = new TransactionService(logger, config)
-
-    var result = transactionService.startTransaction(
-      'transaction',
-      'transaction'
-    )
-
-    expect(result).toBeUndefined()
-  })
-
   it('should start transaction', function(done) {
     config.set('active', true)
     config.set('browserResponsivenessInterval', true)
@@ -128,17 +104,6 @@ describe('TransactionService', function() {
     expect(trans.name).toBe('Unknown')
     transactionService.startTransaction('transaction', 'transaction')
     expect(trans.name).toBe('transaction')
-  })
-
-  it('should not create transaction if performance is not enabled', function() {
-    config.set('active', false)
-    transactionService = new TransactionService(logger, config)
-    var result = transactionService.createTransaction(
-      'test',
-      'test',
-      config.get('performance')
-    )
-    expect(result).toBeUndefined()
   })
 
   it('should capture page load on first transaction', function(done) {

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -137,6 +137,17 @@ describe('TransactionService', function() {
     tr2.detectFinish()
   })
 
+  it('should reuse Transaction', function() {
+    transactionService = new TransactionService(logger, config)
+    const zoneTr = new Transaction('test-name', 'test-type', {
+      canReuse: true
+    })
+    transactionService.setCurrentTransaction(zoneTr)
+    const pageLoadTr = sendPageLoadMetrics('new tr')
+
+    expect(pageLoadTr).toBe(zoneTr)
+  })
+
   it('should contain agent marks in page load transaction', function() {
     const _getEntriesByType = window.performance.getEntriesByType
 


### PR DESCRIPTION
+ removed dead code from transaction service `sendPageLoadMetrics` which was only used in tests . and also refactored the async code. 
+ removed functions related to how we run async code with function context passed around, Not necessary anymore with arrow functions. Helps new contributors understand the code easier. 
+ Moved transaction name and type as constants. 
+ Extracted from other clean up PR to make review easier. 