### PR TITLE
chore(travis): run packages tests only on single stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,22 +34,6 @@ jobs:
       name: 'Analyse size of JS bundles'
     - stage: test
       env:
-        - STACK_VERSION=6.5.0
-        - SCOPE=@elastic/apm-rum-core
-    - stage: test
-      env:
-        - STACK_VERSION=6.5.0
-        - SCOPE=@elastic/apm-rum
-    - stage: test
-      env:
-        - STACK_VERSION=6.6.0
-        - SCOPE=@elastic/apm-rum-core
-    - stage: test
-      env:
-        - STACK_VERSION=6.6.0
-        - SCOPE=@elastic/apm-rum
-    - stage: test
-      env:
         - STACK_VERSION=7.0.0
         - SCOPE=@elastic/apm-rum-core
     - stage: test


### PR DESCRIPTION
+ Our Jenkins pipeline already runs all of the packages/* tests in multiple stack versions. We can remove the run the sauce tests through travis on single stack to reduce the wait times and timeouts in travis. 