### PR TITLE
refactor(rum-core): remove test specific code from perf-monitoring

### DIFF
--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -401,23 +401,6 @@ class PerformanceMonitoring {
     }
   }
 
-  sendTransactions(transactions) {
-    const payload = transactions
-      .map(tr => this.createTransactionPayload(tr))
-      .filter(tr => tr)
-
-    if (__DEV__) {
-      this._logginService.debug(
-        'Sending Transactions to apm server.',
-        transactions.length
-      )
-    }
-
-    // todo: check if transactions are already being sent
-    const promise = this._apmServer.sendTransactions(payload)
-    return promise
-  }
-
   convertTransactionsToServerModel(transactions) {
     return transactions.map(tr => this.createTransactionDataModel(tr))
   }

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -196,22 +196,6 @@ describe('PerformanceMonitoring', function() {
     expect(resp).toBe(false)
   })
 
-  it('should sendTransactionInterval', function() {
-    var tr = new Transaction('test transaction', 'transaction', {
-      transactionSampleRate: 1
-    })
-    var span = tr.startSpan('test span', 'test span thype')
-    span.end()
-    span._end += 10
-    tr.detectFinish()
-    expect(tr._end).toBeDefined()
-    if (tr._end === tr._start) {
-      tr._end = tr._end + 100
-    }
-    var result = performanceMonitoring.sendTransactions([tr])
-    expect(result).toBeDefined()
-  })
-
   it('should filter transactions based on duration and spans', () => {
     configService.setConfig({
       transactionDurationThreshold: 200


### PR DESCRIPTION
+ remove unused `sendTransactions` which is used only in benchmarks. saves bundle size. 