### PR TITLE
chore: build must watch for local packages while testing

### DIFF
--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -170,6 +170,7 @@ function getWebpackConfig(bundleType, packageType) {
     mode: isEnvProduction ? 'production' : 'development',
     plugins: [new EnvironmentPlugin(getWebpackEnv())],
     resolve: {
+      mainFields: ['source', 'browser', 'module', 'main'],
       extensions: ['.js', '.jsx', '.ts']
     }
   }


### PR DESCRIPTION
+ fix https://github.com/elastic/apm-agent-rum-js/issues/482
+ By default webpack uses `browser`, `main` and `module`. Since we expose source as a field in our internal packages, we can use it to resolve to the current source changes which can be reflected easily in karma watch and webpack watch modes. 