### PR TITLE
fix(rum): log unsupported message only on browser environment

### DIFF
--- a/packages/rum/src/bootstrap.js
+++ b/packages/rum/src/bootstrap.js
@@ -37,7 +37,11 @@ export default function bootstrap() {
   if (isPlatformSupported()) {
     patchAll()
     enabled = true
-  } else {
+  } else if (typeof window !== 'undefined') {
+    /**
+     * Print this error message only on the browser console
+     * on unsupported browser versions
+     */
     console.log('APM: Platform is not supported!')
   }
 

--- a/packages/rum/test/node/index-export.spec.js
+++ b/packages/rum/test/node/index-export.spec.js
@@ -26,7 +26,7 @@
 const elasticApm = require('@elastic/apm-rum')
 const { init: namedInit, apm, apmBase, ApmBase } = require('@elastic/apm-rum')
 
-describe('apm base build', () => {
+describe('apm base', () => {
   it('should have default and named exports', () => {
     expect(elasticApm.init).toEqual(jasmine.any(Function))
     expect(namedInit).toEqual(jasmine.any(Function))
@@ -34,5 +34,17 @@ describe('apm base build', () => {
     expect(apmBase).toEqual(jasmine.any(Object))
     expect(apmBase.init).toEqual(jasmine.any(Function))
     expect(ApmBase).toEqual(jasmine.any(Function))
+  })
+
+  it('should not log platform message on Node.js', () => {
+    spyOn(console, 'log')
+    /**
+     * Delete module cache and run bootstrap again
+     */
+    delete require.cache[require.resolve('@elastic/apm-rum')]
+    delete require.cache[require.resolve('@elastic/apm-rum/dist/lib/bootstrap')]
+    require('@elastic/apm-rum')
+
+    expect(console.log).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum/test/node/opentracing-export.spec.js
+++ b/packages/rum/test/node/opentracing-export.spec.js
@@ -31,7 +31,7 @@ const {
   createTracer
 } = require('@elastic/apm-rum/dist/lib/opentracing')
 
-describe('opentracing build', () => {
+describe('opentracing', () => {
   it('should have default and named exports', () => {
     expect(opentracing.default).toEqual(jasmine.any(Function))
     expect(createTracer).toEqual(jasmine.any(Function))

--- a/packages/rum/test/specs/index.spec.js
+++ b/packages/rum/test/specs/index.spec.js
@@ -42,6 +42,22 @@ describe('index', function() {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
   })
 
+  it('should log only on browser environments', () => {
+    // Pass unsupported check
+    const nowFn = window.performance.now
+    window.performance.now = undefined
+
+    spyOn(console, 'log')
+
+    delete require.cache[require.resolve('../../src/')]
+    delete require.cache[require.resolve('../../src/bootstrap')]
+    require('../../src/')
+
+    expect(console.log).toHaveBeenCalledWith('APM: Platform is not supported!')
+
+    window.performance.now = nowFn
+  })
+
   it('should init ApmBase', function(done) {
     var apmServer = apmBase.serviceFactory.getService('ApmServer')
     if (globalConfig.useMocks) {


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#363 