### PR TITLE
feat(rum-core): use error event instead of global onerror method

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -111,24 +111,9 @@ class ErrorLogging {
   }
 
   registerGlobalEventListener() {
-    window.onerror = (messageOrEvent, source, lineno, colno, error) => {
-      let errorEvent
-      if (
-        typeof messageOrEvent !== 'undefined' &&
-        typeof messageOrEvent !== 'string'
-      ) {
-        errorEvent = messageOrEvent
-      } else {
-        errorEvent = {
-          message: messageOrEvent,
-          filename: source,
-          lineno,
-          colno,
-          error
-        }
-      }
+    window.addEventListener('error', errorEvent =>
       this.logErrorEvent(errorEvent)
-    }
+    )
   }
 
   logError(messageOrError) {

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -191,10 +191,10 @@ describe('ErrorLogging', function() {
     })
 
     const addedListenerTypes = []
-    window.addEventListener = function(type, listener) {
+    let listener = (window.addEventListener = function(type, event) {
       addedListenerTypes.push(type)
-      original.call(null, type, listener)
-    }
+      errorLogging.logErrorEvent(event)
+    })
     errorLogging.registerGlobalEventListener()
     expect(addedListenerTypes).toContain('error')
 
@@ -205,7 +205,7 @@ describe('ErrorLogging', function() {
     try {
       throw new Error(testErrorMessage)
     } catch (error) {
-      errorLogging.logErrorEvent({
+      listener('error', {
         message: testErrorMessage,
         filename,
         lineno,
@@ -213,21 +213,16 @@ describe('ErrorLogging', function() {
         error
       })
     }
-    errorLogging.logErrorEvent({
+    listener('error', {
       message: testErrorMessage,
       filename,
       lineno,
-      colno,
-      error: undefined
+      colno
     })
-    errorLogging.logErrorEvent({
-      message: 'Script error.' + testErrorMessage,
-      filename: undefined,
-      lineno: undefined,
-      colno: undefined,
-      error: undefined
+    listener('error', {
+      message: 'Script error.' + testErrorMessage
     })
-    errorLogging.logErrorEvent(createErrorEvent(testErrorMessage))
+    listener('error', createErrorEvent(testErrorMessage))
   })
 
   it('should handle edge cases', function(done) {


### PR DESCRIPTION
+ fixes https://github.com/elastic/apm-agent-rum-js/issues/267