### PR TITLE
ci(jenkins): retry in case some enviromental issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,14 +236,18 @@ def runScript(Map params = [:]){
         sleep randomNumber(min: 5, max: 10)
         sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
       }
-      if(params.saucelab_test){
-        env.MODE = 'saucelabs'
-        withSaucelabsEnv(){
+      // Another retry in case there are any environmental issues
+      retry(2) {
+        sleep randomNumber(min: 5, max: 10)
+        if(params.saucelab_test){
+          env.MODE = 'saucelabs'
+          withSaucelabsEnv(){
+            sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
+          }
+        } else {
+          env.MODE = 'none'
           sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
         }
-      } else {
-        env.MODE = 'none'
-        sh(label: "Start Elastic Stack ${stack}", script: '.ci/scripts/test.sh')
       }
     }
   }


### PR DESCRIPTION
## Highlights
- A way to add resilient in case of environmental issues as for instance it might happen what it just happened in one of the builds:

```
[2019-07-18T10:16:12.795Z] node-puppeteer         | + npm install puppeteer --unsafe-perm=true --allow-root
[2019-07-18T10:16:34.781Z] node-puppeteer         | 
[2019-07-18T10:16:34.781Z] node-puppeteer         | > puppeteer@1.18.1 install /app/node_modules/puppeteer
[2019-07-18T10:16:34.781Z] node-puppeteer         | > node install.js
[2019-07-18T10:16:34.781Z] node-puppeteer         | 
[2019-07-18T10:16:34.781Z] node-puppeteer         | ERROR: Failed to download Chromium r672088! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.
[2019-07-18T10:16:34.781Z] node-puppeteer         | Error: end of central directory record signature not found
```
