### PR TITLE
refactor(rum-core): remove optional timestamp from breakdown metrics

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -262,12 +262,7 @@ class ApmServer {
   }
 
   ndjsonMetricsets(metricsets) {
-    const timestamp = Date.now() * 1000
-    return metricsets
-      .map(metricset =>
-        NDJSON.stringify({ metricset: { timestamp, ...metricset } })
-      )
-      .join('')
+    return metricsets.map(metricset => NDJSON.stringify({ metricset })).join('')
   }
 
   ndjsonTransactions(transactions) {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -409,20 +409,17 @@ describe('ApmServer', function() {
 
   it('should ndjson metricsets along with transactions', function() {
     const tr = generateTransaction(1, true)
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date(0))
     const payload = performanceMonitoring.convertTransactionsToServerModel(tr)
     const result = apmServer.ndjsonTransactions(payload)
     /* eslint-disable max-len */
     const expected = [
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":true}}\n',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
-      '{"metricset":{"timestamp":0,"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
-      '{"metricset":{"timestamp":0,"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',
-      '{"metricset":{"timestamp":0,"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'
     ].join('')
     expect(result).toEqual([expected])
-    jasmine.clock().uninstall()
   })
 
   if (isVersionInRange(testConfig.stackVersion, '7.3.0')) {


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#289 