### PR TITLE
ci(jenkins): ITs for forked repos with different name is not supported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
             log(level: 'INFO', text: 'Launching Async ITs')
             build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                   parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'RUM'),
-                               string(name: 'BUILD_OPTS', value: "--rum-agent-branch ${env.GIT_BASE_COMMIT} --rum-agent-repo ${env.CHANGE_FORK?.trim() ?: 'elastic' }/${env.REPO}"),
+                               string(name: 'BUILD_OPTS', value: "--rum-agent-branch ${env.GIT_BASE_COMMIT}"),
                                string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])


### PR DESCRIPTION
This is caused by https://github.com/jenkinsci/github-branch-source-plugin/pull/235

## Highlights
- ITs for the rum-js agent don't require the repo name as it does fetch the PRs too
  - See https://github.com/elastic/apm-integration-testing/blob/edb0048bb0d3c79e8c8c9349bde7030762ddc7f6/docker/rum/Dockerfile#L23-L26