### PR TITLE
fix(rum-angular): use explicit angular injection for service

### DIFF
--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -16,8 +16,8 @@ npm install @elastic/apm-rum-angular --save
 [float]
 ==== Instrumenting your Angular application
 
-The Angular integration package comes with a `ApmService` that will start subscribing to 
-https://angular.io/api/router/Event[Angular Router Events] once the service is initialized. 
+The Angular integration package comes with a `ApmService` which uses Angular Depedency injection pattern and 
+will start subscribing to https://angular.io/api/router/Event[Angular Router Events] once the service is initialized. 
 
 `ApmService` must be initialized from either the application module or application component since 
 the RUM agent has to start capturing all the resources and API calls as soon as possible. 
@@ -25,7 +25,8 @@ the RUM agent has to start capturing all the resources and API calls as soon as 
 
 [source,js]
 ----
-import { Routes, RouterModule } from '@angular/router'
+import { NgModule, Inject } from '@angular/core'
+import { Routes, Router, RouterModule } from '@angular/router'
 import { ApmService } from '@elastic/apm-rum-angular'
 
 const routes: Routes = [
@@ -36,11 +37,15 @@ const routes: Routes = [
 @NgModule({
   imports: [BrowserModule, RouterModule.forRoot(routes)],
   declarations: [AppComponent, ContactListComponent, ContactDetailComponent],
-  providers: [ApmService],
+  providers: [{
+    provide: ApmService,
+    useClass: ApmService,
+    deps: [Router]
+  }],
   bootstrap: [AppComponent]
 })
 export class AppModule {
-  constructor(service: ApmService) {
+  constructor(@Inject(ApmService) service: ApmService) {
     // API is exposed through this apm instance
     const apm = service.init({
       serviceName: 'angular-app',

--- a/packages/rum-angular/src/apm-service.ts
+++ b/packages/rum-angular/src/apm-service.ts
@@ -23,13 +23,7 @@
  *
  */
 
-import {
-  Router,
-  Event,
-  NavigationStart,
-  NavigationEnd,
-  NavigationError
-} from '@angular/router'
+import { Router, NavigationStart } from '@angular/router'
 import { Injectable } from '@angular/core'
 import { Promise } from 'es6-promise'
 
@@ -61,17 +55,17 @@ export class ApmService {
 
   observe() {
     let transaction
-    this.router.events.subscribe((event: Event) => {
-      const instanceName = event.constructor.name
-      if (instanceName === NavigationStart.name) {
+    this.router.events.subscribe(event => {
+      const eventName = event.toString()
+      if (eventName.indexOf('NavigationStart') >= 0) {
         const name = (event as NavigationStart).url
         transaction = ApmService.apm.startTransaction(name, 'route-change', {
           managed: true,
           canReuse: true
         })
-      } else if (instanceName === NavigationError.name) {
+      } else if (eventName.indexOf('NavigationError') >= 0) {
         transaction && transaction.detectFinish()
-      } else if (instanceName === NavigationEnd.name) {
+      } else if (eventName.indexOf('NavigationEnd') >= 0) {
         if (!transaction) {
           return
         }

--- a/packages/rum-angular/test/e2e/with-router/app/app.module.ts
+++ b/packages/rum-angular/test/e2e/with-router/app/app.module.ts
@@ -23,9 +23,10 @@
  *
  */
 
-import { NgModule } from '@angular/core'
+import { NgModule, Inject } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { HttpClientModule } from '@angular/common/http'
+import { Router } from '@angular/router'
 
 import { AppRoutingModule } from './app.routing.module'
 import { AppComponent } from './app.component'
@@ -45,11 +46,17 @@ import { initializeApmService } from '../../../index'
     ContactListComponent,
     ContactDetailComponent
   ],
-  providers: [ApmService],
+  providers: [
+    {
+      provide: ApmService,
+      useClass: ApmService,
+      deps: [Router]
+    }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {
-  constructor(service: ApmService) {
+  constructor(@Inject(ApmService) service: ApmService) {
     initializeApmService(service, {
       serviceName: 'e2e-angular-integration',
       debug: true


### PR DESCRIPTION
+ fixes elastic/apm-agent-rum-js#437 
+ Libraries needs to use explicit injection to make it work with all build configs.
+ Since the injection uses Reflection API like metadata and decorate, its better to use explicit check instead of doing `instanceof` since it fails with Angular CLI builds. 
+ remove the activated route deps since we can extract the firstChild from router state.  
+ Modify the E2E tests with the new behaviour. 
+ Update the angular docs to reflect the same. 

We can extend the tests in the future to include Angular AOT compiler and all those, but it requires pulling in lots of dependencies, so kept it simple for now and tested all the scenarios in the example repo which is a repo constructed with Angular CLI https://github.com/railsstudent/apm-rum-angular-routing-failed