### PR TITLE
chore(karma): watch files in dev and run individual tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ $ APM_SERVER_URL=<server-url> SCOPE=@elastic/apm-rum npm run test
 ##### Unit tests
 ```sh
 $ npx lerna run --scope @elastic/apm-rum test:unit
+
+// to run tests in watch mode
+
+$ npx lerna run --scope @elastic/apm-rum tdd -- --grep <path-to-test-file>
 ```
 
 ##### Integration tests

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -83,9 +83,10 @@ const baseConfig = {
 function prepareConfig(config, packageName) {
   const globalConfig = getGlobalConfig(packageName)
   console.log('Global test Configuration: ', globalConfig)
+  const { agentConfig, testConfig } = globalConfig
 
-  const { isTravis, isJenkins, sauceLabs: isSauce } = globalConfig.testConfig
-  let buildId = `ApmJs-${globalConfig.agentConfig.name}`
+  const { isTravis, isJenkins, sauceLabs: isSauce } = testConfig
+  let buildId = `ApmJs-${agentConfig.name}`
 
   if (isTravis) {
     console.log('prepareConfig: Run in Travis')

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -24,7 +24,11 @@
  */
 
 const { Server } = require('karma')
-const { getSauceConnectOptions, getBrowserList } = require('./test-config')
+const {
+  getSauceConnectOptions,
+  getBrowserList,
+  getGlobalConfig
+} = require('./test-config')
 const { getWebpackConfig, BUNDLE_TYPES } = require('./build')
 
 const baseLaunchers = getBrowserList().map(launcher => ({
@@ -38,7 +42,6 @@ const { tunnelIdentifier } = getSauceConnectOptions()
  * Common base config for all the mono repo packages
  */
 const baseConfig = {
-  exclude: ['e2e/**/*.*'],
   files: [specPattern],
   frameworks: ['jasmine'],
   preprocessors: {
@@ -54,8 +57,9 @@ const baseConfig = {
   ],
   webpack: getWebpackConfig(BUNDLE_TYPES.BROWSER_DEV),
   webpackMiddleware: {
-    stats: 'errors-only'
+    logLevel: 'error'
   },
+  autoWatch: false,
   browserNoActivityTimeout: 120000,
   customLaunchers: baseLaunchers,
   browsers: [],
@@ -76,11 +80,12 @@ const baseConfig = {
   }
 }
 
-function prepareConfig(defaultConfig) {
-  const testConfig = defaultConfig.testConfig || {}
-  const agentConfig = defaultConfig.globalConfigs.agentConfig || {}
-  const { isTravis, isJenkins, sauceLabs: isSauce } = testConfig
-  let buildId = `ApmJs-${agentConfig.name}`
+function prepareConfig(config, packageName) {
+  const globalConfig = getGlobalConfig(packageName)
+  console.log('Global test Configuration: ', globalConfig)
+
+  const { isTravis, isJenkins, sauceLabs: isSauce } = globalConfig.testConfig
+  let buildId = `ApmJs-${globalConfig.agentConfig.name}`
 
   if (isTravis) {
     console.log('prepareConfig: Run in Travis')
@@ -91,8 +96,8 @@ function prepareConfig(defaultConfig) {
       ' (' +
       process.env.TRAVIS_BUILD_ID +
       ')'
-    defaultConfig.plugins.push('karma-firefox-launcher')
-    defaultConfig.browsers.push('Firefox')
+    config.plugins.push('karma-firefox-launcher')
+    config.browsers.push('Firefox')
   } else if (isJenkins) {
     console.log('prepareConfig: Run in Jenkins')
     buildId =
@@ -104,9 +109,9 @@ function prepareConfig(defaultConfig) {
       ') Elastic Stack ' +
       process.env.STACK_VERSION
 
-    defaultConfig.plugins.push('karma-chrome-launcher')
-    defaultConfig.browsers = ['ChromeHeadlessNoSandbox']
-    defaultConfig.customLaunchers = {
+    config.plugins.push('karma-chrome-launcher')
+    config.browsers = ['ChromeHeadlessNoSandbox']
+    config.customLaunchers = {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
         flags: [
@@ -116,27 +121,27 @@ function prepareConfig(defaultConfig) {
         ]
       }
     }
-    defaultConfig.plugins.push('karma-junit-reporter')
-    defaultConfig.reporters.push('junit')
-    defaultConfig.junitReporter = {
+    config.plugins.push('karma-junit-reporter')
+    config.reporters.push('junit')
+    config.junitReporter = {
       outputDir: 'reports'
     }
   } else {
     console.log('prepareConfig: Run in Default enviroment')
-    defaultConfig.plugins.push('karma-chrome-launcher')
-    defaultConfig.browsers.push('Chrome')
+    config.plugins.push('karma-chrome-launcher')
+    config.browsers.push('Chrome')
   }
 
   /**
    *  Add coverage reports and plugins required for all environments
    */
-  if (defaultConfig.coverage) {
-    defaultConfig.plugins.push('karma-coverage')
-    defaultConfig.reporters.push('coverage')
-    const babelPlugins = defaultConfig.webpack.module.rules[0].options.plugins
+  if (config.coverage) {
+    config.plugins.push('karma-coverage')
+    config.reporters.push('coverage')
+    const babelPlugins = config.webpack.module.rules[0].options.plugins
     babelPlugins.push('istanbul')
 
-    defaultConfig.coverageReporter = {
+    config.coverageReporter = {
       includeAllSources: true,
       reporters: [
         { type: 'cobertura', file: 'coverage-' + buildId + '-report.xml' },
@@ -149,23 +154,20 @@ function prepareConfig(defaultConfig) {
 
   if (isSauce) {
     console.log('prepareConfig: Run in SauceLab mode')
-    defaultConfig.sauceLabs.build = buildId
+    config.sauceLabs.build = buildId
     console.log('saucelabs.build:', buildId)
-    defaultConfig.concurrency = 3
+    config.concurrency = 3
     if (isJenkins) {
-      defaultConfig.sauceLabs.tags = [
-        testConfig.branch,
-        process.env.STACK_VERSION
-      ]
+      config.sauceLabs.tags = [testConfig.branch, process.env.STACK_VERSION]
     } else if (testConfig.branch === 'master') {
-      defaultConfig.sauceLabs.tags = [testConfig.branch]
+      config.sauceLabs.tags = [testConfig.branch]
     }
-    defaultConfig.reporters = ['dots', 'saucelabs']
-    defaultConfig.browsers = Object.keys(defaultConfig.customLaunchers)
-    defaultConfig.transports = ['polling']
+    config.reporters = ['dots', 'saucelabs']
+    config.browsers = Object.keys(config.customLaunchers)
+    config.transports = ['polling']
   }
 
-  return defaultConfig
+  return config
 }
 
 function singleRunKarma(configFile, done) {

--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -49,19 +49,15 @@ function getTestEnvironmentVariables() {
 
 function getGlobalConfig(packageName = 'rum') {
   const testEnv = getTestEnvironmentVariables()
-  const globalConfigs = {
+  return {
     agentConfig: {
       serverUrl: testEnv.serverUrl,
       serviceName: `test`,
       name: `${packageName}`
     },
+    testConfig: testEnv,
     useMocks: false,
     mockApmServer: false
-  }
-
-  return {
-    globalConfigs,
-    testConfig: testEnv
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -927,8 +927,7 @@
       "dependencies": {
         "hoist-non-react-statics": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "bundled": true,
           "requires": {
             "react-is": "^16.7.0"
           }
@@ -3392,6 +3391,12 @@
       "dev": true,
       "optional": true
     },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -4128,24 +4133,6 @@
         "find-up": "^3.0.0",
         "istanbul-lib-instrument": "^3.3.0",
         "test-exclude": "^5.2.3"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
       }
     },
     "backo2": {
@@ -5314,6 +5301,25 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
     },
     "cmd-shim": {
       "version": "2.0.2",
@@ -8664,8 +8670,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8686,14 +8691,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8708,20 +8711,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8838,8 +8838,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8851,7 +8850,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8866,7 +8864,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8874,14 +8871,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8900,7 +8895,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8981,8 +8975,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8994,7 +8987,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9080,8 +9072,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9117,7 +9108,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9137,7 +9127,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9181,14 +9170,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11560,32 +11547,23 @@
       }
     },
     "karma-webpack": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.13.tgz",
-      "integrity": "sha512-2cyII34jfrAabbI2+4Rk4j95Nazl98FvZQhgSiqKUDarT317rxfv/EdzZ60CyATN4PQxJdO5ucR5bOOXkEVrXw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-4.0.2.tgz",
+      "integrity": "sha512-970/okAsdUOmiMOCY8sb17A2I8neS25Ad9uhyK3GHgmRSIFJbDcNEFE8dqqUhNe9OHiCC9k3DMrSmtd/0ymP1A==",
       "dev": true,
       "requires": {
-        "async": "^2.0.0",
-        "babel-runtime": "^6.0.0",
-        "loader-utils": "^1.0.0",
-        "lodash": "^4.0.0",
-        "source-map": "^0.5.6",
-        "webpack-dev-middleware": "^1.12.0"
+        "clone-deep": "^4.0.1",
+        "loader-utils": "^1.1.0",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^1.0.0",
+        "source-map": "^0.7.3",
+        "webpack-dev-middleware": "^3.7.0"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
           "dev": true
         }
       }
@@ -15431,6 +15409,23 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -16607,12 +16602,6 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
-    },
-    "time-stamp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
-      "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==",
-      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.10",
@@ -17794,24 +17783,39 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+      "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
       "dev": true,
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.2",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
       },
       "dependencies": {
         "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
+        },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
           "dev": true
         }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.31",
-    "karma-webpack": "^2.0.4",
+    "karma-webpack": "^4.0.2",
     "lerna": "^3.15.0",
     "license-checker": "^25.0.1",
     "lint-staged": "^8.2.0",

--- a/packages/rum-core/karma.bench.conf.js
+++ b/packages/rum-core/karma.bench.conf.js
@@ -26,7 +26,6 @@
 const { join } = require('path')
 const { mkdirSync, existsSync } = require('fs')
 const { baseConfig, prepareConfig } = require('../../dev-utils/karma')
-const { getGlobalConfig } = require('../../dev-utils/test-config')
 
 const BENCHMARKS_DIR = join(__dirname, 'test', 'benchmarks')
 const REPORTS_DIR = join(__dirname, 'reports')
@@ -45,16 +44,13 @@ module.exports = function(config) {
   }
 
   config.set(baseConfig)
-  const customConfig = getGlobalConfig('rum-core')
 
-  console.log(
-    'Custom test bench config:',
-    JSON.stringify(customConfig, null, 2)
-  )
-  config.set(customConfig)
   const specPattern = `${BENCHMARKS_DIR}/**/*.bench.js`
   config.set({
     files: [specPattern],
+    preprocessors: {
+      [specPattern]: ['webpack']
+    },
     autoWatch: false,
     singleRun: true,
     concurrency: 1,
@@ -88,9 +84,6 @@ module.exports = function(config) {
       }
     }
   })
-  const cfg = prepareConfig(config)
-  cfg.preprocessors = {
-    [specPattern]: ['webpack']
-  }
-  config.set(cfg)
+  const preparedConfig = prepareConfig(config)
+  config.set(preparedConfig)
 }

--- a/packages/rum-core/karma.conf.js
+++ b/packages/rum-core/karma.conf.js
@@ -24,23 +24,16 @@
  */
 
 const { baseConfig, prepareConfig } = require('../../dev-utils/karma')
-const { getGlobalConfig } = require('../../dev-utils/test-config')
 
 module.exports = function(config) {
   config.set(baseConfig)
-  const customConfig = getGlobalConfig('rum-core')
-
-  console.log('Custom Test Config:', JSON.stringify(customConfig, null, 2))
-  config.set(customConfig)
-  config.files.unshift('test/utils/polyfill.js')
+  const preparedConfig = prepareConfig(config, 'rum-core')
+  preparedConfig.files.unshift('test/utils/polyfill.js')
   /**
    * Common dependencies are hoisted to root node modules
    */
-  config.files.unshift(
+  preparedConfig.files.unshift(
     '../../node_modules/es6-promise/dist/es6-promise.auto.js'
   )
-  config.files.push({ pattern: 'src/**/*.js', included: false, watched: true })
-
-  const cfg = prepareConfig(config)
-  config.set(cfg)
+  config.set(preparedConfig)
 }

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -17,11 +17,11 @@
   "scripts": {
     "prepublishOnly": "npm run build:main",
     "build:main": "npx babel src -d dist/lib",
-    "karma": "karma start",
     "karma:bench": "NODE_ENV=production karma start karma.bench.conf.js",
     "karma:coverage": "karma start --coverage --singleRun",
     "test:unit": "node ../../dev-utils/run-script.js runUnitTests packages/rum-core true",
-    "test": "npm run test:unit"
+    "test": "npm run test:unit",
+    "tdd": "karma start --auto-watch --restartOnFileChange"
   },
   "files": [
     "src",

--- a/packages/rum-core/test/benchmarks/performance-monitoring.bench.js
+++ b/packages/rum-core/test/benchmarks/performance-monitoring.bench.js
@@ -26,7 +26,8 @@
 import { generateTestTransaction } from './'
 import { createServiceFactory } from '../../'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
-const { agentConfig } = getGlobalConfig('rum-core').globalConfigs
+
+const { agentConfig } = getGlobalConfig('rum-core')
 
 suite('PerformanceMonitoring', () => {
   const serviceFactory = createServiceFactory()

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -28,7 +28,7 @@ import Transaction from '../../src/performance-monitoring/transaction'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 import { createServiceFactory } from '../'
 
-const { agentConfig } = getGlobalConfig('rum-core').globalConfigs
+const { agentConfig } = getGlobalConfig('rum-core')
 
 function generateTransaction(count) {
   var result = []

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -26,7 +26,7 @@
 import { createServiceFactory } from '../'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 
-const { agentConfig } = getGlobalConfig('rum-core').globalConfigs
+const { agentConfig } = getGlobalConfig('rum-core')
 
 describe('ErrorLogging', function() {
   var testErrorMessage = 'errorevent_test_error_message'

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -34,7 +34,7 @@ import patchEventHandler from '../common/patch'
 import { mockGetEntriesByType } from '../utils/globals-mock'
 import { ON_TRANSACTION_END } from '../../src/common/constants'
 
-const { agentConfig } = getGlobalConfig('rum-core').globalConfigs
+const { agentConfig } = getGlobalConfig('rum-core')
 
 describe('PerformanceMonitoring', function() {
   var serviceFactory

--- a/packages/rum-react/karma.conf.js
+++ b/packages/rum-react/karma.conf.js
@@ -24,7 +24,6 @@
  */
 
 const { baseConfig, prepareConfig } = require('../../dev-utils/karma.js')
-const { getGlobalConfig } = require('../../dev-utils/test-config')
 const {
   getWebpackConfig,
   PACKAGE_TYPES,
@@ -33,13 +32,9 @@ const {
 
 module.exports = function(config) {
   config.set(baseConfig)
-  config.webpack = getWebpackConfig(
-    BUNDLE_TYPES.BROWSER_DEV,
-    PACKAGE_TYPES.REACT
-  )
-  const testConfig = getGlobalConfig('rum-react')
-  console.log('Custom Test Config:', testConfig)
-  config.set(testConfig)
-  const cfg = prepareConfig(config)
-  config.set(cfg)
+  config.set({
+    webpack: getWebpackConfig(BUNDLE_TYPES.BROWSER_DEV, PACKAGE_TYPES.REACT)
+  })
+  const preparedConfig = prepareConfig(config, 'rum-react')
+  config.set(preparedConfig)
 }

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -30,7 +30,8 @@
     "test:unit": "npm run script runUnitTests packages/rum-react",
     "test:e2e:supported": "npm run script runE2eTests packages/rum-react/wdio.conf.js",
     "test:sauce": "npm run script runSauceTests packages/rum-react true build:e2e test:unit test:e2e:supported",
-    "test": "npm run test:sauce"
+    "test": "npm run test:sauce",
+    "tdd": "karma start --auto-watch --restartOnFileChange"
   },
   "bugs": {
     "url": "https://github.com/elastic/apm-agent-rum-js/issues"

--- a/packages/rum/karma.conf.js
+++ b/packages/rum/karma.conf.js
@@ -24,13 +24,9 @@
  */
 
 const { baseConfig, prepareConfig } = require('../../dev-utils/karma.js')
-const { getGlobalConfig } = require('../../dev-utils/test-config')
 
 module.exports = function(config) {
   config.set(baseConfig)
-  const testConfig = getGlobalConfig()
-  console.log('Custom Test Config:', testConfig)
-  config.set(testConfig)
-  const cfg = prepareConfig(config)
-  config.set(cfg)
+  const preparedConfig = prepareConfig(config, 'rum')
+  config.set(preparedConfig)
 }

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "webpack --colors && npm run build:main",
-    "build:dev": "webpack -w",
     "build:main": "npx babel src -d dist/lib",
     "build:e2e": "npm run script buildE2eBundles packages/rum/test/e2e",
     "bundlesize": "npm run build && bundlesize",
@@ -28,7 +27,8 @@
     "test:e2e:supported": "npm run script runE2eTests packages/rum/wdio.conf.js",
     "test:e2e:failsafe": "npm run script runE2eTests packages/rum/wdio-failsafe.conf.js",
     "test:sauce": "npm run script runSauceTests packages/rum true test:unit test:e2e:supported test:e2e:failsafe",
-    "test": "npm-run-all build build:e2e test:node test:integration test:sauce"
+    "test": "npm-run-all build build:e2e test:node test:integration test:sauce",
+    "tdd": "karma start --auto-watch --restartOnFileChange"
   },
   "files": [
     "src",

--- a/packages/rum/test/e2e/index.js
+++ b/packages/rum/test/e2e/index.js
@@ -27,16 +27,16 @@ import { apmBase } from '../../src'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 import ApmServerMock from '../../../rum-core/test/utils/apm-server-mock'
 
-const { globalConfigs } = getGlobalConfig()
+const globalConfig = getGlobalConfig()
 
 function createApmBase(config) {
-  console.log('E2E Global Configs', JSON.stringify(globalConfigs, null, 2))
+  console.log('E2E Global Configs', JSON.stringify(globalConfig, null, 2))
   const apmServer = apmBase.serviceFactory.getService('ApmServer')
-  const { serverUrl } = globalConfigs.agentConfig
+  const { serverUrl } = globalConfig.agentConfig
   if (serverUrl) {
     config.serverUrl = serverUrl
   }
-  const serverMock = new ApmServerMock(apmServer, globalConfigs.useMocks)
+  const serverMock = new ApmServerMock(apmServer, globalConfig.useMocks)
   apmBase.serviceFactory.registerServiceInstance('ApmServer', serverMock)
 
   return apmBase.init(config)

--- a/packages/rum/test/e2e/standalone-html/opentracing.js
+++ b/packages/rum/test/e2e/standalone-html/opentracing.js
@@ -25,6 +25,7 @@
 
 import { testXHR, renderTestElement } from '../utils'
 import { getGlobalConfig } from '../../../../../dev-utils/test-config'
+
 const { serverUrl, mockBackendUrl } = getGlobalConfig().testConfig
 
 window.elasticApm.init({

--- a/packages/rum/test/integration/index.spec.js
+++ b/packages/rum/test/integration/index.spec.js
@@ -26,7 +26,7 @@
 import { apmBase } from '../../src'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 
-const { agentConfig } = getGlobalConfig().globalConfigs
+const { agentConfig } = getGlobalConfig()
 
 describe('ApmBase', function() {
   it('should not init ApmBase', function() {

--- a/packages/rum/test/specs/index.spec.js
+++ b/packages/rum/test/specs/index.spec.js
@@ -27,9 +27,8 @@ import { apmBase } from '../../src/'
 import { isPlatformSupported } from '@elastic/apm-rum-core'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 
-const { globalConfigs } = getGlobalConfig()
-
 describe('index', function() {
+  const globalConfig = getGlobalConfig()
   var originalTimeout
 
   beforeEach(function() {
@@ -43,7 +42,7 @@ describe('index', function() {
 
   it('should init ApmBase', function(done) {
     var apmServer = apmBase.serviceFactory.getService('ApmServer')
-    if (globalConfigs && globalConfigs.useMocks) {
+    if (globalConfig.useMocks) {
       apmServer._makeHttpRequest = function() {
         return Promise.resolve()
       }
@@ -52,7 +51,7 @@ describe('index', function() {
     spyOn(apmServer, 'sendErrors').and.callThrough()
     spyOn(apmServer, '_postJson').and.callThrough()
 
-    const { agentConfig } = globalConfigs
+    const { agentConfig } = globalConfig
     apmBase.init({
       serverUrl: agentConfig.serverUrl,
       serviceName: agentConfig.serviceName,


### PR DESCRIPTION
+ part of elastic/apm-agent-rum-js#308 
+ refactor karma config based on the babel/webpack configs. 
+ move global config in single place. 
+ ability to watch files on dev with `npx lerna run tdd --scope=@elastic/<pkg-name>`