### PR TITLE
fix(rum-react): capture network requests inside useEffect hook

### DIFF
--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -40,7 +40,7 @@
     "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-router-dom": "^4.2.2"
+    "react": "^16.0.0",
+    "react-router-dom": "^4.0.0"
   }
 }

--- a/packages/rum-react/src/get-apm-route.js
+++ b/packages/rum-react/src/get-apm-route.js
@@ -30,12 +30,10 @@ import { getWithTransaction } from './get-with-transaction'
 function getApmRoute(apm) {
   const withTransaction = getWithTransaction(apm)
 
-  return class ApmRoute extends React.Component {
-    render() {
-      const { path, component } = this.props
-      const apmComponent = withTransaction(path, 'route-change')(component)
-      return <Route {...this.props} component={apmComponent} />
-    }
+  return function ApmRoute(props) {
+    const { path, component } = props
+    const apmComponent = withTransaction(path, 'route-change')(component)
+    return <Route {...props} component={apmComponent} />
   }
 }
 

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -27,6 +27,19 @@ import React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 
 /**
+ * Check if the given component is class based component
+ * ex: class Component extends React.Component
+ *
+ * React internally uses this logic to check if it has to call new Component or Component
+ * to decide between functional and class based components
+ * https://github.com/facebook/react/blob/769b1f270e1251d9dbdce0fcbd9e92e502d059b8/packages/react-reconciler/src/ReactFiber.js#L297-L300
+ */
+function isReactClassComponent(Component) {
+  const prototype = Component.prototype
+  return !!(prototype && prototype.isReactComponent)
+}
+
+/**
  * Usage:
  *  - Pure function: `withTransaction('name','route-change')(Component)`
  *  - As a decorator: `@withTransaction('name','route-change')`
@@ -41,37 +54,70 @@ function getWithTransaction(apm) {
         )
         return Component
       }
-      class ApmComponent extends React.Component {
-        constructor(props) {
-          super(props)
-          /**
-           * We need to start the transaction in constructor because otherwise,
-           * we won't be able to capture what happens in componentDidMount of child components.
-           */
-          this.transaction = apm.startTransaction(name, type, {
+
+      let ApmComponent = null
+      /**
+       * In react, there are two recommended ways to instantiate network requests
+       *  - in componentDidMount lifecycle which happens before rendering the component
+       *  - useEffect hook which is supported in react > 16.7.x versions
+       *
+       * Since we are wrapping the underlying component that renders the route, We have to
+       * account for any network effects that happens inside these two methods to capture those
+       * requests as spans in the route-change transaction
+       *
+       * Parent component's componentDidMount and useEffect are always called after childs cDM and
+       * effects are called (Ordering is preserved). So we check for our transaction finish
+       * logic inside these methods to make sure we are capturing the span information
+       */
+      if (
+        !isReactClassComponent(Component) &&
+        typeof React.useEffect === 'function'
+      ) {
+        ApmComponent = function ApmComponent(props) {
+          const transaction = apm.startTransaction(name, type, {
             canReuse: true
           })
-        }
 
-        componentDidMount() {
-          if (this.transaction) {
-            this.transaction.detectFinish()
+          React.useEffect(() => {
+            transaction && transaction.detectFinish()
+            return () => transaction && transaction.detectFinish()
+          })
+
+          return <Component transaction={transaction} {...props} />
+        }
+      } else {
+        ApmComponent = class ApmComponent extends React.Component {
+          constructor(props) {
+            super(props)
+            /**
+             * We need to start the transaction in constructor because otherwise,
+             * we won't be able to capture what happens in componentDidMount of child
+             * components since the parent component is mounted after child
+             */
+            this.transaction = apm.startTransaction(name, type, {
+              canReuse: true
+            })
           }
-        }
 
-        componentWillUnmount() {
-          /**
-           * It is possible that the transaction has ended before this unmount event,
-           * in that case this is a noop.
-           */
-          if (this.transaction) {
-            this.transaction.detectFinish()
+          componentDidMount() {
+            if (this.transaction) {
+              this.transaction.detectFinish()
+            }
           }
-        }
 
-        render() {
-          // todo: should we pass the transaction down (could use react context provider instead)
-          return <Component transaction={this.transaction} {...this.props} />
+          componentWillUnmount() {
+            /**
+             * It is possible that the transaction has ended before this unmount event,
+             * in that case this is a noop.
+             */
+            if (this.transaction) {
+              this.transaction.detectFinish()
+            }
+          }
+
+          render() {
+            return <Component transaction={this.transaction} {...this.props} />
+          }
         }
       }
 

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -57,7 +57,7 @@ function getWithTransaction(apm) {
 
       let ApmComponent = null
       /**
-       * In react, there are two recommended ways to instantiate network requests
+       * In react, there are two recommended ways to instantiate network requests inside components
        *  - in componentDidMount lifecycle which happens before rendering the component
        *  - useEffect hook which is supported in react > 16.7.x versions
        *

--- a/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
@@ -41,11 +41,20 @@ describe('Using Switch component of react router', function() {
       'expected functional component to be rendered'
     )
 
-    const serverCalls = waitForApmServerCalls(0, 1)
-    expect(serverCalls.sendTransactions.length).toBe(1)
+    const serverCalls = waitForApmServerCalls(0, 2)
+    expect(serverCalls.sendTransactions.length).toBe(2)
 
-    const transaction = serverCalls.sendTransactions[0].args[0][0]
-    expect(transaction.type).toBe('page-load')
-    expect(transaction.name).toBe('/notfound')
+    const pageLoadTransaction = serverCalls.sendTransactions[0].args[0][0]
+    expect(pageLoadTransaction.type).toBe('page-load')
+    expect(pageLoadTransaction.name).toBe('/notfound')
+
+    const routeTransaction = serverCalls.sendTransactions[1].args[0][0]
+    expect(routeTransaction.name).toBe('/func')
+    expect(routeTransaction.type).toBe('route-change')
+    /**
+     * Should include the fetch call inside useEffect hook
+     */
+    expect(routeTransaction.spans.length).toBe(1)
+    expect(routeTransaction.spans[0].name).toBe('GET /test/e2e/data.json')
   })
 })


### PR DESCRIPTION
+ fixes #344 


### Issue

In react, there are two recommended ways to instantiate network requests inside components
  - in componentDidMount lifecycle which happens before rendering the component
  - useEffect hook which is supported in react > 16.7.x versions

Since we are wrapping the underlying component that renders the route, We have to account for any network effects that happens inside these two methods to capture those requests as spans in the route-change transaction. 

By registering to the cDM of class based component we are not able to create spans for fetch/XHR happening inside effect callbacks. 

### Considered solutions
React internally uses scheduler (based on MessageChannel) and `requestAnimationFrameWithTimeout` logic to run the effects registered inside useEffect callbacks which is scheduled to run after the current frame `Paint`. 

Due to this, I tried exploring solutions like scheduling the transaction finish detection logic
 + After the current frame (after-frame) 
 + After the current frame with timeouts (raf-setTimeout)
 + After two frames (double-raf)

None of this seems to work across all browsers (Edge - top, Chrome-bottom)

<img width="888" alt="Screenshot 2019-07-25 at 15 14 17" src="https://user-images.githubusercontent.com/3902525/61963729-8e791580-afcc-11e9-9f02-e1f27b761cdc.png">
<img width="775" alt="Screenshot 2019-07-25 at 15 13 06" src="https://user-images.githubusercontent.com/3902525/61963730-8e791580-afcc-11e9-9b5c-3eb9c17fb2f1.png">

### Preferred Solution 
Parent components render tree depends completely on the child component which means Parent component's componentDidMount and useEffect are always called after child's cDM and effects  (Ordering is preserved). So we check for our transaction finish logic inside these methods to make sure we are capturing the span information

There is a small feature detection in place to check for class based components and also for react version (which has useEffects) to decide which apm component to be used. 
