### PR TITLE
fix(rum-core): ensure context metadata is shallow merged on transaction

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -45,6 +45,9 @@ The given `context` argument must be an object and can contain the following pro
 
 The provided user context is stored under `context.user` in Elasticsearch on both errors and transactions.
 
+It’s possible to call this function multiple times within the scope of the same active transaction. 
+For each call, the properties of the context argument are shallow merged with the context previously given.
+
 
 [float]
 [[apm-set-custom-context]]
@@ -59,10 +62,14 @@ Call this to enrich collected errors and transactions with any information that 
 
 The provided custom context is stored under `context.custom` in Elasticsearch on both errors and transactions.
 
+It’s possible to call this function multiple times within the scope of the same active transaction. 
+For each call, the properties of the context argument are shallow merged with the context previously given.
+
 The given `context` argument must be an object and can contain any property that can be JSON encoded.
 
 TIP: Before using custom context, ensure you understand the different types of
 {apm-overview-ref-v}/metadata.html[metadata] that are available.
+
 
 [float]
 [[apm-add-tags]]

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -23,7 +23,13 @@
  *
  */
 
-import { getCurrentScript, setLabel, merge, getDtHeaderValue } from './utils'
+import {
+  getCurrentScript,
+  setLabel,
+  merge,
+  extend,
+  getDtHeaderValue
+} from './utils'
 import EventHandler from './event-handler'
 import { CONFIG_CHANGE } from './constants'
 
@@ -159,26 +165,6 @@ class Config {
     return this.config.serverUrl + this.config.serverUrlPrefix
   }
 
-  set(key, value) {
-    var levels = key.split('.')
-    var maxLevel = levels.length - 1
-    var target = this.config
-
-    for (let i = 0; i < maxLevel + 1; i++) {
-      const level = levels[i]
-      if (!level) {
-        continue
-      }
-      if (i === maxLevel) {
-        target[level] = value
-      } else {
-        var obj = target[level] || {}
-        target[level] = obj
-        target = obj
-      }
-    }
-  }
-
   setUserContext(userContext = {}) {
     const context = {}
     const { id, username, email } = userContext
@@ -192,13 +178,14 @@ class Config {
     if (typeof email === 'string') {
       context.email = email
     }
-    this.set('context.user', context)
+    this.config.context.user = extend(this.config.context.user || {}, context)
   }
 
-  setCustomContext(customContext) {
-    if (customContext && typeof customContext === 'object') {
-      this.set('context.custom', customContext)
-    }
+  setCustomContext(customContext = {}) {
+    this.config.context.custom = extend(
+      this.config.context.custom || {},
+      customContext
+    )
   }
 
   addLabels(tags) {

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -61,8 +61,8 @@ describe('ConfigService', function() {
   it('should return undefined if the config does not exists', function() {
     expect(configService.get('context')).toEqual({})
     expect(configService.get('context.user')).toBe(undefined)
-    configService.set('context.user', { test: 'test' })
-    expect(configService.get('context.user')).toEqual({ test: 'test' })
+    configService.setUserContext({ id: 'test' })
+    expect(configService.get('context.user')).toEqual({ id: 'test' })
     expect(configService.get('nonexisting.nonexisting')).toBe(undefined)
     expect(configService.get('context.nonexisting.nonexisting')).toBe(undefined)
   })
@@ -96,8 +96,17 @@ describe('ConfigService', function() {
 
   it('should set userContext and customContext', function() {
     configService.setCustomContext({ test: 'test' })
-    var customContext = configService.get('context.custom')
-    expect(customContext).toEqual({ test: 'test' })
+    expect(configService.get('context.custom')).toEqual({ test: 'test' })
+
+    configService.setCustomContext({ test: 'test2', foo: 'bar', bar: 'baz' })
+    expect(configService.get('context.custom')).toEqual({
+      test: 'test2',
+      foo: 'bar',
+      bar: 'baz'
+    })
+
+    configService.setUserContext({ test: 'test', username: {} })
+    expect(configService.get('context.user')).toEqual({})
 
     configService.setUserContext({
       test: 'test',
@@ -105,25 +114,23 @@ describe('ConfigService', function() {
       username: 'username',
       email: 'email'
     })
-    var userContext = configService.get('context.user')
-    expect(userContext).toEqual({
+    expect(configService.get('context.user')).toEqual({
       id: 'userId',
       username: 'username',
       email: 'email'
     })
 
     configService.setUserContext({
-      test: 'test',
+      foo: 'bar',
       id: 1,
       username: 1,
       email: 'email'
     })
-    userContext = configService.get('context.user')
-    expect(userContext).toEqual({ id: 1, email: 'email' })
-
-    configService.setUserContext({ test: 'test', username: {} })
-    userContext = configService.get('context.user')
-    expect(userContext).toEqual({})
+    expect(configService.get('context.user')).toEqual({
+      id: 1,
+      email: 'email',
+      username: 'username'
+    })
   })
 
   it('should validate required config options', () => {

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -311,7 +311,9 @@ describe('ErrorLogging', function() {
       return evt
     }
 
-    configService.set('flushInterval', 1)
+    configService.setConfig({
+      flushInterval: 1
+    })
     errorLogging.registerListeners()
 
     spyOn(apmServer, 'sendErrors').and.callFake(errors => {

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -68,8 +68,10 @@ describe('TransactionService', function() {
   })
 
   it('should start transaction', function(done) {
-    config.set('active', true)
-    config.set('browserResponsivenessInterval', true)
+    config.setConfig({
+      browserResponsivenessInterval: true
+    })
+
     transactionService = new TransactionService(logger, config)
 
     var result = transactionService.startTransaction(
@@ -101,7 +103,6 @@ describe('TransactionService', function() {
   })
 
   it('should create a reusable transaction on the first span', function() {
-    config.set('active', true)
     transactionService = new TransactionService(logger, config)
 
     transactionService.startSpan('testSpan', 'testtype')
@@ -116,8 +117,9 @@ describe('TransactionService', function() {
 
   it('should capture page load on first transaction', function(done) {
     // todo: can't test hard navigation metrics since karma runs tests inside an iframe
-    config.set('active', true)
-    config.set('capturePageLoad', true)
+    config.setConfig({
+      capturePageLoad: true
+    })
     transactionService = new TransactionService(logger, config)
 
     var tr1 = transactionService.startTransaction(
@@ -185,7 +187,9 @@ describe('TransactionService', function() {
     })
     expect(tr.name).toBe('Unknown')
 
-    config.set('pageLoadTransactionName', 'page load name')
+    config.setConfig({
+      pageLoadTransactionName: 'page load name'
+    })
     tr.detectFinish()
 
     /**
@@ -199,7 +203,6 @@ describe('TransactionService', function() {
   })
 
   xit('should not add duplicate resource spans', function() {
-    config.set('active', true)
     transactionService = new TransactionService(logger, config)
 
     var tr = transactionService.startTransaction('transaction', 'transaction', {
@@ -243,8 +246,6 @@ describe('TransactionService', function() {
   it('should capture resources from navigation timing', function(done) {
     const unMock = mockGetEntriesByType()
 
-    config.set('active', true)
-
     const customTransactionService = new TransactionService(logger, config)
     config.events.observe(TRANSACTION_END, function() {
       expect(tr.captureTimings).toBe(true)
@@ -274,7 +275,9 @@ describe('TransactionService', function() {
   })
 
   it('should ignore transactions that match the list', function() {
-    config.set('ignoreTransactions', ['transaction1', /transaction2/])
+    config.setConfig({
+      ignoreTransactions: ['transaction1', /transaction2/]
+    })
     transactionService = new TransactionService(logger, config)
 
     expect(
@@ -289,7 +292,9 @@ describe('TransactionService', function() {
       )
     ).toBeTruthy()
 
-    config.set('ignoreTransactions', [])
+    config.setConfig({
+      ignoreTransactions: []
+    })
   })
 
   it('should apply sampling to transactions', function() {
@@ -300,7 +305,9 @@ describe('TransactionService', function() {
     var span = transactionService.startSpan('testspan', 'test')
     expect(span.sampled).toBe(true)
 
-    config.set('transactionSampleRate', 0)
+    config.setConfig({
+      transactionSampleRate: 0
+    })
     tr = transactionService.startTransaction('test', 'test')
     expect(tr.sampled).toBe(false)
     span = tr.startSpan('testspan', 'test')


### PR DESCRIPTION
+ fixes #448 
+ Removed `configService.set` since the functionality is not required and we can achieve the same using `setConfig`.
+ Removed config.active settings in test since the agent is `active` by default. 