### PR TITLE
chore(release): clean dist folder before preparing release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "version": "node scripts/prompt-release",
-    "prerelease": "npm test",
+    "prerelease": "npm test && npm run clean",
     "release": "lerna publish && npm run github-release",
     "release-package": "node scripts/publish-package",
     "github-release": "node scripts/github-release",
@@ -21,7 +21,8 @@
     "bundlesize": "lerna run bundlesize --stream",
     "serve": "node ./dev-utils/run-script.js startTestServers",
     "coverage": "lerna run build:main && lerna run karma:coverage --stream",
-    "bench:dev": "node ./scripts/benchmarks.js"
+    "bench:dev": "node ./scripts/benchmarks.js",
+    "clean": "npx lerna exec -- rm -rf dist/"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
+ Previous releases `@elastic/apm-rum@4.3.0` and `@elastic/apm-rum@4.3.1` has `env.js` file published as part of the apm-rum package which is not intended to be published. Not sure how it got in, But this PR helps us prevent these issue in future. 

<img width="1019" alt="Screenshot 2019-08-12 at 10 47 07" src="https://user-images.githubusercontent.com/3902525/62854088-8e785580-bcee-11e9-83a9-60cad4371668.png">


Check here - https://unpkg.com/browse/@elastic/apm-rum@4.3.0/dist/lib/