### PR TITLE
perf(rum-core): ignored XHR's are exempted from task creation process

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -66,7 +66,6 @@ export function patchFetch(callback) {
         method: request.method,
         sync: false,
         url,
-        args,
         aborted: false
       }
     }

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -63,7 +63,6 @@ function registerEventListener(target) {
 describe('xhrPatch', function() {
   function mapEvent(event) {
     delete event.task.data.target
-    event.task.data.args = [].slice.call(event.task.data.args)
     return event
   }
 
@@ -87,12 +86,10 @@ describe('xhrPatch', function() {
               source: XMLHTTPREQUEST,
               state: 'invoke',
               type: 'macroTask',
-              ignore: undefined,
               data: {
                 method: 'GET',
                 url: '/',
                 sync: false,
-                args: [],
                 aborted: false
               }
             }
@@ -103,12 +100,10 @@ describe('xhrPatch', function() {
               source: XMLHTTPREQUEST,
               state: 'invoke',
               type: 'macroTask',
-              ignore: undefined,
               data: {
                 method: 'GET',
                 url: '/',
                 sync: false,
-                args: [],
                 aborted: false
               }
             }
@@ -249,12 +244,14 @@ describe('xhrPatch', function() {
     expect(func).not.toThrow()
   })
 
-  it('should consider xhr ignore', function(done) {
+  it('should not create events and pollute xhr when ignore flag is true', function(done) {
     var req = new window.XMLHttpRequest()
     let getEvents = registerEventListener(req)
     req[XHR_IGNORE] = true
     req.open('GET', '/?ignoretest')
     req.addEventListener('load', function() {
+      expect(req[XHR_METHOD]).toBeUndefined()
+      expect(req[XHR_URL]).toBeUndefined()
       expect(getEvents(done).map(e => e.event)).toEqual([])
     })
 


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#486 
+ Small optimisation to ignore task creation process / event listener registration for the ignored XHR  objects (APM Server Request)
+ Also cleaned up the task object since some fields were not required to be passed around. 