### PR TITLE
feat(rum-core): move breakdown algorithm post transaction finish

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -239,7 +239,7 @@ class ApmServer {
   }
 
   ndjsonMetricsets(metricsets) {
-    const timestamp = Date.now()
+    const timestamp = Date.now() * 1000
     return metricsets
       .map(metricset =>
         NDJSON.stringify({ metricset: { timestamp, ...metricset } })

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -402,7 +402,7 @@ function now() {
   return window.performance.now()
 }
 
-function mayBeTime(time) {
+function getTime(time) {
   return typeof time === 'number' && time >= 0 ? time : now()
 }
 
@@ -440,7 +440,7 @@ export {
   getPageLoadMarks,
   getDuration,
   now,
-  mayBeTime,
+  getTime,
   rng,
   checkSameOrigin,
   setLabel,

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -402,6 +402,10 @@ function now() {
   return window.performance.now()
 }
 
+function mayBeTime(time) {
+  return typeof time === 'number' && time >= 0 ? time : now()
+}
+
 function getDuration(start, end) {
   if (isUndefined(end) || isUndefined(start)) {
     return null
@@ -436,6 +440,7 @@ export {
   getPageLoadMarks,
   getDuration,
   now,
+  mayBeTime,
   rng,
   checkSameOrigin,
   setLabel,

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -28,7 +28,7 @@ import {
   setLabel,
   merge,
   getDuration,
-  now
+  mayBeTime
 } from '../common/utils'
 import { NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
 
@@ -50,7 +50,7 @@ class SpanBase {
     this.traceId = options.traceId
     this.sampled = options.sampled
     this.timestamp = options.timestamp
-    this._start = now()
+    this._start = mayBeTime(options.startTime)
     this._end = undefined
     this.ended = false
     this.onEnd = options.onEnd
@@ -83,12 +83,12 @@ class SpanBase {
     merge(this.context, context)
   }
 
-  end() {
+  end(endTime) {
     if (this.ended) {
       return
     }
     this.ended = true
-    this._end = now()
+    this._end = mayBeTime(endTime)
 
     this.callOnEnd()
   }

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -28,7 +28,7 @@ import {
   setLabel,
   merge,
   getDuration,
-  mayBeTime
+  getTime
 } from '../common/utils'
 import { NAME_UNKNOWN, TYPE_CUSTOM } from '../common/constants'
 
@@ -50,7 +50,7 @@ class SpanBase {
     this.traceId = options.traceId
     this.sampled = options.sampled
     this.timestamp = options.timestamp
-    this._start = mayBeTime(options.startTime)
+    this._start = getTime(options.startTime)
     this._end = undefined
     this.ended = false
     this.onEnd = options.onEnd
@@ -88,7 +88,7 @@ class SpanBase {
       return
     }
     this.ended = true
-    this._end = mayBeTime(endTime)
+    this._end = getTime(endTime)
 
     this.callOnEnd()
   }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -222,11 +222,10 @@ class TransactionService {
         if (breakdownMetrics) {
           tr.captureBreakdown()
         }
-
+        this._config.events.send(TRANSACTION_END, [tr])
         if (__DEV__) {
           this._logger.debug('TransactionService transaction ended', tr)
         }
-        this._config.events.send(TRANSACTION_END, [tr])
       },
       err => {
         if (__DEV__) {

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -25,7 +25,7 @@
 
 import { Promise } from 'es6-promise'
 import Transaction from './transaction'
-import { extend } from '../common/utils'
+import { extend, getEarliestSpan, getLatestNonXHRSpan } from '../common/utils'
 import { PAGE_LOAD, NAME_UNKNOWN } from '../common/constants'
 import { captureNavigation } from './capture-navigation'
 import { __DEV__ } from '../env'
@@ -190,20 +190,12 @@ class TransactionService {
   handleTransactionEnd(tr) {
     return Promise.resolve().then(
       () => {
-        if (__DEV__) {
-          this._logger.debug('TransactionService transaction finished', tr)
-        }
         if (this.shouldIgnoreTransaction(tr.name)) {
+          if (__DEV__) {
+            this._logger.debug('TransactionService transaction is ignored', tr)
+          }
           return
         }
-        /**
-         * Capture breakdown metrics once the transaction is completed
-         */
-        const breakdownMetrics = this._config.get('breakdownMetrics')
-        if (breakdownMetrics) {
-          tr.captureBreakdown()
-        }
-
         if (tr.type === PAGE_LOAD) {
           /**
            * Setting the pageLoadTransactionName via configService.setConfig after
@@ -217,7 +209,24 @@ class TransactionService {
           }
         }
         captureNavigation(tr)
-        this.add(tr)
+
+        /**
+         * Adjust transaction start time with span timings and
+         * truncate spans that goes beyond transaction timeframe
+         */
+        this.adjustTransactionTime(tr)
+        /**
+         * Capture breakdown metrics once the transaction is completed
+         */
+        const breakdownMetrics = this._config.get('breakdownMetrics')
+        if (breakdownMetrics) {
+          tr.captureBreakdown()
+        }
+
+        if (__DEV__) {
+          this._logger.debug('TransactionService transaction ended', tr)
+        }
+        this._config.events.send(TRANSACTION_END, [tr])
       },
       err => {
         if (__DEV__) {
@@ -225,6 +234,43 @@ class TransactionService {
         }
       }
     )
+  }
+
+  adjustTransactionTime(transaction) {
+    /**
+     * Adjust start time of the transaction
+     */
+    const spans = transaction.spans
+    const earliestSpan = getEarliestSpan(spans)
+
+    if (earliestSpan && earliestSpan._start < transaction._start) {
+      transaction._start = earliestSpan._start
+    }
+
+    /**
+     * Adjust end time of the transaction to match the latest
+     * span end time
+     */
+    const latestSpan = getLatestNonXHRSpan(spans)
+    if (latestSpan && latestSpan._end > transaction._end) {
+      transaction._end = latestSpan._end
+    }
+
+    /**
+     * Set all spans that are longer than the transaction to
+     * be truncated spans
+     */
+    const transactionEnd = transaction._end
+    for (let i = 0; i < spans.length; i++) {
+      const span = spans[i]
+      if (span._end > transactionEnd) {
+        span._end = transactionEnd
+        span.type += '.truncated'
+      }
+      if (span._start > transactionEnd) {
+        span._start = transactionEnd
+      }
+    }
   }
 
   shouldIgnoreTransaction(transactionName) {
@@ -253,13 +299,6 @@ class TransactionService {
       }
       var span = trans.startSpan(name, type, options)
       return span
-    }
-  }
-
-  add(transaction) {
-    this._config.events.send(TRANSACTION_END, [transaction])
-    if (__DEV__) {
-      this._logger.debug('TransactionService.add', transaction)
     }
   }
 

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -29,7 +29,7 @@ import {
   generateRandomId,
   merge,
   now,
-  mayBeTime,
+  getTime,
   extend,
   getPageMetadata,
   removeInvalidChars
@@ -122,7 +122,7 @@ class Transaction extends SpanBase {
       return
     }
     this.ended = true
-    this._end = mayBeTime(endTime)
+    this._end = getTime(endTime)
 
     // truncate active spans
     for (let sid in this._activeSpans) {

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -29,6 +29,7 @@ import {
   generateRandomId,
   merge,
   now,
+  mayBeTime,
   extend,
   getPageMetadata,
   removeInvalidChars
@@ -50,10 +51,7 @@ class Transaction extends SpanBase {
 
     this.captureTimings = false
 
-    this.selfTime = null
     this.breakdownTimings = []
-    this.childStart = 0
-    this.childDuration = 0
 
     this.sampled = Math.random() <= this.options.transactionSampleRate
   }
@@ -108,14 +106,6 @@ class Transaction extends SpanBase {
     const span = new Span(name, type, opts)
     this._activeSpans[span.id] = span
 
-    /**
-     * Start child duration calculation
-     */
-    const activeChildren = Object.keys(this._activeSpans).length
-    if (activeChildren === 1) {
-      this.childStart = span._start
-    }
-
     return span
   }
 
@@ -127,20 +117,19 @@ class Transaction extends SpanBase {
     if (this.isFinished()) this.end()
   }
 
-  end() {
+  end(endTime) {
     if (this.ended) {
       return
     }
     this.ended = true
-    this._end = now()
+    this._end = mayBeTime(endTime)
 
     // truncate active spans
     for (let sid in this._activeSpans) {
       const span = this._activeSpans[sid]
       span.type = span.type + '.truncated'
-      span.end()
+      span.end(endTime)
     }
-    this.selfTime = this.duration() - this.childDuration
 
     const metadata = getPageMetadata()
     this.addContext(metadata)
@@ -178,15 +167,6 @@ class Transaction extends SpanBase {
     this.spans.push(span)
     // Remove span from _activeSpans
     delete this._activeSpans[span.id]
-
-    /**
-     * Calculate child duration
-     */
-    const activeChildren = Object.keys(this._activeSpans).length
-    if (activeChildren === 0) {
-      this.childDuration += span._end - this.childStart
-      this.childStart = 0
-    }
   }
 }
 

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -27,8 +27,6 @@ import Transaction from '../../src/performance-monitoring/transaction'
 import Span from '../../src/performance-monitoring/span'
 
 describe('transaction.Transaction', function() {
-  beforeEach(function() {})
-
   it('should contain correct number of spans in the end', function(done) {
     var firstSpan = new Span('first-span-name', 'first-span')
     firstSpan.end()


### PR DESCRIPTION
+ Introduce setting `start` and `end` of transaction and spans through options arguments
+ Also address these comments  https://github.com/elastic/apm-agent-rum-js/issues/289#issuecomment-534999842

TODO

+ [x] The algorithm needs few changes and tests fails currently at the moment. 