### PR TITLE
[docs] Remove js-base from documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * resolve main field to source file (#179) ([923405](https://github.com/elastic/apm-agent-rum-js/commit/923405))
 
 <a name="3.0.0"></a>
-# [3.0.0](https://github.com/elastic/apm-agent-js-base/compare/v2.3.0...v3.0.0) (2019-01-29)
+# [3.0.0](https://github.com/elastic/apm-agent-rum-js/compare/v2.3.0...v3.0.0) (2019-01-29)
 
 ### BREAKING CHANGE
 
@@ -166,7 +166,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add OpenTracing support ([#138](https://github.com/elastic/apm-agent-js-base/issues/138)) ([0cff389](https://github.com/elastic/apm-agent-js-base/commit/0cff389))
+* add OpenTracing support ([#138](https://github.com/elastic/apm-agent-rum-js/issues/138)) ([0cff389](https://github.com/elastic/apm-agent-rum-js/commit/0cff389))
 * include transaction flags on error ([#29](https://github.com/elastic/apm-agent-js-core/issues/29)) ([36c13f3](https://github.com/elastic/apm-agent-js-core/commit/36c13f3))
 * send span sync field to apm server ([#17](https://github.com/elastic/apm-agent-js-core/issues/17)) ([abad58b](https://github.com/elastic/apm-agent-js-core/commit/abad58b))
 * add addContext and addTags to Spans and Transactions ([#16](https://github.com/elastic/apm-agent-js-core/issues/16)) ([de0d72b](https://github.com/elastic/apm-agent-js-core/commit/de0d72b))
@@ -177,7 +177,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * propagate transaction ID for unsampled transactions ([#30](https://github.com/elastic/apm-agent-js-core/issues/30)) ([3884806](https://github.com/elastic/apm-agent-js-core/commit/3884806))
 * remove invalid chars in span tags and marks ([#34](https://github.com/elastic/apm-agent-js-core/issues/34)) ([9bdc575](https://github.com/elastic/apm-agent-js-core/commit/9bdc575))
-* Bundling -  moving to webpack 4 and babel 7 ([#123](https://github.com/elastic/apm-agent-js-base/issues/123)) ([0ae3f53](https://github.com/elastic/apm-agent-js-base/commit/0ae3f53))
+* Bundling -  moving to webpack 4 and babel 7 ([#123](https://github.com/elastic/apm-agent-rum-js/issues/123)) ([0ae3f53](https://github.com/elastic/apm-agent-rum-js/commit/0ae3f53))
 * remove query strings from xhr and fetch span name ([#24](https://github.com/elastic/apm-agent-js-core/issues/24)) ([cc82e92](https://github.com/elastic/apm-agent-js-core/commit/cc82e92))
 * set pageLoadTransactionName when transaction ends from configs ([#25](https://github.com/elastic/apm-agent-js-core/issues/25)) ([afdacee](https://github.com/elastic/apm-agent-js-core/commit/afdacee))
 
@@ -189,7 +189,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="2.2.0"></a>
-# [2.2.0](https://github.com/elastic/apm-agent-js-base/compare/v2.1.1...v2.2.0) (2018-12-05)
+# [2.2.0](https://github.com/elastic/apm-agent-rum-js/compare/v2.1.1...v2.2.0) (2018-12-05)
 
 
 ### Features
@@ -198,7 +198,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="2.1.1"></a>
-## [2.1.1](https://github.com/elastic/apm-agent-js-base/compare/v2.1.0...v2.1.1) (2018-12-05)
+## [2.1.1](https://github.com/elastic/apm-agent-rum-js/compare/v2.1.0...v2.1.1) (2018-12-05)
 
 
 ### Bug Fixes
@@ -212,7 +212,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="2.1.0"></a>
-# [2.1.0](https://github.com/elastic/apm-agent-js-base/compare/v2.0.0...v2.1.0) (2018-12-03)
+# [2.1.0](https://github.com/elastic/apm-agent-rum-js/compare/v2.0.0...v2.1.0) (2018-12-03)
 
 
 ### Features
@@ -221,7 +221,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="2.0.0"></a>
-# [2.0.0](https://github.com/elastic/apm-agent-js-base/compare/v1.0.0...v2.0.0) (2018-11-14)
+# [2.0.0](https://github.com/elastic/apm-agent-rum-js/compare/v1.0.0...v2.0.0) (2018-11-14)
 
 
 
@@ -231,8 +231,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* start page load transaction immediately after init ([3b80bdb](https://github.com/elastic/apm-agent-js-base/commit/3b80bdb))
-* use pageLoadTransactionName config option ([d3d3587](https://github.com/elastic/apm-agent-js-base/commit/d3d3587))
+* start page load transaction immediately after init ([3b80bdb](https://github.com/elastic/apm-agent-rum-js/commit/3b80bdb))
+* use pageLoadTransactionName config option ([d3d3587](https://github.com/elastic/apm-agent-rum-js/commit/d3d3587))
 * adopt the w3c dt header flag proposal ([ff0fdfc](https://github.com/elastic/apm-agent-js-core/commit/ff0fdfc))
 * don't startSpan after transaction has ended ([137bd63](https://github.com/elastic/apm-agent-js-core/commit/137bd63))
 * filter out invalid spans ([c9fb0e1](https://github.com/elastic/apm-agent-js-core/commit/c9fb0e1))
@@ -261,14 +261,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="1.0.0"></a>
-# [1.0.0](https://github.com/elastic/apm-agent-js-base/compare/v0.10.3...v1.0.0) (2018-08-23)
+# [1.0.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.10.3...v1.0.0) (2018-08-23)
 
 ### BREAKING CHANGES
 
 * use /v1/rum endpoint (APM Server v6.4+)
 
 <a name="0.10.3"></a>
-## [0.10.3](https://github.com/elastic/apm-agent-js-base/compare/v0.10.2...v0.10.3) (2018-08-20)
+## [0.10.3](https://github.com/elastic/apm-agent-rum-js/compare/v0.10.2...v0.10.3) (2018-08-20)
 
 
 ### Bug Fixes
@@ -282,17 +282,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.10.2"></a>
-## [0.10.2](https://github.com/elastic/apm-agent-js-base/compare/v0.10.1...v0.10.2) (2018-08-16)
+## [0.10.2](https://github.com/elastic/apm-agent-rum-js/compare/v0.10.1...v0.10.2) (2018-08-16)
 
 
 ### Bug Fixes
 
-* check for undefined span when the agent is not active ([3613b01](https://github.com/elastic/apm-agent-js-base/commit/3613b01))
+* check for undefined span when the agent is not active ([3613b01](https://github.com/elastic/apm-agent-rum-js/commit/3613b01))
 
 
 
 <a name="0.10.1"></a>
-## [0.10.1](https://github.com/elastic/apm-agent-js-base/compare/v0.10.0...v0.10.1) (2018-08-14)
+## [0.10.1](https://github.com/elastic/apm-agent-rum-js/compare/v0.10.0...v0.10.1) (2018-08-14)
 
 
 ### Bug Fixes
@@ -302,17 +302,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.10.0"></a>
-# [0.10.0](https://github.com/elastic/apm-agent-js-base/compare/v0.9.1...v0.10.0) (2018-08-07)
+# [0.10.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.9.1...v0.10.0) (2018-08-07)
 
 
 ### Features
 
-* instrument XHR ([3c6a9e5](https://github.com/elastic/apm-agent-js-base/commit/3c6a9e5))
+* instrument XHR ([3c6a9e5](https://github.com/elastic/apm-agent-rum-js/commit/3c6a9e5))
 
 
 
 <a name="0.9.1"></a>
-## [0.9.1](https://github.com/elastic/apm-agent-js-base/compare/v0.9.0...v0.9.1) (2018-06-22)
+## [0.9.1](https://github.com/elastic/apm-agent-rum-js/compare/v0.9.0...v0.9.1) (2018-06-22)
 
 
 ### Bug Fixes
@@ -322,7 +322,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.9.0"></a>
-# [0.9.0](https://github.com/elastic/apm-agent-js-base/compare/v0.8.2...v0.9.0) (2018-06-15)
+# [0.9.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.8.2...v0.9.0) (2018-06-15)
 
 
 ### BREAKING CHANGES
@@ -337,28 +337,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.8.2"></a>
-## [0.8.2](https://github.com/elastic/apm-agent-js-base/compare/v0.8.1...v0.8.2) (2018-06-12)
+## [0.8.2](https://github.com/elastic/apm-agent-rum-js/compare/v0.8.1...v0.8.2) (2018-06-12)
 
 
 ### Bug Fixes
 
-* update elastic-apm-js-core 0.6.2 ([b3807e0](https://github.com/elastic/apm-agent-js-base/commit/b3807e0))
+* update elastic-apm-js-core 0.6.2 ([b3807e0](https://github.com/elastic/apm-agent-rum-js/commit/b3807e0))
 * remove marks before fetchStart to align with resource spans
 * spans generated from navigation and resource timing apis
 
 
 <a name="0.8.1"></a>
-## [0.8.1](https://github.com/elastic/apm-agent-js-base/compare/v0.8.0...v0.8.1) (2018-05-28)
+## [0.8.1](https://github.com/elastic/apm-agent-rum-js/compare/v0.8.0...v0.8.1) (2018-05-28)
 
 
 ### Features
 
-* add transaction custom marks API ([4d2b71b](https://github.com/elastic/apm-agent-js-base/commit/4d2b71b))
+* add transaction custom marks API ([4d2b71b](https://github.com/elastic/apm-agent-rum-js/commit/4d2b71b))
 
 
 
 <a name="0.8.0"></a>
-# [0.8.0](https://github.com/elastic/apm-agent-js-base/compare/v0.7.0...v0.8.0) (2018-05-23)
+# [0.8.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.7.0...v0.8.0) (2018-05-23)
 
 ### BREAKING CHANGES
 
@@ -366,64 +366,64 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.7.0"></a>
-# [0.7.0](https://github.com/elastic/apm-agent-js-base/compare/v0.6.1...v0.7.0) (2018-04-30)
+# [0.7.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.6.1...v0.7.0) (2018-04-30)
 
 
 ### Features
 
-* exposed api initial draft ([9187726](https://github.com/elastic/apm-agent-js-base/commit/9187726))
+* exposed api initial draft ([9187726](https://github.com/elastic/apm-agent-rum-js/commit/9187726))
 
 
 
 <a name="0.6.1"></a>
-## [0.6.1](https://github.com/elastic/apm-agent-js-base/compare/v0.6.0...v0.6.1) (2018-04-10)
+## [0.6.1](https://github.com/elastic/apm-agent-rum-js/compare/v0.6.0...v0.6.1) (2018-04-10)
 
 
 ### Bug Fixes
 
-* update to elastic-apm-js-core 0.4.3 ([1e307ac](https://github.com/elastic/apm-agent-js-base/commit/1e307ac))
+* update to elastic-apm-js-core 0.4.3 ([1e307ac](https://github.com/elastic/apm-agent-rum-js/commit/1e307ac))
 
 
 
 <a name="0.6.0"></a>
-# [0.6.0](https://github.com/elastic/apm-agent-js-base/compare/v0.5.0...v0.6.0) (2018-04-04)
+# [0.6.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.5.0...v0.6.0) (2018-04-04)
 
 
 ### Features
 
-* add addFilter api ([60e9ad5](https://github.com/elastic/apm-agent-js-base/commit/60e9ad5))
+* add addFilter api ([60e9ad5](https://github.com/elastic/apm-agent-rum-js/commit/60e9ad5))
 
 
 
 <a name="0.5.0"></a>
-# [0.5.0](https://github.com/elastic/apm-agent-js-base/compare/v0.4.1...v0.5.0) (2018-03-09)
+# [0.5.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.4.1...v0.5.0) (2018-03-09)
 
 
 ### Features
 
-* add apm.setTags ([523280a](https://github.com/elastic/apm-agent-js-base/commit/523280a))
-* update to elastic-apm-js-core 0.3.0 ([a436334](https://github.com/elastic/apm-agent-js-base/commit/a436334))
+* add apm.setTags ([523280a](https://github.com/elastic/apm-agent-rum-js/commit/523280a))
+* update to elastic-apm-js-core 0.3.0 ([a436334](https://github.com/elastic/apm-agent-rum-js/commit/a436334))
 
 
 
 <a name="0.4.1"></a>
-## [0.4.1](https://github.com/elastic/apm-agent-js-base/compare/v0.4.0...v0.4.1) (2018-02-20)
+## [0.4.1](https://github.com/elastic/apm-agent-rum-js/compare/v0.4.0...v0.4.1) (2018-02-20)
 
 
 ### Bug Fixes
 
-* send page load metrics even after load event ([abe3680](https://github.com/elastic/apm-agent-js-base/commit/abe3680))
+* send page load metrics even after load event ([abe3680](https://github.com/elastic/apm-agent-rum-js/commit/abe3680))
 
 
 ### Features
 
-* upgrade to elastic-apm-js-core 0.2.2 ([c2a6469](https://github.com/elastic/apm-agent-js-base/commit/c2a6469))
+* upgrade to elastic-apm-js-core 0.2.2 ([c2a6469](https://github.com/elastic/apm-agent-rum-js/commit/c2a6469))
   * enforce server string limit
   * set descriptive names for navigation timing spans
 
 
 <a name="0.4.0"></a>
-# [0.4.0](https://github.com/elastic/apm-agent-js-base/compare/v0.3.0...v0.4.0) (2018-02-07)
+# [0.4.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.3.0...v0.4.0) (2018-02-07)
 
 
 ### Features
@@ -436,24 +436,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.3.0"></a>
-# [0.3.0](https://github.com/elastic/apm-agent-js-base/compare/v0.2.0...v0.3.0) (2018-01-11)
+# [0.3.0](https://github.com/elastic/apm-agent-rum-js/compare/v0.2.0...v0.3.0) (2018-01-11)
 
 
 ### Bug Fixes
 
-* **ApmBase:** Disable the module if running on nodejs ([2bf4199](https://github.com/elastic/apm-agent-js-base/commit/2bf4199))
-* upgrade to elastic-apm-js-core 0.1.7 ([325a918](https://github.com/elastic/apm-agent-js-base/commit/325a918))
+* **ApmBase:** Disable the module if running on nodejs ([2bf4199](https://github.com/elastic/apm-agent-rum-js/commit/2bf4199))
+* upgrade to elastic-apm-js-core 0.1.7 ([325a918](https://github.com/elastic/apm-agent-rum-js/commit/325a918))
 
 
 ### Features
 
-* add captureError to ApmBase ([04436b4](https://github.com/elastic/apm-agent-js-base/commit/04436b4))
-* add setUserContext and setCustomContext ([86b4ccc](https://github.com/elastic/apm-agent-js-base/commit/86b4ccc))
+* add captureError to ApmBase ([04436b4](https://github.com/elastic/apm-agent-rum-js/commit/04436b4))
+* add setUserContext and setCustomContext ([86b4ccc](https://github.com/elastic/apm-agent-rum-js/commit/86b4ccc))
 
 
 
 <a name="0.2.0"></a>
-# [0.2.0](https://github.com/jahtalab/apm-agent-js-base/compare/v0.1.1...v0.2.0) (2017-12-20)
+# [0.2.0](https://github.com/jahtalab/apm-agent-rum-js/compare/v0.1.1...v0.2.0) (2017-12-20)
 
 
 ### BREAKING CHANGES
@@ -462,28 +462,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 <a name="0.1.1"></a>
-## [0.1.1](https://github.com/jahtalab/apm-agent-js-base/compare/v0.1.0...v0.1.1) (2017-12-20)
+## [0.1.1](https://github.com/jahtalab/apm-agent-rum-js/compare/v0.1.0...v0.1.1) (2017-12-20)
 
 
 ### Bug Fixes
 
-* typo serviceUrl ([9ff81a7](https://github.com/jahtalab/apm-agent-js-base/commit/9ff81a7))
+* typo serviceUrl ([9ff81a7](https://github.com/jahtalab/apm-agent-rum-js/commit/9ff81a7))
 
 
 
 <a name="0.1.0"></a>
-# [0.1.0](https://github.com/jahtalab/apm-agent-js-base/compare/v0.0.3...v0.1.0) (2017-12-13)
+# [0.1.0](https://github.com/jahtalab/apm-agent-rum-js/compare/v0.0.3...v0.1.0) (2017-12-13)
 
 
 ### BREAKING CHANGES
 
-* upgrading to apm-agent-js-core@0.1.0 ([150bc66](https://github.com/jahtalab/apm-agent-js-base/commit/150bc66))
+* upgrading to apm-agent-js-core@0.1.0 ([150bc66](https://github.com/jahtalab/apm-agent-rum-js/commit/150bc66))
 * rename apiOrigin to serverUrl
 * rename app to service
 
 
 <a name="0.0.3"></a>
-## [0.0.3](https://github.com/jahtalab/apm-agent-js-base/compare/v0.0.2...v0.0.3) (2017-11-21)
+## [0.0.3](https://github.com/jahtalab/apm-agent-rum-js/compare/v0.0.2...v0.0.3) (2017-11-21)
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This is the official Real User Monitoring JavaScript agent.
 
 ## Documentation
-You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html).
+You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html).
 
 If you are interested in contributing to Elastic APM JavaScript agent, please see [our contributing guide](CONTRIBUTING.md).
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]
 NOTE: For the best reading experience,
-please view this documentation at https://www.elastic.co/guide/en/apm/agent/js-base[elastic.co]
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/rum-js[elastic.co]
 endif::[]
 
 = APM Real User Monitoring JavaScript Agent Reference

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "author": "",
   "license": "MIT",
-  "homepage": "https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html",
+  "homepage": "https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html",
   "devDependencies": {
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.2.0",

--- a/packages/rum-core/README.md
+++ b/packages/rum-core/README.md
@@ -5,7 +5,7 @@ This is the core JavaScript module for Elastic APM.
 **Only use this package if you want to implement an integration for a framework that Elastic APM does not support yet.**
 
 ## Documentation
-You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html).
+You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html).
 
 If you are interested in contributing to Elastic APM JavaScript agent, please see [our contributing guide](CONTRIBUTING.md).
 

--- a/packages/rum-react/README.md
+++ b/packages/rum-react/README.md
@@ -3,7 +3,7 @@
 This package provides Real User Monitoring (RUM) for React applications.
 
 ## Documentation
-You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html).
+You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html).
 
 If you are interested in contributing to Elastic APM JavaScript agent, please see [our contributing guide](CONTRIBUTING.md).
 

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.2",
   "description": "Elastic APM Real User Monitoring for React applications",
   "author": "Hamid <h.jahtalab@gmail.com>",
-  "homepage": "https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html",
+  "homepage": "https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html",
   "license": "MIT",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -3,7 +3,7 @@
 This is the main package for Elastic APM Real User Monitoring.
 
 ## Documentation
-You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/js-base/current/index.html).
+You can find our documentation [on our website](https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html).
 
 If you are interested in contributing to Elastic APM JavaScript agent, please see [our contributing guide](CONTRIBUTING.md).
 


### PR DESCRIPTION
Replaces `js-base` with `rum-js` in the documentation. Not sure if you wanted me to do this or not (as there are more instances of `js-base` in the codebase). You can close this if you want to tackle all changes in one PR.

For https://github.com/elastic/apm-agent-rum-js/issues/108.