### PR TITLE
chore(coverage): adding code coverage for all packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,6 +110,7 @@ pipeline {
         Build the documentation.
         */
         stage('Documentation') {
+          agent { label 'linux && immutable' }
           steps {
             withGithubNotify(context: 'Documentation') {
               deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,8 @@ pipeline {
         stage('Coverage') {
           steps {
             withGithubNotify(context: 'Coverage') {
-              runScript(label: 'coverage', stack: '7.0.0', scope: '@elastic/apm-rum', goal: 'coverage')
+              // No scope is required as the coverage should run for all of them
+              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
               codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
             }
           }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Elastic APM Real User Monitoring (RUM) JavaScript agent
 
-[![Build status](https://travis-ci.org/elastic/apm-agent-rum-js.svg?branch=master)](https://travis-ci.org/elastic/apm-agent-rum-js)
+[![Build Status in Travis](https://travis-ci.org/elastic/apm-agent-rum-js.svg?branch=master)](https://travis-ci.org/elastic/apm-agent-rum-js)
+[![Build Status in Jenkins](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-rum%2Fapm-agent-rum-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/master/)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
+[![codecov](https://codecov.io/gh/elastic/apm-agent-rum-js/branch/master/graph/badge.svg)](https://codecov.io/gh/elastic/apm-agent-rum-js)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/elastic-apm-base.svg)](https://saucelabs.com/u/elastic-apm-base)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+comment:
+  layout: "header, changes, diff, files"
+  behavior: default
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1
+      rum:
+        - packages/rum
+      rum-core:
+        - packages/rum-core
+      rum-react:
+        - packages/rum-react
+    patch:
+      default:
+        target: auto

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - SAUCE_USERNAME=${SAUCE_USERNAME}
       - SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}
       - MODE=${MODE}
-      - GOAL=${COVERAGE}
+      - GOAL=${GOAL}
     command: >
       /bin/bash -c "set -x
         id

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -119,6 +119,7 @@ services:
           - wait-for-apm-server
 
   node-puppeteer:
+    build: ../.ci/docker/node-puppeteer
     container_name: node-puppeteer
     image: docker.elastic.co/observability-ci/node-puppeteer:8
     environment:

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -132,6 +132,7 @@ services:
       - SAUCE_USERNAME=${SAUCE_USERNAME}
       - SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}
       - MODE=${MODE}
+      - GOAL=${COVERAGE}
     command: >
       /bin/bash -c "set -x
         id
@@ -143,7 +144,7 @@ services:
         npm install
         npm install puppeteer --unsafe-perm=true --allow-root
         set -eo pipefail
-        npm run test"
+        npm run ${GOAL}"
     mem_limit: 2000m
 #    cpus: 0.5
     depends_on:

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -156,10 +156,7 @@ function prepareConfig(defaultConfig) {
 
       defaultConfig.coverageReporter = {
         includeAllSources: true,
-        reporters: [
-          { type: 'html', dir: 'coverage/' },
-          { type: 'text-summary' }
-        ],
+        reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
         dir: 'coverage/'
       }
       defaultConfig.reporters.push('coverage')

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -116,7 +116,7 @@ function prepareConfig(defaultConfig) {
       ')'
     defaultConfig.plugins.push('karma-firefox-launcher')
     defaultConfig.browsers.push('Firefox')
-  } else if (isJenkins && isSauce) {
+  } else if (isJenkins) {
     console.log('prepareConfig: Run in Jenkins')
     buildId =
       buildId +
@@ -126,10 +126,7 @@ function prepareConfig(defaultConfig) {
       process.env.BRANCH_NAME +
       ') Elastic Stack ' +
       process.env.STACK_VERSION
-    console.log('prepareConfig: buildId ' + buildId)
-    defaultConfig.plugins.push('karma-firefox-launcher')
-    defaultConfig.browsers.push('Firefox')
-  } else if (isJenkins && !isSauce) {
+
     defaultConfig.plugins.push('karma-chrome-launcher')
     defaultConfig.browsers = ['ChromeHeadlessNoSandbox']
     defaultConfig.customLaunchers = {
@@ -142,41 +139,41 @@ function prepareConfig(defaultConfig) {
         ]
       }
     }
-    if (defaultConfig.coverage) {
-      // istanbul code coverage
-      defaultConfig.plugins.push('karma-coverage')
-
-      var babelPlugins = defaultConfig.webpack.module.rules[0].options.plugins
-      babelPlugins.push('istanbul')
-
-      defaultConfig.coverageReporter = {
-        includeAllSources: true,
-        reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
-        dir: 'coverage/'
-      }
-      defaultConfig.reporters.push('coverage')
-    }
   } else {
     console.log('prepareConfig: Run in Default enviroment')
     defaultConfig.plugins.push('karma-chrome-launcher')
     defaultConfig.browsers.push('Chrome')
   }
 
+  /**
+   *  Add coverage reports and plugins required for all environments
+   */
+  if (defaultConfig.coverage) {
+    defaultConfig.plugins.push('karma-coverage')
+    defaultConfig.reporters.push('coverage')
+
+    const babelPlugins = defaultConfig.webpack.module.rules[0].options.plugins
+    babelPlugins.push('istanbul')
+
+    defaultConfig.coverageReporter = {
+      includeAllSources: true,
+      reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
+      dir: 'coverage/'
+    }
+  }
+
   if (isSauce) {
-    console.log('prepareConfig: Run in SuaceLab mode')
+    console.log('prepareConfig: Run in SauceLab mode')
+    defaultConfig.sauceLabs.build = buildId
+    console.log('saucelabs.build:', buildId)
     defaultConfig.concurrency = 3
-    if (testConfig.branch === 'master' && !isJenkins) {
-      // && process.env.TRAVIS_PULL_REQUEST !== 'false'
-      defaultConfig.sauceLabs.build = buildId
-      defaultConfig.sauceLabs.tags = ['master']
-      console.log('saucelabs.build:', buildId)
-    } else if (isJenkins) {
-      defaultConfig.sauceLabs.build = buildId
+    if (isJenkins) {
       defaultConfig.sauceLabs.tags = [
         testConfig.branch,
         process.env.STACK_VERSION
       ]
-      console.log('saucelabs.build:', buildId)
+    } else if (testConfig.branch === 'master') {
+      defaultConfig.sauceLabs.tags = [testConfig.branch]
     }
     defaultConfig.reporters = ['dots', 'saucelabs']
     defaultConfig.browsers = Object.keys(defaultConfig.customLaunchers)

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -142,11 +142,6 @@ function prepareConfig(defaultConfig) {
         ]
       }
     }
-  } else {
-    console.log('prepareConfig: Run in Default enviroment')
-    defaultConfig.plugins.push('karma-chrome-launcher')
-    defaultConfig.browsers.push('Chrome')
-
     if (defaultConfig.coverage) {
       // istanbul code coverage
       defaultConfig.plugins.push('karma-coverage')
@@ -161,6 +156,10 @@ function prepareConfig(defaultConfig) {
       }
       defaultConfig.reporters.push('coverage')
     }
+  } else {
+    console.log('prepareConfig: Run in Default enviroment')
+    defaultConfig.plugins.push('karma-chrome-launcher')
+    defaultConfig.browsers.push('Chrome')
   }
 
   if (isSauce) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,6 +3730,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5251,6 +5257,19 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codecov": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.5.0.tgz",
+      "integrity": "sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==",
+      "dev": true,
+      "requires": {
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.13.1",
+        "teeny-request": "^3.11.3",
+        "urlgrey": "^0.4.4"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -16170,6 +16189,17 @@
         "xtend": "^4.0.0"
       }
     },
+    "teeny-request": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
+      "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -16861,6 +16891,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "lerna run build:main && lerna run test --stream --scope=$SCOPE --no-prefix",
     "bundlesize": "lerna run bundlesize --stream",
     "serve": "node ./dev-utils/run-script.js startTestServers",
-    "coverage": "lerna run karma:coverage --stream && codecov"
+    "coverage": "lerna run karma:coverage --stream"
   },
   "lint-staged": {
     "*.{js,jsx}": [
@@ -94,7 +94,7 @@
     "npm-run-all": "^4.1.5",
     "npmlog": "^4.1.2",
     "prettier": "^1.16.4",
-    "puppeteer": "^1.12.2",
+    "puppeteer": "^1.18.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "lerna run build:main && lerna run test --stream --scope=$SCOPE --no-prefix",
     "bundlesize": "lerna run bundlesize --stream",
     "serve": "node ./dev-utils/run-script.js startTestServers",
-    "coverage": "lerna run karma:coverage --stream"
+    "coverage": "lerna run build:main && lerna run karma:coverage --stream"
   },
   "lint-staged": {
     "*.{js,jsx}": [
@@ -94,7 +94,7 @@
     "npm-run-all": "^4.1.5",
     "npmlog": "^4.1.2",
     "prettier": "^1.16.4",
-    "puppeteer": "^1.18.1",
+    "puppeteer": "^1.12.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:license": "node scripts/license-checker",
     "test": "lerna run build:main && lerna run test --stream --scope=$SCOPE --no-prefix",
     "bundlesize": "lerna run bundlesize --stream",
-    "serve": "node ./dev-utils/run-script.js startTestServers"
+    "serve": "node ./dev-utils/run-script.js startTestServers",
+    "coverage": "lerna run karma:coverage --stream && codecov"
   },
   "lint-staged": {
     "*.{js,jsx}": [
@@ -58,6 +59,7 @@
     "babel-plugin-istanbul": "^5.1.4",
     "benchmark": "^2.1.4",
     "bundlesize": "^0.17.2",
+    "codecov": "^3.5.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "es6-promise": "^4.2.4",

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -19,7 +19,7 @@
     "build:main": "npx babel src -d dist/lib --config-file ../../babel.node.js",
     "karma": "karma start",
     "karma:bench": "karma start karma.bench.conf.js",
-    "karma:coverage": "karma start --coverage",
+    "karma:coverage": "karma start --coverage --singleRun",
     "test:unit": "node ../../dev-utils/run-script.js runUnitTests packages/rum-core true",
     "test": "npm run test:unit"
   },

--- a/packages/rum-react/karma.conf.js
+++ b/packages/rum-react/karma.conf.js
@@ -38,24 +38,22 @@ module.exports = function(config) {
         {
           test: /.jsx?$/,
           exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-            options: {
-              presets: [
-                [
-                  '@babel/preset-env',
-                  {
-                    targets: {
-                      ie: '11'
-                    },
-                    useBuiltIns: false,
-                    modules: 'umd'
-                  }
-                ],
-                ['@babel/preset-react']
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              [
+                '@babel/preset-env',
+                {
+                  targets: {
+                    ie: '11'
+                  },
+                  useBuiltIns: false,
+                  modules: 'umd'
+                }
               ],
-              plugins: ['@babel/plugin-transform-destructuring']
-            }
+              ['@babel/preset-react']
+            ],
+            plugins: ['@babel/plugin-transform-destructuring']
           }
         }
       ]

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -26,6 +26,7 @@
     "build:main": "npx babel src -d dist/lib --config-file ./babel.config.js",
     "build:e2e": "npm run script buildE2eBundles packages/rum-react/test/e2e",
     "karma": "karma start",
+    "karma:coverage": "karma start --coverage --singleRun",
     "test:unit": "npm run script runUnitTests packages/rum-react",
     "test:e2e:supported": "npm run script runE2eTests packages/rum-react/wdio.conf.js",
     "test:sauce": "npm run script runSauceTests packages/rum-react true build:e2e test:unit test:e2e:supported",

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -20,7 +20,7 @@
     "build:e2e": "node ../../dev-utils/run-script.js buildE2eBundles packages/rum/test/e2e",
     "bundlesize": "npm run build && bundlesize",
     "karma": "karma start",
-    "karma:coverage": "karma start --coverage",
+    "karma:coverage": "karma start --coverage --singleRun",
     "script": "node ../../dev-utils/run-script.js",
     "test:node": "npm run script runNodeTests",
     "test:integration": "npm run script runIntegrationTests",


### PR DESCRIPTION
+ testing code coverage since we have Jenkins pipeline already integrated now. 
+ fixes #153 

## Highlights
- Publish to `https://codecov.io/gh/elastic/apm-agent-rum-js`
- https://github.com/elastic/apm-agent-rum-js/pull/322/commits/fa5a844063726348f24b6f8a59952f72258fefcb enable the coverage in the Jenkins pipeline.
- It does provide a new stage to validate the code coverage and push to codecov.io using the stack `7.0.0` and without any goal (as it will run for all the packages) rather than the whole configuration matrix of stacks and scopes.
- It does extend the puppeteer docker node to run the npm goal which has been specified in the `GOAL` env variable. Therefore, the same dockerised infra can be used for running `npm run test` and `npm run coverage`.

## How to test locally

```
## You need docker and docker-compose
export STACK_VERSION=7.0.0
export APM_SERVER_URL='http://apm-server:8200'
export APM_SERVER_PORT='8200'
export GOAL="coverage"
export JENKINS_URL="https://jenkins.elastic.co/"
.ci/scripts/test.sh
```