### PR TITLE
chore(rum-core): remove unused stack-generator from deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -914,7 +914,6 @@
       "requires": {
         "error-stack-parser": "^1.3.5",
         "opentracing": "^0.14.3",
-        "stack-generator": "^1.0.7",
         "uuid": "^3.1.0"
       }
     },
@@ -15983,21 +15982,6 @@
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
-      }
-    },
-    "stack-generator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-1.1.0.tgz",
-      "integrity": "sha1-NvapIHUabBD0maE8Msu19RoLiyU=",
-      "requires": {
-        "stackframe": "^1.0.2"
-      },
-      "dependencies": {
-        "stackframe": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
-        }
       }
     },
     "stackframe": {

--- a/packages/rum-core/NOTICE.txt
+++ b/packages/rum-core/NOTICE.txt
@@ -59,36 +59,6 @@ SOFTWARE.
 
 
 ---
-This product relies on stack-generator
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-
-
----
 This product relies on uuid
 
 The MIT License (MIT)

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "error-stack-parser": "^1.3.5",
     "opentracing": "^0.14.3",
-    "stack-generator": "^1.0.7",
     "uuid": "^3.1.0"
   }
 }

--- a/packages/rum/NOTICE.txt
+++ b/packages/rum/NOTICE.txt
@@ -90,36 +90,6 @@ SOFTWARE.
 
 
 ---
-This product relies on stack-generator
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-
-
----
 This product relies on uuid
 
 The MIT License (MIT)


### PR DESCRIPTION
+ Not sure how we missed it, but `stack-generator` is not used in rum-core. 