### PR TITLE
[docs] Update link to APM server

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -126,7 +126,7 @@ you will need to configure Cross-Origin Resource Sharing (CORS).
 To configure CORS, simply:
 
 1. {apm-server-ref-v}/configuration-rum.html[Enable RUM support] in APM Server.
-2. Adjust the {apm-server-ref-v}/configuration-rum.html#_literal_allow_origins_literal[`apm-server.rum.allow_origins`] configuration.
+2. Adjust the {apm-server-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`] configuration.
 By default, APM Server allows all origins.
 
 [float]


### PR DESCRIPTION
The RUM Agent links to literal anchors in the APM Server documentation. These links will break on the switch from asciidoc to asciidoctor. This PR fixes the link to use new anchor tags added in https://github.com/elastic/apm-server/pull/2603.

Backport to `4.x`.

For https://github.com/elastic/apm-server/issues/1965. Full error log available in https://github.com/elastic/docs/pull/1083#issuecomment-523130974.