### PR TITLE
docs: add vue integration link in framework docs [skip ci]

### DIFF
--- a/docs/framework-integrations.asciidoc
+++ b/docs/framework-integrations.asciidoc
@@ -3,6 +3,7 @@
 
 * <<react-integration, React Integration>>
 * <<angular-integration, Angular Integration>>
+* <<vue-integration, Vue Integration>>
 
 include::./react-integration.asciidoc[React Integration]
 include::./angular-integration.asciidoc[Angular Integration]


### PR DESCRIPTION
+ Missed it while doing the Vue docs elastic/apm-agent-rum-js#465 