### PR TITLE
chore(saucelabs): fix script timeout issues in saucelabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,20 +42,12 @@ jobs:
         - SCOPE=@elastic/apm-rum
     - stage: test
       env:
-        - STACK_VERSION=6.5.0
-        - SCOPE=@elastic/apm-rum-react
-    - stage: test
-      env:
         - STACK_VERSION=6.6.0
         - SCOPE=@elastic/apm-rum-core
     - stage: test
       env:
         - STACK_VERSION=6.6.0
         - SCOPE=@elastic/apm-rum
-    - stage: test
-      env:
-        - STACK_VERSION=6.6.0
-        - SCOPE=@elastic/apm-rum-react
     - stage: test
       env:
         - STACK_VERSION=7.0.0

--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -163,6 +163,9 @@ function getWebpackConfig(bundleType, packageType) {
             extractComments: true
           })
         ]
+      },
+      performance: {
+        hints: false
       }
     })
   }

--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -174,7 +174,7 @@ function getWebdriveBaseConfig(
     jasmineNodeOpts: {
       defaultTimeoutInterval: 90000
     },
-    onPrepare() {
+    before() {
       /**
        * Increase timeout so that executeAsyncScript does not fail
        */

--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -174,31 +174,20 @@ function getWebdriveBaseConfig(
     jasmineNodeOpts: {
       defaultTimeoutInterval: 90000
     },
-    before() {
+    async before() {
       /**
-       * Increase timeout so that executeAsyncScript does not fail
+       * Increase script timeout so that executeAsyncScript does not
+       * throw async script failure in 0 ms error
        *
-       * Override setTimeout command to account for issues in
-       * unsupported selenium drivers
+       * Skip setting timeouts on firefox and microsoftedge since they
+       * result in NullPointerException issue from selenium driver
        */
       const browserName = getBrowserName()
-      browser.overwriteCommand(
-        'setTimeout',
-        async (origTimeout, timeoutConfig) => {
-          let result
-          try {
-            result = await origTimeout(timeoutConfig)
-          } catch (e) {
-            console.log('setTimeout command is not supported in', browserName)
-          } finally {
-            return result
-          }
-        }
-      )
+      if (browserName === 'firefox' || browserName === 'microsoftedge') {
+        return
+      }
 
-      browser.setTimeout({
-        script: 30000
-      })
+      await browser.setTimeout({ script: 30000 })
     },
     afterTest(test) {
       /**

--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -174,6 +174,14 @@ function getWebdriveBaseConfig(
     jasmineNodeOpts: {
       defaultTimeoutInterval: 90000
     },
+    onPrepare() {
+      /**
+       * Increase timeout so that executeAsyncScript does not fail
+       */
+      browser.setTimeout({
+        script: 30000
+      })
+    },
     afterTest(test) {
       /**
        * Log only on failures

--- a/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
@@ -29,8 +29,9 @@ const {
 } = require('../../../../../dev-utils/webdriver')
 
 describe('General usecase with react-router', function() {
+  beforeAll(() => browser.url('/test/e2e/with-router/'))
+
   it('should run the react app', function() {
-    browser.url('/test/e2e/with-router/')
     browser.waitUntil(
       () => {
         return $('#test-element').getText() === 'Passed'

--- a/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
@@ -26,8 +26,9 @@
 const { waitForApmServerCalls } = require('../../../../../dev-utils/webdriver')
 
 describe('Using Switch component of react router', function() {
+  beforeAll(() => browser.url('/test/e2e/with-router/switch.html'))
+
   it('should render the react app on route change', function() {
-    browser.url('/test/e2e/with-router/switch.html')
     browser.waitUntil(
       () => {
         /**

--- a/packages/rum-react/test/e2e/with-router/webpack.config.js
+++ b/packages/rum-react/test/e2e/with-router/webpack.config.js
@@ -40,5 +40,5 @@ module.exports = {
     filename: '[name].e2e-bundle.js',
     libraryTarget: 'umd'
   },
-  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_DEV, PACKAGE_TYPES.REACT)
+  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_PROD, PACKAGE_TYPES.REACT)
 }


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#400 
+ Increase the timeout for script execution commands to 30 seconds. 
+ handle issues with setTimeout not being supported on Firefox and MSEdge
+ Due to the bundles getting generated for React in dev mode, the size of the bundles are huge and it causes E2E tests to fail in some browsers. 
+ By compiling the bundles in prod mode, the size of the bundles gets reduced from 1.6 MB to ~300Kbs. This should reduce the time required for downloading the script which is 30 seconds by default. 
+ Run react test only on 7.0.0 stack
