### PR TITLE
ci(jenkins): more resilient when infra is temporarily unreachable

### DIFF
--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker-compose -f ./dev-utils/docker-compose.yml pull --ignore-pull-failures
+docker-compose -f ./dev-utils/docker-compose.yml build --force-rm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,6 +210,11 @@ def runScript(Map params = [:]){
   unstash 'cache'
   dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "docker.elastic.co")
   dir("${BASE_DIR}"){
+    retry(2) {
+      sleep randomNumber(min: 5, max: 10)
+      sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
+    }
+
     if(params.saucelab_test){
       env.MODE = 'saucelabs'
       withSaucelabsEnv(){


### PR DESCRIPTION
## Highlight
- Sometimes if the infra is temporary down then the pipelines might fail. See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/PR-322/6/pipeline/122)
```
[2019-07-12T14:14:14.216Z] Pulling elasticsearch (docker.elastic.co/elasticsearch/elasticsearch:6.6.0)...
[2019-07-12T14:14:32.360Z] Get https://docker.elastic.co/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
script returned exit code 1
```
- let's retry up to 3 times with a sleep time to pull and build the required docker images previously.


