### PR TITLE
fix(rum): page-load transaction duration should reflect load event

### DIFF
--- a/packages/rum-core/src/index.js
+++ b/packages/rum-core/src/index.js
@@ -28,7 +28,11 @@
 import ErrorLogging from './error-logging'
 import PerformanceMonitoring from './performance-monitoring'
 import ServiceFactory from './common/service-factory'
-import { isPlatformSupported, scheduleMicroTask } from './common/utils'
+import {
+  isPlatformSupported,
+  scheduleMicroTask,
+  scheduleMacroTask
+} from './common/utils'
 import { patchAll, patchEventHandler } from './common/patching'
 import { PAGE_LOAD, ERROR } from './common/constants'
 import { getInstrumentationFlags } from './common/instrument'
@@ -52,5 +56,6 @@ export {
   PAGE_LOAD,
   getInstrumentationFlags,
   createTracer,
-  scheduleMicroTask
+  scheduleMicroTask,
+  scheduleMacroTask
 }

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -25,6 +25,7 @@
 
 import {
   getInstrumentationFlags,
+  scheduleMacroTask,
   PAGE_LOAD,
   ERROR
 } from '@elastic/apm-rum-core'
@@ -126,7 +127,6 @@ class ApmBase {
     const transactionService = this.serviceFactory.getService(
       'TransactionService'
     )
-
     /**
      * Name of the transaction is set in transaction service to
      * avoid duplicating the logic at multiple places
@@ -135,15 +135,15 @@ class ApmBase {
       managed: true,
       canReuse: true
     })
-
     if (tr) {
       tr.addTask(PAGE_LOAD)
     }
-    const sendPageLoadMetrics = function sendPageLoadMetrics() {
-      // to make sure PerformanceTiming.loadEventEnd has a value
-      setTimeout(function() {
+    // to make sure PerformanceTiming.loadEventEnd has a value
+    const sendPageLoadMetrics = () => {
+      scheduleMacroTask(() => {
         if (tr) {
           tr.removeTask(PAGE_LOAD)
+          tr.end()
         }
       })
     }


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#474 
+ `page-load` transaction duration must always reflect the window.load event value. Even if there are tasks associated with the transaction, they should be truncated and added to the page-load transaction instead of extending the duration of the transaction