### PR TITLE
fix(rum-core): handle relative urls without slash properly

### DIFF
--- a/packages/rum-core/src/common/url.js
+++ b/packages/rum-core/src/common/url.js
@@ -71,6 +71,14 @@ class Url {
     // Sanitize what is left of the address
     address = address.replace('\\', '/')
 
+    /**
+     * When the authority component is absent the URL starts with a path component.
+     * By setting it as NaN, we set the remaining parsed address to path
+     */
+    if (!slashes) {
+      instructions[2] = [NaN, 'path']
+    }
+
     let index
     for (let i = 0; i < instructions.length; i++) {
       const instruction = instructions[i]
@@ -102,6 +110,7 @@ class Url {
       } else {
         /** NaN condition */
         this[key] = address
+        address = ''
       }
       /**
        * Default values for all keys from location if url is relative
@@ -115,9 +124,17 @@ class Url {
       if (instruction[3]) this[key] = this[key].toLowerCase()
     }
 
+    /**
+     * if the URL is relative, prepend the path with `/`
+     * to construct the href correctly
+     */
+    if (relative && this.path.charAt(0) !== '/') {
+      this.path = '/' + this.path
+    }
+
     this.relative = relative
 
-    this.protocol = protocol || location.protocol || ''
+    this.protocol = protocol || location.protocol
 
     this.origin =
       this.protocol && this.host && this.protocol !== 'file:'

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -101,8 +101,45 @@ describe('Url parser', function() {
     var result = new Url('?param=value')
     expect(result).toEqual(
       jasmine.objectContaining({
-        path: '',
+        path: '/',
         query: '?param=value'
+      })
+    )
+  })
+
+  it('should parse url correctly without /', () => {
+    expect(new Url('api/foo')).toEqual(
+      jasmine.objectContaining({
+        path: '/api/foo',
+        query: '',
+        hash: '',
+        relative: true,
+        protocol: 'http:'
+      })
+    )
+
+    expect(new Url('api/foo?a=b')).toEqual(
+      jasmine.objectContaining({
+        path: '/api/foo',
+        query: '?a=b',
+        hash: ''
+      })
+    )
+
+    expect(new Url('api/foo#fragment')).toEqual(
+      jasmine.objectContaining({
+        path: '/api/foo',
+        hash: '#fragment'
+      })
+    )
+  })
+
+  it('should inherit protocol for relative urls with protocols', () => {
+    expect(new Url('//foo.com/bar')).toEqual(
+      jasmine.objectContaining({
+        path: '/bar',
+        host: 'foo.com',
+        protocol: 'http:'
       })
     )
   })


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#444 
+ Handle the pathname resolution according to browser URL implementation. 
+ Added more tests to cover this case. 