### PR TITLE
ci(jenkins): enable junit reporting to be consumed by the pipeline

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -3,4 +3,5 @@ docker-compose -f ./dev-utils/docker-compose.yml up \
   --abort-on-container-exit \
   --exit-code-from node-puppeteer \
   --remove-orphans \
+  --build \
   node-puppeteer

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -3,5 +3,4 @@ docker-compose -f ./dev-utils/docker-compose.yml up \
   --abort-on-container-exit \
   --exit-code-from node-puppeteer \
   --remove-orphans \
-  --build \
   node-puppeteer

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,8 +222,8 @@ def runScript(Map params = [:]){
     withEnv([
       "STACK_VERSION=${stack}",
       "SCOPE=${scope}",
-      "APM_SERVER_URL='http://apm-server:8200'",
-      "APM_SERVER_PORT='8200'",
+      "APM_SERVER_URL=http://apm-server:8200",
+      "APM_SERVER_PORT=8200",
       "GOAL=${goal}"]) {
       retry(2) {
         sleep randomNumber(min: 5, max: 10)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ def bundlesize(){
 def wrappingUp(){
   junit(allowEmptyResults: true,
     keepLongStdio: true,
-    testResults: "**/spec/rum-agent-junit.xml")
+    testResults: "**/reports/TEST-*.xml")
   archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs")
   codecov(repo: 'apm-agent-rum', basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,5 +280,5 @@ def wrappingUp(){
   junit(allowEmptyResults: true,
     keepLongStdio: true,
     testResults: "**/reports/TESTS-*.xml")
-  archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs")
+  archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs,**/reports/TESTS-*.xml")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,6 +279,6 @@ def bundlesize(){
 def wrappingUp(){
   junit(allowEmptyResults: true,
     keepLongStdio: true,
-    testResults: "**/reports/TESTS-*.xml")
-  archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs,**/reports/TESTS-*.xml")
+    testResults: "${env.BASE_DIR}/packages/**/reports/TESTS-*.xml")
+  archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs,${env.BASE_DIR}/packages/**/reports/TESTS-*.xml")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,30 +214,30 @@ def runScript(Map params = [:]){
   def label = params.label
   def goal = params.get('goal', 'test')
 
-  env.STACK_VERSION = "${stack}"
-  env.SCOPE = "${scope}"
-  env.APM_SERVER_URL = 'http://apm-server:8200'
-  env.APM_SERVER_PORT = '8200'
-  env.GOAL = "${goal}"
-
   deleteDir()
   unstash 'source'
   unstash 'cache'
   dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "docker.elastic.co")
   dir("${BASE_DIR}"){
-    retry(2) {
-      sleep randomNumber(min: 5, max: 10)
-      sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
-    }
-
-    if(params.saucelab_test){
-      env.MODE = 'saucelabs'
-      withSaucelabsEnv(){
+    withEnv([
+      "STACK_VERSION=${stack}",
+      "SCOPE=${scope}",
+      "APM_SERVER_URL='http://apm-server:8200'",
+      "APM_SERVER_PORT='8200'",
+      "GOAL=${goal}"]) {
+      retry(2) {
+        sleep randomNumber(min: 5, max: 10)
+        sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
+      }
+      if(params.saucelab_test){
+        env.MODE = 'saucelabs'
+        withSaucelabsEnv(){
+          sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
+        }
+      } else {
+        env.MODE = 'none'
         sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
       }
-    } else {
-      env.MODE = 'none'
-      sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ def bundlesize(){
 def wrappingUp(){
   junit(allowEmptyResults: true,
     keepLongStdio: true,
-    testResults: "**/reports/TEST-*.xml")
+    testResults: "**/reports/TESTS-*.xml")
   archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs")
   codecov(repo: 'apm-agent-rum', basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
 }

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -127,12 +127,6 @@ function prepareConfig(defaultConfig) {
       ') Elastic Stack ' +
       process.env.STACK_VERSION
 
-    defaultConfig.plugins.push('karma-junit-reporter')
-    defaultConfig.junitReporter = {
-      outputDir: 'reports'
-    }
-    defaultConfig.reporters.push('junit')
-
     defaultConfig.plugins.push('karma-chrome-launcher')
     defaultConfig.browsers = ['ChromeHeadlessNoSandbox']
     defaultConfig.customLaunchers = {
@@ -155,9 +149,10 @@ function prepareConfig(defaultConfig) {
    *  Add coverage reports and plugins required for all environments
    */
   if (defaultConfig.coverage) {
+    defaultConfig.plugins.push('karma-junit-reporter')
     defaultConfig.plugins.push('karma-coverage')
     defaultConfig.reporters.push('coverage')
-
+    defaultConfig.reporters.push('junit')
     const babelPlugins = defaultConfig.webpack.module.rules[0].options.plugins
     babelPlugins.push('istanbul')
 
@@ -165,6 +160,16 @@ function prepareConfig(defaultConfig) {
       includeAllSources: true,
       reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
       dir: 'coverage/'
+    }
+    defaultConfig.junitReporter = {
+      outputDir: 'reports',
+      outputFile: undefined,
+      suite: '',
+      useBrowserName: true,
+      nameFormatter: undefined,
+      classNameFormatter: undefined,
+      properties: {},
+      xmlVersion: null
     }
   }
 

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -129,14 +129,7 @@ function prepareConfig(defaultConfig) {
 
     defaultConfig.plugins.push('karma-junit-reporter')
     defaultConfig.junitReporter = {
-      outputDir: 'reports',
-      outputFile: undefined,
-      suite: '',
-      useBrowserName: true,
-      nameFormatter: undefined,
-      classNameFormatter: undefined,
-      properties: {},
-      xmlVersion: null
+      outputDir: 'reports'
     }
     defaultConfig.reporters.push('junit')
 

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -130,6 +130,18 @@ function prepareConfig(defaultConfig) {
     defaultConfig.plugins.push('karma-firefox-launcher')
     defaultConfig.browsers.push('Firefox')
   } else if (isJenkins && !isSauce) {
+    defaultConfig.plugins.push('karma-junit-reporter')
+    defaultConfig.junitReporter = {
+      outputDir: 'reports',
+      outputFile: undefined,
+      suite: '',
+      useBrowserName: true,
+      nameFormatter: undefined,
+      classNameFormatter: undefined,
+      properties: {},
+      xmlVersion: null
+    }
+    defaultConfig.reporters.push('junit')
     defaultConfig.plugins.push('karma-chrome-launcher')
     defaultConfig.browsers = ['ChromeHeadlessNoSandbox']
     defaultConfig.customLaunchers = {

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -142,14 +142,7 @@ function prepareConfig(defaultConfig) {
     defaultConfig.plugins.push('karma-junit-reporter')
     defaultConfig.reporters.push('junit')
     defaultConfig.junitReporter = {
-      outputDir: 'reports',
-      outputFile: undefined,
-      suite: '',
-      useBrowserName: true,
-      nameFormatter: undefined,
-      classNameFormatter: undefined,
-      properties: {},
-      xmlVersion: null
+      outputDir: 'reports'
     }
   } else {
     console.log('prepareConfig: Run in Default enviroment')

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -139,6 +139,18 @@ function prepareConfig(defaultConfig) {
         ]
       }
     }
+    defaultConfig.plugins.push('karma-junit-reporter')
+    defaultConfig.reporters.push('junit')
+    defaultConfig.junitReporter = {
+      outputDir: 'reports',
+      outputFile: undefined,
+      suite: '',
+      useBrowserName: true,
+      nameFormatter: undefined,
+      classNameFormatter: undefined,
+      properties: {},
+      xmlVersion: null
+    }
   } else {
     console.log('prepareConfig: Run in Default enviroment')
     defaultConfig.plugins.push('karma-chrome-launcher')
@@ -149,10 +161,8 @@ function prepareConfig(defaultConfig) {
    *  Add coverage reports and plugins required for all environments
    */
   if (defaultConfig.coverage) {
-    defaultConfig.plugins.push('karma-junit-reporter')
     defaultConfig.plugins.push('karma-coverage')
     defaultConfig.reporters.push('coverage')
-    defaultConfig.reporters.push('junit')
     const babelPlugins = defaultConfig.webpack.module.rules[0].options.plugins
     babelPlugins.push('istanbul')
 
@@ -160,16 +170,6 @@ function prepareConfig(defaultConfig) {
       includeAllSources: true,
       reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
       dir: 'coverage/'
-    }
-    defaultConfig.junitReporter = {
-      outputDir: 'reports',
-      outputFile: undefined,
-      suite: '',
-      useBrowserName: true,
-      nameFormatter: undefined,
-      classNameFormatter: undefined,
-      properties: {},
-      xmlVersion: null
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11357,6 +11357,16 @@
       "integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=",
       "dev": true
     },
+    "karma-junit-reporter": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
+      "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
+      "dev": true,
+      "requires": {
+        "path-is-absolute": "^1.0.0",
+        "xmlbuilder": "8.2.2"
+      }
+    },
     "karma-sauce-launcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz",
@@ -17704,6 +17714,12 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "karma-failed-reporter": "^0.0.3",
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.0",
+    "karma-junit-reporter": "^1.2.0",
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.31",


### PR DESCRIPTION
## Highlights
- Enable JUnit reporting in the Jenkins pipeline.


## Tests
- See [this](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp%2FPR-323/detail/PR-323/2/tests/)

![image](https://user-images.githubusercontent.com/2871786/61134809-547e1e80-a4b8-11e9-9392-1c7edfa3e956.png)


## How to test locally

```
## You need docker and docker-compose
export STACK_VERSION=7.0.0
export APM_SERVER_URL='http://apm-server:8200'
export APM_SERVER_PORT='8200'
export GOAL="test"
export JENKINS_URL="https://jenkins.elastic.co/"
.ci/scripts/test.sh
```