### PR TITLE
fix(rum-core): create transaction only on component mount

### DIFF
--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -79,15 +79,14 @@ function getWithTransaction(apm) {
         typeof React.useEffect === 'function'
       ) {
         ApmComponent = function ApmComponent(props) {
-          let transaction = null
           React.useEffect(() => {
-            transaction = apm.startTransaction(name, type, {
+            const transaction = apm.startTransaction(name, type, {
               canReuse: true
             })
             return () => transaction && transaction.detectFinish()
           }, [])
 
-          return <Component transaction={transaction} {...props} />
+          return <Component {...props} />
         }
       } else {
         ApmComponent = class ApmComponent extends React.Component {

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -95,7 +95,7 @@ function getWithTransaction(apm) {
           )
 
           /**
-           * React guarentess the parent component effects are run after the child components effects
+           * React guarantees the parent component effects are run after the child components effects
            * So once all the child components effects are run, we run the detectFinish logic
            * which ensures if the transaction can be completed or not.
            */
@@ -106,7 +106,7 @@ function getWithTransaction(apm) {
                * Incase the transaction is never ended, we close the
                * transaction when component unmounts
                */
-              transaction && transaction.detectFinish()
+              transaction && transaction.end()
             }
           }, [])
 
@@ -138,7 +138,7 @@ function getWithTransaction(apm) {
              * in that case this is a noop.
              */
             if (this.transaction) {
-              this.transaction.detectFinish()
+              this.transaction.end()
             }
           }
 

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -103,10 +103,14 @@ function getWithTransaction(apm) {
             transaction && transaction.detectFinish()
             return () => {
               /**
-               * Incase the transaction is never ended, we close the
-               * transaction when component unmounts
+               * Incase the transaction is never ended, we check if the transaction
+               * can be closed during unmount phase
+               *
+               * We call detectFinish instead of forcefully ending the transaction
+               * since it could be a redirect route and we might prematurely close
+               * the currently running transaction
                */
-              transaction && transaction.end()
+              transaction && transaction.detectFinish()
             }
           }, [])
 
@@ -127,6 +131,9 @@ function getWithTransaction(apm) {
           }
 
           componentDidMount() {
+            /**
+             * React guarantees the parent CDM runs after the child components CDM
+             */
             if (this.transaction) {
               this.transaction.detectFinish()
             }
@@ -138,7 +145,7 @@ function getWithTransaction(apm) {
              * in that case this is a noop.
              */
             if (this.transaction) {
-              this.transaction.end()
+              this.transaction.detectFinish()
             }
           }
 

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -79,14 +79,13 @@ function getWithTransaction(apm) {
         typeof React.useEffect === 'function'
       ) {
         ApmComponent = function ApmComponent(props) {
-          const transaction = apm.startTransaction(name, type, {
-            canReuse: true
-          })
-
+          let transaction = null
           React.useEffect(() => {
-            transaction && transaction.detectFinish()
+            transaction = apm.startTransaction(name, type, {
+              canReuse: true
+            })
             return () => transaction && transaction.detectFinish()
-          })
+          }, [])
 
           return <Component transaction={transaction} {...props} />
         }

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -140,8 +140,10 @@ describe('withTransaction', function() {
   it('should end transaction when component unmounts', () => {
     const transactionService = serviceFactory.getService('TransactionService')
     const detectFinishSpy = jasmine.createSpy('detectFinish')
+    const endSpy = jasmine.createSpy('endSpy')
     spyOn(transactionService, 'startTransaction').and.returnValue({
-      detectFinish: detectFinishSpy
+      detectFinish: detectFinishSpy,
+      end: endSpy
     })
 
     const wrapper = TestComponent(apmBase)
@@ -150,7 +152,8 @@ describe('withTransaction', function() {
       'test-type',
       { canReuse: true }
     )
-    wrapper.unmount()
     expect(detectFinishSpy).toHaveBeenCalled()
+    wrapper.unmount()
+    expect(endSpy).toHaveBeenCalled()
   })
 })

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -116,7 +116,7 @@ describe('withTransaction', function() {
 
   it('should not create new transaction on every render', () => {
     const transactionService = serviceFactory.getService('TransactionService')
-    spyOn(transactionService, 'startTransaction').and.callThrough()
+    spyOn(transactionService, 'startTransaction')
 
     const wrapper = TestComponent(apmBase)
     expect(transactionService.startTransaction).toHaveBeenCalledWith(
@@ -136,5 +136,22 @@ describe('withTransaction', function() {
 
     expect(transactionService.startTransaction).not.toHaveBeenCalled()
     expect(wrapper.text()).toBe('Testing, new-props')
+  })
+
+  it('should end transaction when component unmounts', () => {
+    const transactionService = serviceFactory.getService('TransactionService')
+    const detectFinishSpy = jasmine.createSpy('detectFinish')
+    spyOn(transactionService, 'startTransaction').and.returnValue({
+      detectFinish: detectFinishSpy
+    })
+
+    const wrapper = TestComponent(apmBase)
+    expect(transactionService.startTransaction).toHaveBeenCalledWith(
+      'test-transaction',
+      'test-type',
+      { canReuse: true }
+    )
+    wrapper.unmount()
+    expect(detectFinishSpy).toHaveBeenCalled()
   })
 })

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -140,10 +140,8 @@ describe('withTransaction', function() {
   it('should end transaction when component unmounts', () => {
     const transactionService = serviceFactory.getService('TransactionService')
     const detectFinishSpy = jasmine.createSpy('detectFinish')
-    const endSpy = jasmine.createSpy('endSpy')
     spyOn(transactionService, 'startTransaction').and.returnValue({
-      detectFinish: detectFinishSpy,
-      end: endSpy
+      detectFinish: detectFinishSpy
     })
 
     const wrapper = TestComponent(apmBase)
@@ -154,6 +152,6 @@ describe('withTransaction', function() {
     )
     expect(detectFinishSpy).toHaveBeenCalled()
     wrapper.unmount()
-    expect(endSpy).toHaveBeenCalled()
+    expect(detectFinishSpy).toHaveBeenCalled()
   })
 })

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -45,9 +45,8 @@ function TestComponent(apm) {
   expect(typeof WrappedComponent).toBe('function')
   const wrapped = mount(<WrappedComponent name="withTransaction" />)
 
-  const text = wrapped.find('h1').text()
+  let text = wrapped.find('h1').text()
   expect(text).toBe('Testing, withTransaction')
-
   return wrapped
 }
 

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -23,7 +23,7 @@
  *
  */
 
-import Enzyme, { render } from 'enzyme'
+import Enzyme, { mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import React from 'react'
 
@@ -43,12 +43,12 @@ function TestComponent(apm) {
     Component
   )
   expect(typeof WrappedComponent).toBe('function')
-  const rendered = render(<WrappedComponent name="withTransaction" />)
-  expect(rendered.length).toBe(1)
-  var node = rendered[0]
-  expect(node.name).toBe('h1')
-  expect(node.type).toBe('tag')
-  expect(rendered.text()).toBe('Testing, withTransaction')
+  const wrapped = mount(<WrappedComponent name="withTransaction" />)
+
+  const text = wrapped.find('h1').text()
+  expect(text).toBe('Testing, withTransaction')
+
+  return wrapped
 }
 
 describe('withTransaction', function() {
@@ -112,5 +112,29 @@ describe('withTransaction', function() {
     )
     expect(WrappedComponent).toEqual(Component)
     expect(transactionService.startTransaction).not.toHaveBeenCalled()
+  })
+
+  it('should not create new transaction on every render', () => {
+    const transactionService = serviceFactory.getService('TransactionService')
+    spyOn(transactionService, 'startTransaction').and.callThrough()
+
+    const wrapper = TestComponent(apmBase)
+    expect(transactionService.startTransaction).toHaveBeenCalledWith(
+      'test-transaction',
+      'test-type',
+      { canReuse: true }
+    )
+    transactionService.startTransaction.calls.reset()
+    /**
+     * Trigger rerender of component
+     */
+    wrapper
+      .setProps({
+        name: 'new-props'
+      })
+      .update()
+
+    expect(transactionService.startTransaction).not.toHaveBeenCalled()
+    expect(wrapper.text()).toBe('Testing, new-props')
   })
 })


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#410 
+ We need to create route change transaction only when component mounts(first render in terms of effect terminology), however the effect hook was running on component rerenders. By passing empty arr on the useEffect hook, we create the transaction only on mount

+ We also need to create transaction only once inside setState and not inside function body since it gets executed on every render and effectively changes the transaction state which was passed down to the underlying component. 

This PR keeps the functional components in sync with the Class based ones. 

## TODO
+ [x] Add tests
+ [x] figure out issues with transaction type not set to `route-change` in e2e. 
+ [x] Validate the issue with Kibana App