### PR TITLE
[docs] Fix build script

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -27,6 +27,6 @@ dest_dir="$html_dir/${name}"
 mkdir -p "$dest_dir"
 params="--chunk=1"
 if [ "$PREVIEW" = "1" ]; then
-  params="--chunk=1 -open chunk=1 -open"
+  params="--chunk=1 --open"
 fi
-$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+$docs_dir/build_docs --asciidoctor $params --doc "$index" --out "$dest_dir"


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-rum-js/issues/243.

Build the docs with:

`npm run build-docs` – Builds the docs
`PREVIEW=1 npm run build-docs` – Builds the docs and opens a local preview

---

It might make more sense to add `PREVIEW=1` here so that the docs open by default?
https://github.com/elastic/apm-agent-rum-js/blob/e9938243a657405d2f231be93d258274fc4e5cc5/package.json#L16