### PR TITLE
chore(benchmark): add parse and exec time metrics to benchmark

### DIFF
--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -28,7 +28,7 @@ const stats = require('stats-lite')
 const { readFileSync } = require('fs')
 const path = require('path')
 const zlib = require('zlib')
-const { runs } = require('./config')
+const { runs, noOfImages } = require('./config')
 
 const dist = path.join(__dirname, '../../dist')
 
@@ -42,7 +42,7 @@ function getMinifiedApmBundle() {
 function getApmBundleSize() {
   const content = getMinifiedApmBundle()
   /**
-   * To match the level with our bub
+   * To match the level with our bundlesize check
    */
   const gzippedContent = zlib.gzipSync(content, {
     level: 9
@@ -61,6 +61,7 @@ function getCommonFields({ version, url, scenario }) {
     'parameters.browser': version,
     'parameters.url': url,
     'parameters.runs': runs,
+    'parameters.images': scenario === 'heavy' ? noOfImages : 0,
     'bundle-size.minified.bytes': minified,
     'bundle-size.gzip.bytes': gzip
   }

--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -25,7 +25,46 @@
 
 const cpuprofile = require('cpuprofile-filter')
 const stats = require('stats-lite')
-const { elasticApmUrl } = require('./config')
+const { readFileSync } = require('fs')
+const path = require('path')
+const zlib = require('zlib')
+const { runs } = require('./config')
+
+const dist = path.join(__dirname, '../../dist')
+
+function getMinifiedApmBundle() {
+  return readFileSync(
+    path.join(dist, 'bundles/elastic-apm-rum.umd.min.js'),
+    'utf-8'
+  )
+}
+
+function getApmBundleSize() {
+  const content = getMinifiedApmBundle()
+  /**
+   * To match the level with our bub
+   */
+  const gzippedContent = zlib.gzipSync(content, {
+    level: 9
+  })
+
+  return {
+    minified: content.length,
+    gzip: gzippedContent.length
+  }
+}
+
+function getCommonFields({ version, url, scenario }) {
+  const { minified, gzip } = getApmBundleSize()
+  return {
+    scenario,
+    'parameters.browser': version,
+    'parameters.url': url,
+    'parameters.runs': runs,
+    'bundle-size.minified.bytes': minified,
+    'bundle-size.gzip.bytes': gzip
+  }
+}
 
 function getFromEntries(entries, name, key) {
   entries = JSON.parse(entries)
@@ -45,13 +84,17 @@ function getUnit(metricName) {
 }
 
 async function analyzeMetrics(metric, resultMap) {
-  const { cpu, payload, navigation, measure, resource, url, scenario } = metric
+  const { cpu, payload, navigation, measure, url, scenario } = metric
 
   const loadTime =
     getFromEntries(navigation, url, 'loadEventEnd') -
     getFromEntries(navigation, url, 'fetchStart')
   const initializationTime = getFromEntries(measure, 'init', 'duration')
-  const bundleSize = getFromEntries(resource, elasticApmUrl, 'transferSize')
+  const parseAndExecTime = getFromEntries(
+    measure,
+    'parse-and-execute',
+    'duration'
+  )
 
   /**
    * Analysis of each run
@@ -59,12 +102,12 @@ async function analyzeMetrics(metric, resultMap) {
   const analysis = {
     'page-load-time': loadTime,
     'rum-init-time': initializationTime,
+    'parse-and-execute-time': parseAndExecTime,
     'total-cpu-time': cpu.cpuTime,
     'rum-cpu-time': cpu.cpuTimeFiltered,
     'payload-size': payload.size,
     transactions: payload.transactions,
-    spans: payload.spans,
-    'bundle-size': bundleSize
+    spans: payload.spans
   }
 
   /**
@@ -103,9 +146,9 @@ function calculateResults(resultMap) {
   return results
 }
 
-function filterCpuMetrics(profile) {
+function filterCpuMetrics(profile, url) {
   return cpuprofile.filter(profile, {
-    files: [elasticApmUrl]
+    files: [url]
   })
 }
 
@@ -141,5 +184,8 @@ module.exports = {
   analyzeMetrics,
   calculateResults,
   filterCpuMetrics,
-  capturePayloadInfo
+  capturePayloadInfo,
+  getMinifiedApmBundle,
+  getApmBundleSize,
+  getCommonFields
 }

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -27,7 +27,7 @@ const port = 9000
 module.exports = {
   scenarios: ['basic', 'heavy'],
   runs: 3,
-  imageCount: 30,
+  noOfImages: 30,
   port,
   chrome: {
     /**

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -27,8 +27,8 @@ const port = 9000
 module.exports = {
   scenarios: ['basic', 'heavy'],
   runs: 3,
+  imageCount: 30,
   port,
-  elasticApmUrl: `http://localhost:${port}/elastic-apm-rum.js`,
   chrome: {
     /**
      * By default the CPU samples are taken at 1000 microseconds, To get

--- a/packages/rum/test/benchmarks/pages/head.ejs
+++ b/packages/rum/test/benchmarks/pages/head.ejs
@@ -3,5 +3,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-  <script src="<%= elasticApmUrl %>"></script>
+  <script>
+    performance.mark('parse-start')
+    <%- apmBundleContent %>
+    performance.measure('parse-and-execute', 'parse-start')
+  </script>
 </head>

--- a/packages/rum/test/benchmarks/pages/init.ejs
+++ b/packages/rum/test/benchmarks/pages/init.ejs
@@ -1,10 +1,7 @@
 <script>
-  function initScript() {
-    performance.mark('init-start')
-    window.elasticApm.init({
-      serviceName: 'eum-benchmarks'
-    })
-    performance.measure('init', 'init-start')
-  }
-  initScript()
+  performance.mark('init-start')
+  window.elasticApm.init({
+    serviceName: 'eum-benchmarks'
+  })
+  performance.measure('init', 'init-start')
 </script>

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -56,14 +56,14 @@ function gatherRawMetrics(browser, url) {
     let metrics = {}
 
     page.on('request', async request => {
-      const url = request.url()
-      if (url.indexOf('/intake/v2/rum/events') >= 0) {
+      const requestUrl = request.url()
+      if (requestUrl.indexOf('/intake/v2/rum/events') >= 0) {
         /**
          * Stop the profiler once we post the transaction to
          * the apm server
          */
         const result = await client.send('Profiler.stop')
-        const filteredCpuMetrics = filterCpuMetrics(result.profile)
+        const filteredCpuMetrics = filterCpuMetrics(result.profile, url)
         const response = request.postData()
         const payload = capturePayloadInfo(response)
 

--- a/packages/rum/test/benchmarks/run.js
+++ b/packages/rum/test/benchmarks/run.js
@@ -26,7 +26,11 @@
 const { join } = require('path')
 const { writeFileSync } = require('fs')
 const { gatherRawMetrics, launchBrowser } = require('./profiler')
-const { analyzeMetrics, calculateResults } = require('./analyzer')
+const {
+  analyzeMetrics,
+  calculateResults,
+  getCommonFields
+} = require('./analyzer')
 const { runs, port, scenarios } = require('./config')
 const startServer = require('./server')
 
@@ -49,12 +53,8 @@ const REPORTS_DIR = join(__dirname, '../../reports')
       /**
        * Add common set of metrics for all scenarios
        */
-      resultMap.set(scenario, {
-        browser: version,
-        url,
-        runs,
-        scenario
-      })
+      resultMap.set(scenario, getCommonFields({ version, url, scenario }))
+
       for (let i = 0; i < runs; i++) {
         const metrics = await gatherRawMetrics(browser, url)
         Object.assign(metrics, { scenario, url })

--- a/packages/rum/test/benchmarks/server.js
+++ b/packages/rum/test/benchmarks/server.js
@@ -25,38 +25,44 @@
 
 const express = require('express')
 const path = require('path')
-const { elasticApmUrl, port } = require('./config')
-const { createReadStream } = require('fs')
+const { port, imageCount } = require('./config')
+const { getMinifiedApmBundle } = require('./analyzer')
 
 const pages = path.join(__dirname, 'pages')
-const dist = path.join(__dirname, '../../dist')
 
-function generateImageUrls(number) {
+function generateImageUrls() {
   const path = `http://localhost:${port}`
   const urls = []
-  for (let i = 0; i < number; i++) {
+  for (let i = 0; i < imageCount; i++) {
     urls.push(`${path}/images/${i}.png`)
   }
   return urls
 }
 
 /**
- * Avoid APM Script HTTP and Disk Cache in chrome
+ * Strip license and sourcemap url
  */
-function cacheBurstUrl(url) {
-  return url + '?' + Date.now()
+const APM_BUNDLE = getMinifiedApmBundle()
+  .replace(
+    '/*! For license information please see elastic-apm-rum.umd.min.js.LICENSE */',
+    ''
+  )
+  .replace('//# sourceMappingURL=elastic-apm-rum.umd.min.js.map', '')
+
+/**
+ * Adding a random value at the end of the script text prevents
+ * Chrome from caching the parsed/JITed script
+ */
+function getRandomBundleContent() {
+  let content = APM_BUNDLE
+  content += `var script = ${Date.now()};`
+  return content
 }
 
 module.exports = function startServer() {
   return new Promise(resolve => {
     const app = express()
 
-    app.get('/elastic-apm-rum.js*', (req, res) => {
-      createReadStream(
-        path.join(dist, 'bundles/elastic-apm-rum.umd.min.js'),
-        'utf-8'
-      ).pipe(res)
-    })
     /**
      * Generate empty responses to test payload size
      */
@@ -69,15 +75,16 @@ module.exports = function startServer() {
 
     app.get('/basic', (req, res) => {
       res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
-      const bundleUrl = cacheBurstUrl(elasticApmUrl)
-      res.render('basic', { elasticApmUrl: bundleUrl })
+      res.render('basic', { apmBundleContent: getRandomBundleContent() })
     })
 
     app.get('/heavy', (req, res) => {
       res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
-      const images = generateImageUrls(30)
-      const bundleUrl = cacheBurstUrl(elasticApmUrl)
-      res.render('heavy', { elasticApmUrl: bundleUrl, images })
+      const images = generateImageUrls()
+      res.render('heavy', {
+        apmBundleContent: getRandomBundleContent(),
+        images
+      })
     })
 
     let server = app.listen(port, () => {


### PR DESCRIPTION
Parse and excution time measurement is calculated in such a way that network overhead will not affect the parse and exec time. Plus random bytes are added to the bundle js content to avoid chrome caching the parsed/JIT'ed script. 

+ Add measurement for parse and execution time of apm bundle. 
+ Add metrics for bundle size for both minified and gzipped version. 
+ Add common metrics to the `parameters` list. 

Results
```js
{
    "scenario": "basic",
    "parameters.browser": "HeadlessChrome/77.0.3844.0",
    "parameters.url": "http://localhost:9000/basic",
    "parameters.runs": 3,
    "bundle-size.minified.bytes": 50466,
    "bundle-size.gzip.bytes": 15928,
    "page-load-time.mean.ms": 20.313333331917722,
    "page-load-time.p90.ms": 29.920000000856817,
    "rum-init-time.mean.ms": 2.4733333460365734,
    "rum-init-time.p90.ms": 2.4950000224635005,
    "parse-and-execute-time.mean.ms": 2.631666682039698,
    "parse-and-execute-time.p90.ms": 2.8150000143796206,
    "total-cpu-time.mean.ms": 19802.738999999998,
    "total-cpu-time.p90.ms": 21366.527999999995,
    "rum-cpu-time.mean.ms": 10201.176666666666,
    "rum-cpu-time.p90.ms": 10554.548,
    "payload-size.mean.bytes": 1422.6666666666667,
    "payload-size.p90.bytes": 1427,
    "transactions.mean.count": 1,
    "transactions.p90.count": 1,
    "spans.mean.count": 2,
    "spans.p90.count": 2
  },
  {
    "scenario": "heavy",
    "parameters.browser": "HeadlessChrome/77.0.3844.0",
    "parameters.url": "http://localhost:9000/heavy",
    "parameters.runs": 3,
    "bundle-size.minified.bytes": 50466,
    "bundle-size.gzip.bytes": 15928,
    "page-load-time.mean.ms": 62.64666665811092,
    "page-load-time.p90.ms": 65.65500004217029,
    "rum-init-time.mean.ms": 2.740000064174334,
    "rum-init-time.p90.ms": 2.7600000612437725,
    "parse-and-execute-time.mean.ms": 2.62833332332472,
    "parse-and-execute-time.p90.ms": 2.6649999199435115,
    "total-cpu-time.mean.ms": 64185.51366666672,
    "total-cpu-time.p90.ms": 64888.458000000086,
    "rum-cpu-time.mean.ms": 11794.134333333333,
    "rum-cpu-time.p90.ms": 12289.633,
    "payload-size.mean.bytes": 14256.666666666666,
    "payload-size.p90.bytes": 14386,
    "transactions.mean.count": 1,
    "transactions.p90.count": 1,
    "spans.mean.count": 32.333333333333336,
    "spans.p90.count": 33
  }

```