### PR TITLE
chore(rum-angular): fix npm publish config in angular package [skip ci]

### DIFF
--- a/packages/rum-angular/package.json
+++ b/packages/rum-angular/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
+ During the last release 4.4.3, angular package alone was not published. Since the cli considered it as private package due to the absence of access field set as `public`. 