### PR TITLE
fix(rum-core): handle script error events properly

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -48,24 +48,26 @@ class ErrorLogging {
       culprit = lastFrame.filename
     }
 
-    const message =
-      errorEvent.message || (errorEvent.error && errorEvent.error.message)
-    let errorType = errorEvent.error ? errorEvent.error.name : ''
+    const { message, error } = errorEvent
+    let errorMessage = message
+    let errorType = ''
+    let errorContext = {}
+    if (error && typeof error === 'object') {
+      errorMessage = error.message
+      errorType = error.name
+      errorContext = this._getErrorProperties(error)
+    }
+
     if (!errorType) {
       /**
        * Try to extract type from message formatted like
        * 'ReferenceError: Can't find variable: initHighlighting'
        */
-      if (message && message.indexOf(':') > -1) {
-        errorType = message.split(':')[0]
+      if (errorMessage && errorMessage.indexOf(':') > -1) {
+        errorType = errorMessage.split(':')[0]
       }
     }
-
     const configContext = this._configService.get('context')
-    let errorContext
-    if (typeof errorEvent.error === 'object') {
-      errorContext = this._getErrorProperties(errorEvent.error)
-    }
     const browserMetadata = getPageMetadata()
     const context = merge({}, browserMetadata, configContext, errorContext)
 
@@ -73,7 +75,7 @@ class ErrorLogging {
       id: generateRandomId(),
       culprit,
       exception: {
-        message,
+        message: errorMessage,
         stacktrace: filteredFrames,
         type: errorType
       },

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -53,7 +53,7 @@ class ErrorLogging {
     let errorType = ''
     let errorContext = {}
     if (error && typeof error === 'object') {
-      errorMessage = error.message
+      errorMessage = errorMessage || error.message
       errorType = error.name
       errorContext = this._getErrorProperties(error)
     }

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -129,7 +129,8 @@ describe('ErrorLogging', function() {
       type: 'error',
       message: 'Uncaught Error: ' + message,
       lineno: 1,
-      filename: 'test.js'
+      filename: 'test.js',
+      error: null
     }
 
     try {
@@ -170,6 +171,31 @@ describe('ErrorLogging', function() {
         reason => {
           fail('Failed to send errors to the server, reason: ' + reason)
         }
+      )
+      .then(() => done())
+  })
+
+  it('should use message over error.message for error event', done => {
+    spyOn(apmServer, 'sendErrors').and.callThrough()
+
+    const errorEvent = createErrorEvent(testErrorMessage)
+
+    /**
+     * Override error message
+     */
+    if (errorEvent.error) {
+      errorEvent.error.message = 'Constructor Error'
+    }
+
+    errorLogging
+      .logErrorEvent(errorEvent, true)
+      .then(
+        () => {
+          expect(apmServer.sendErrors).toHaveBeenCalled()
+          const errors = apmServer.sendErrors.calls.argsFor(0)[0]
+          expect(errors[0].exception.message).toContain(testErrorMessage)
+        },
+        reason => fail(reason)
       )
       .then(() => done())
   })
@@ -217,7 +243,8 @@ describe('ErrorLogging', function() {
       message: testErrorMessage,
       filename,
       lineno,
-      colno
+      colno,
+      error: undefined
     })
     listener('error', {
       message: 'Script error.' + testErrorMessage,

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -220,7 +220,8 @@ describe('ErrorLogging', function() {
       colno
     })
     listener('error', {
-      message: 'Script error.' + testErrorMessage
+      message: 'Script error.' + testErrorMessage,
+      error: null
     })
     listener('error', createErrorEvent(testErrorMessage))
   })


### PR DESCRIPTION
+ fixes https://github.com/elastic/apm-agent-rum-js/issues/416
+ When script error is thrown, error key is set to `null` which passes the typeof `object` check. We handle this case in this PR and the code portions are merged to make it cleaner. 