### PR TITLE
chore(benchmarks): build bundles before running benchmarks [skip ci]

### DIFF
--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -29,7 +29,7 @@
     "test:sauce": "npm run script runSauceTests packages/rum true test:unit test:e2e:supported test:e2e:failsafe",
     "test": "npm-run-all build build:e2e test:node test:integration test:sauce",
     "tdd": "karma start --auto-watch --restartOnFileChange",
-    "bench": "node test/benchmarks/run.js"
+    "bench": "npm run build && node test/benchmarks/run.js"
   },
   "files": [
     "src",


### PR DESCRIPTION
+ benchmark run needs our bundle before starting the benchmarks. It was failing in our Jenkins run. 

```
@elastic/apm-rum: > @elastic/apm-rum@4.4.2 bench /app/packages/rum
@elastic/apm-rum: > node test/benchmarks/run.js
@elastic/apm-rum: fs.js:646
@elastic/apm-rum:   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
@elastic/apm-rum:                  ^
@elastic/apm-rum: Error: ENOENT: no such file or directory, open '/app/packages/rum/dist/bundles/elastic-apm-rum.umd.min.js'
@elastic/apm-rum:     at Object.fs.openSync (fs.js:646:18)
@elastic/apm-rum:     at fs.readFileSync (fs.js:551:33)
@elastic/apm-rum:     at getMinifiedApmBundle (/app/packages/rum/test/benchmarks/analyzer.js:36:10)
@elastic/apm-rum:     at Object.<anonymous> (/app/packages/rum/test/benchmarks/server.js:45:20)
@elastic/apm-rum:     at Module._compile (module.js:653:30)
@elastic/apm-rum:     at Object.Module._extensions..js (module.js:664:10)
@elastic/apm-rum:     at Module.load (module.js:566:32)
@elastic/apm-rum:     at tryModuleLoad (module.js:506:12)
@elastic/apm-rum:     at Function.Module._load (module.js:498:3)
@elastic/apm-rum:     at Module.require (module.js:597:17)

```