### PR TITLE
fix(rum:core): send labels via context.tags in the payload

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -199,12 +199,12 @@ class Config {
     }
   }
 
-  addLabels(labels) {
-    if (!this.config.context.labels) {
-      this.config.context.labels = {}
+  addLabels(tags) {
+    if (!this.config.context.tags) {
+      this.config.context.tags = {}
     }
-    var keys = Object.keys(labels)
-    keys.forEach(k => setLabel(k, labels[k], this.config.context.labels))
+    var keys = Object.keys(tags)
+    keys.forEach(k => setLabel(k, tags[k], this.config.context.tags))
   }
 
   setConfig(properties = {}) {

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -63,14 +63,14 @@ class SpanBase {
     this.addLabels(tags)
   }
 
-  addLabels(labels) {
+  addLabels(tags) {
     this.ensureContext()
     var ctx = this.context
-    if (!ctx.labels) {
-      ctx.labels = {}
+    if (!ctx.tags) {
+      ctx.tags = {}
     }
-    var keys = Object.keys(labels)
-    keys.forEach(k => setLabel(k, labels[k], ctx.labels))
+    var keys = Object.keys(tags)
+    keys.forEach(k => setLabel(k, tags[k], ctx.tags))
   }
 
   addContext(context) {

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -175,7 +175,7 @@ describe('ConfigService', function() {
       date
     }
     configService.addLabels(labels)
-    const contextLabels = configService.get('context.labels')
+    const contextLabels = configService.get('context.tags')
     expect(contextLabels).toEqual({
       test: 'test',
       no: '1',

--- a/packages/rum-core/test/opentracing/opentracing.spec.js
+++ b/packages/rum-core/test/opentracing/opentracing.spec.js
@@ -96,7 +96,7 @@ describe('OpenTracing API', function() {
         username: 'test-username',
         email: 'test-email'
       },
-      labels: { another_tag: 'test-tag' }
+      tags: { another_tag: 'test-tag' }
     })
 
     var testError = new Error('OpenTracing test error')
@@ -126,7 +126,7 @@ describe('OpenTracing API', function() {
 
     expect(childSpan.span.type).toBe('new-type')
     expect(childSpan.span.context).toEqual({
-      labels: {
+      tags: {
         another_tag: 'test-tag',
         user_id: 'test-id',
         user_username: 'test-username',

--- a/packages/rum-core/test/performance-monitoring/span-base.spec.js
+++ b/packages/rum-core/test/performance-monitoring/span-base.spec.js
@@ -37,7 +37,7 @@ describe('SpanBase', function() {
     var span = new SpanBase()
     span.addLabels({ test: 'passed', 'test.new': 'new' })
     expect(span.context).toEqual({
-      labels: { test: 'passed', test_new: 'new' }
+      tags: { test: 'passed', test_new: 'new' }
     })
   })
 


### PR DESCRIPTION
+ fixes https://github.com/elastic/apm-agent-rum-js/issues/315