### PR TITLE
chore(rum-core): remove duplicate patch boolean logic

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -26,14 +26,7 @@
 import { globalState } from './patch-utils'
 import { SCHEDULE, INVOKE, FETCH_SOURCE } from '../constants'
 
-var alreadyPatched = false
-
 export function patchFetch(callback) {
-  if (alreadyPatched) {
-    return
-  }
-  alreadyPatched = true
-
   if (!window.fetch || !window.Request) {
     return
   }
@@ -72,7 +65,7 @@ export function patchFetch(callback) {
         method: request.method,
         sync: false,
         url,
-        args: arguments,
+        args,
         aborted: false
       }
     }

--- a/packages/rum-core/src/common/patching/history-patch.js
+++ b/packages/rum-core/src/common/patching/history-patch.js
@@ -24,13 +24,11 @@
  */
 
 import { INVOKE, HISTORY_PUSHSTATE } from '../constants'
-var alreadyPatched = false
 
 export function patchHistory(callback) {
-  if (alreadyPatched || !window.history) {
+  if (!window.history) {
     return
   }
-  alreadyPatched = true
 
   const nativePushState = history.pushState
   if (typeof nativePushState === 'function') {

--- a/packages/rum-core/src/common/patching/index.js
+++ b/packages/rum-core/src/common/patching/index.js
@@ -31,7 +31,7 @@ import { ON_TASK } from '../constants'
 
 const patchEventHandler = new EventHandler()
 
-var alreadyPatched = false
+let alreadyPatched = false
 function patchAll() {
   if (!alreadyPatched) {
     alreadyPatched = true

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -45,15 +45,7 @@ const XHR_TASK = apmSymbol('xhrTask')
 const XHR_LISTENER = apmSymbol('xhrListener')
 const XHR_SCHEDULED = apmSymbol('xhrScheduled')
 
-var alreadyPatched = false
-
 export function patchXMLHttpRequest(callback) {
-  if (alreadyPatched) {
-    return
-  }
-
-  alreadyPatched = true
-
   const XMLHttpRequestPrototype = XMLHttpRequest.prototype
 
   let oriAddListener = XMLHttpRequestPrototype[ADD_EVENT_LISTENER_STR]

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -77,10 +77,7 @@ class PerformanceMonitoring {
       }
     })
 
-    const patchSubFn = this.getXhrPatchSubFn(
-      this._configService,
-      this._transactionService
-    )
+    const patchSubFn = this.getXhrPatchSubFn()
     this.cancelPatchSub = patchEventHandler.observe(ON_TASK, patchSubFn)
   }
 

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -120,7 +120,6 @@ class ApmBase {
    *  }]
    * }
    */
-
   config(config) {
     const configService = this.serviceFactory.getService('ConfigService')
     const { missing, invalid } = configService.validate(config)


### PR DESCRIPTION
+ patching logic check should be implemented by the consumer and we have a global patchAll function which takes care of doing the patching for AJAX,  FETCH and History state change only once. 