### PR TITLE
chore: use default name and type for transaction and spans

### DIFF
--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -29,7 +29,16 @@ import { NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
 class SpanBase {
   // context
 
-  constructor(name = NAME_UNKNOWN, type = TYPE_CUSTOM, options = {}) {
+  constructor(name, type, options = {}) {
+    /**
+     * Check for undefined and empty string
+     */
+    if (!name) {
+      name = NAME_UNKNOWN
+    }
+    if (!type) {
+      type = TYPE_CUSTOM
+    }
     this.options = options
     this.name = name
     this.type = type

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -25,7 +25,7 @@
 
 import Transaction from './transaction'
 import { extend, getPageLoadMarks } from '../common/utils'
-import { PAGE_LOAD, NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
+import { PAGE_LOAD, NAME_UNKNOWN } from '../common/constants'
 import Subscription from '../common/subscription'
 import { captureHardNavigation } from './capture-hard-navigation'
 
@@ -111,7 +111,6 @@ class TransactionService {
         pageLoadTraceId: config.pageLoadTraceId,
         pageLoadSampled: config.pageLoadSampled,
         pageLoadSpanId: config.pageLoadSpanId,
-        pageLoadTransactionName: config.pageLoadTransactionName,
         transactionSampleRate: config.transactionSampleRate,
         checkBrowserResponsiveness: config.checkBrowserResponsiveness
       },
@@ -121,14 +120,6 @@ class TransactionService {
 
   startTransaction(name, type, options) {
     const perfOptions = this.createPerfOptions(options)
-
-    if (!type) {
-      type = TYPE_CUSTOM
-    }
-
-    if (!name) {
-      name = NAME_UNKNOWN
-    }
 
     var tr = this.getCurrentTransaction()
 
@@ -164,13 +155,6 @@ class TransactionService {
       if (perfOptions.pageLoadSampled) {
         tr.sampled = perfOptions.pageLoadSampled
       }
-      /**
-       * Retriving the name before transaction ends should reflect
-       * the correctg page load transaction name
-       */
-      if (tr.name === NAME_UNKNOWN && perfOptions.pageLoadTransactionName) {
-        tr.name = perfOptions.pageLoadTransactionName
-      }
     }
 
     this._logger.debug('TransactionService.startTransaction', tr)
@@ -184,8 +168,8 @@ class TransactionService {
           }
           if (type === PAGE_LOAD) {
             /**
-             * Setting the name via configService.setConfig after transaction
-             * has started should also reflect the correct name.
+             * Setting the pageLoadTransactionName via configService.setConfig after
+             * transaction has started should also reflect the correct name.
              */
             const pageLoadTransactionName = this._config.get(
               'pageLoadTransactionName'

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -111,6 +111,7 @@ class TransactionService {
         pageLoadTraceId: config.pageLoadTraceId,
         pageLoadSampled: config.pageLoadSampled,
         pageLoadSpanId: config.pageLoadSpanId,
+        pageLoadTransactionName: config.pageLoadTransactionName,
         transactionSampleRate: config.transactionSampleRate,
         checkBrowserResponsiveness: config.checkBrowserResponsiveness
       },
@@ -154,6 +155,13 @@ class TransactionService {
       }
       if (perfOptions.pageLoadSampled) {
         tr.sampled = perfOptions.pageLoadSampled
+      }
+      /**
+       * The name must be set as soon as the transaction is started
+       * Ex: Helps to decide sampling based on name
+       */
+      if (tr.name === NAME_UNKNOWN && perfOptions.pageLoadTransactionName) {
+        tr.name = perfOptions.pageLoadTransactionName
       }
     }
 

--- a/packages/rum-core/test/performance-monitoring/span-base.spec.js
+++ b/packages/rum-core/test/performance-monitoring/span-base.spec.js
@@ -26,6 +26,13 @@
 import SpanBase from '../../src/performance-monitoring/span-base'
 
 describe('SpanBase', function() {
+  it('should add default name and type for span', () => {
+    const span = new SpanBase('', undefined)
+
+    expect(span.name).toEqual('Unknown')
+    expect(span.type).toEqual('custom')
+  })
+
   it('should addLabels', function() {
     var span = new SpanBase()
     span.addLabels({ test: 'passed', 'test.new': 'new' })

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -65,21 +65,21 @@ class ApmBase {
   }
 
   _sendPageLoadMetrics() {
-    var transactionService = this.serviceFactory.getService(
+    const transactionService = this.serviceFactory.getService(
       'TransactionService'
     )
-    var configService = this.serviceFactory.getService('ConfigService')
 
     const pageLoadTaskId = 'page-load'
-    var tr = transactionService.startTransaction(
-      configService.get('pageLoadTransactionName'),
-      'page-load'
-    )
+    /**
+     * Name of the transaction is set in transaction service to
+     * avoid duplicate the logic at multiple places
+     */
+    const tr = transactionService.startTransaction(undefined, 'page-load')
 
     if (tr) {
       tr.addTask(pageLoadTaskId)
     }
-    var sendPageLoadMetrics = function sendPageLoadMetrics() {
+    const sendPageLoadMetrics = function sendPageLoadMetrics() {
       // to make sure PerformanceTiming.loadEventEnd has a value
       setTimeout(function() {
         if (tr) {


### PR DESCRIPTION
+ Set the default name and type for all transaction and span and remove the check in other places on the codebase. 
+ Extracted from other PR elastic/apm-agent-rum-js#294 