### PR TITLE
ci(jenkins): report cobertura in the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,11 @@ pipeline {
               codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
             }
           }
+          post {
+            always {
+              coverageReport("${BASE_DIR}/packages/**")
+            }
+          }
         }
         /**
         Build the documentation.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
             withGithubNotify(context: 'Coverage') {
               // No scope is required as the coverage should run for all of them
               runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
+              sh '''find . -name "*-report.xml" -exec grep '<source>' {} +'''
               codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,6 @@ pipeline {
           post {
             always {
               coverageReport("${BASE_DIR}/packages/**")
-              archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/packages/**/coverage/coverage-*.xml")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,25 @@ pipeline {
           }
         }
         /**
+        Execute code coverange only once.
+        */
+        stage('Coverage') {
+          steps {
+            withGithubNotify(context: 'Coverage') {
+              // No scope is required as the coverage should run for all of them
+              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
+              sh 'ls -l ${WORKSPACE}/${BASE_DIR}/packages || true'
+              sh 'find ${WORKSPACE}/${BASE_DIR}/packages -name *-report.xml || true'
+              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
+            }
+          }
+          post {
+            always {
+              coverageReport("${BASE_DIR}/packages/**")
+            }
+          }
+        }
+        /**
         Execute unit tests.
         */
         stage('Test') {
@@ -91,23 +110,6 @@ pipeline {
               dir("${BASE_DIR}"){
                 runParallelTest()
               }
-            }
-          }
-        }
-        /**
-        Execute code coverange only once.
-        */
-        stage('Coverage') {
-          steps {
-            withGithubNotify(context: 'Coverage') {
-              // No scope is required as the coverage should run for all of them
-              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
-              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
-            }
-          }
-          post {
-            always {
-              coverageReport("${BASE_DIR}/packages/**")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,25 +81,6 @@ pipeline {
           }
         }
         /**
-        Execute code coverange only once.
-        */
-        stage('Coverage') {
-          steps {
-            withGithubNotify(context: 'Coverage') {
-              // No scope is required as the coverage should run for all of them
-              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
-              sh 'ls -l ${WORKSPACE}/${BASE_DIR}/packages || true'
-              sh 'find ${WORKSPACE}/${BASE_DIR}/packages -name *-report.xml || true'
-              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
-            }
-          }
-          post {
-            always {
-              coverageReport("${BASE_DIR}/packages/**")
-            }
-          }
-        }
-        /**
         Execute unit tests.
         */
         stage('Test') {
@@ -110,6 +91,23 @@ pipeline {
               dir("${BASE_DIR}"){
                 runParallelTest()
               }
+            }
+          }
+        }
+        /**
+        Execute code coverange only once.
+        */
+        stage('Coverage') {
+          steps {
+            withGithubNotify(context: 'Coverage') {
+              // No scope is required as the coverage should run for all of them
+              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
+              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
+            }
+          }
+          post {
+            always {
+              coverageReport("${BASE_DIR}/packages/**")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,26 +80,6 @@ pipeline {
             }
           }
         }
-
-        /**
-        Execute code coverange only once.
-        */
-        stage('Coverage') {
-          steps {
-            withGithubNotify(context: 'Coverage') {
-              // No scope is required as the coverage should run for all of them
-              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
-              sh '''find . -name "*-report.xml" -exec grep '<source>' {} +'''
-              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
-            }
-          }
-          post {
-            always {
-              coverageReport("${BASE_DIR}/packages/**")
-              archiveArtifacts(allowEmptyArchive: true, artifacts: "**/packages/**/coverage/**")
-            }
-          }
-        }
         /**
         Execute unit tests.
         */
@@ -111,6 +91,23 @@ pipeline {
               dir("${BASE_DIR}"){
                 runParallelTest()
               }
+            }
+          }
+        }
+        /**
+        Execute code coverange only once.
+        */
+        stage('Coverage') {
+          steps {
+            withGithubNotify(context: 'Coverage') {
+              // No scope is required as the coverage should run for all of them
+              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
+              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
+            }
+          }
+          post {
+            always {
+              coverageReport("${BASE_DIR}/packages/**")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,8 @@ pipeline {
           post {
             always {
               coverageReport("${BASE_DIR}/packages/**")
+              publishCoverage(adapters: [coberturaAdapter("${BASE_DIR}/packages/**/coverage-*-report.xml")],
+                              sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,7 @@ pipeline {
           post {
             always {
               coverageReport("${BASE_DIR}/packages/**")
+              archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/packages/**/coverage/coverage-*.xml")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,20 +80,7 @@ pipeline {
             }
           }
         }
-        /**
-        Execute unit tests.
-        */
-        stage('Test') {
-          steps {
-            withGithubNotify(context: 'Test', tab: 'tests') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                runParallelTest()
-              }
-            }
-          }
-        }
+
         /**
         Execute code coverange only once.
         */
@@ -108,6 +95,21 @@ pipeline {
           post {
             always {
               coverageReport("${BASE_DIR}/packages/**")
+              archiveArtifacts(allowEmptyArchive: true, artifacts: "**/packages/**/coverage/**")
+            }
+          }
+        }
+        /**
+        Execute unit tests.
+        */
+        stage('Test') {
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                runParallelTest()
+              }
             }
           }
         }

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -149,8 +149,8 @@ services:
         set -eo pipefail
         npm run ${GOAL}
         ## Workaround to enable the cobertura source code navigation in Jenkins
-        find . -name "*-report.xml" -exec grep '<source>' {} +
         find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/${BASE_DIR}/#g" {} +"
+        find . -name "*-report.xml" -exec grep '<source>' {} +
     mem_limit: 2000m
 #    cpus: 0.5
     depends_on:

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -148,8 +148,7 @@ services:
         set -eo pipefail
         npm run ${GOAL}
         ## Workaround to enable the cobertura source code navigation in Jenkins
-        ls -ltra ${WORKSPACE}
-        find . -name "*-report.xml"
+        find . -name "*-report.xml" -exec grep '<source>' {} +
         find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/#g" {} +"
     mem_limit: 2000m
 #    cpus: 0.5

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -148,6 +148,8 @@ services:
         set -eo pipefail
         npm run ${GOAL}
         ## Workaround to enable the cobertura source code navigation in Jenkins
+        ls -ltra ${WORKSPACE}
+        find . -name "*-report.xml"
         find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/#g" {} +"
     mem_limit: 2000m
 #    cpus: 0.5

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -135,6 +135,7 @@ services:
       - MODE=${MODE}
       - GOAL=${GOAL}
       - WORKSPACE=${WORKSPACE}
+      - BASE_DIR=${BASE_DIR}
     command: >
       /bin/bash -c "set -x
         id
@@ -149,7 +150,7 @@ services:
         npm run ${GOAL}
         ## Workaround to enable the cobertura source code navigation in Jenkins
         find . -name "*-report.xml" -exec grep '<source>' {} +
-        find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/#g" {} +"
+        find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/${BASE_DIR}/#g" {} +"
     mem_limit: 2000m
 #    cpus: 0.5
     depends_on:

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       - SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}
       - MODE=${MODE}
       - GOAL=${GOAL}
+      - WORKSPACE=${WORKSPACE}
     command: >
       /bin/bash -c "set -x
         id
@@ -145,7 +146,9 @@ services:
         npm install
         npm install puppeteer --unsafe-perm=true --allow-root
         set -eo pipefail
-        npm run ${GOAL}"
+        npm run ${GOAL}
+        ## Workaround to enable the cobertura source code navigation in Jenkins
+        find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/#g" {} +"
     mem_limit: 2000m
 #    cpus: 0.5
     depends_on:

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -147,10 +147,7 @@ services:
         npm install
         npm install puppeteer --unsafe-perm=true --allow-root
         set -eo pipefail
-        npm run ${GOAL}
-        ## Workaround to enable the cobertura source code navigation in Jenkins
-        find . -name "*-report.xml" -exec sed -i "s#/app/#${WORKSPACE}/${BASE_DIR}/#g" {} +"
-        find . -name "*-report.xml" -exec grep '<source>' {} +
+        npm run ${GOAL}"
     mem_limit: 2000m
 #    cpus: 0.5
     depends_on:

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -161,7 +161,11 @@ function prepareConfig(defaultConfig) {
 
     defaultConfig.coverageReporter = {
       includeAllSources: true,
-      reporters: [{ type: 'lcov' }, { type: 'text-summary' }],
+      reporters: [
+        { type: 'cobertura' },
+        { type: 'lcov' },
+        { type: 'text-summary' }
+      ],
       dir: 'coverage/'
     }
   }

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -162,7 +162,7 @@ function prepareConfig(defaultConfig) {
     defaultConfig.coverageReporter = {
       includeAllSources: true,
       reporters: [
-        { type: 'cobertura' },
+        { type: 'cobertura', file: 'coverage-' + buildId + '-report.xml' },
         { type: 'lcov' },
         { type: 'text-summary' }
       ],


### PR DESCRIPTION
## Highlights
- Export coverage as cobertura reports being exposed in the Jenkins pipeline.

## Test cases
See [here](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/view/change-requests/job/PR-332/2/cobertura/)

![image](https://user-images.githubusercontent.com/2871786/61333995-a0b2c100-a820-11e9-9862-d04631059b75.png)
