### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,10 @@ pipeline {
                 dir("${OPBEANS_REPO}"){
                   git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                       url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-                  // The opbeans-go pipeline will trigger a release for the release tag
+                  sh script: ".ci/bump-version.sh '${env.BRANCH_NAME}'", label: 'Bump version'
+                  // The opbeans pipeline will trigger a release for the master branch
+                  gitPush()
+                  // The opbeans pipeline will trigger a release for the release tag
                   gitCreateTag(tag: "${env.BRANCH_NAME}")
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    OPBEANS_REPO = 'opbeans-frontend'
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -176,6 +177,29 @@ pipeline {
                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+          }
+        }
+        stage('Release') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            tag pattern: '@elastic/apm-rum@\\d+\\.\\d+\\.\\d+$', comparator: 'REGEXP'
+          }
+          stages {
+            stage('Opbeans') {
+              environment {
+                REPO_NAME = "${OPBEANS_REPO}"
+              }
+              steps {
+                deleteDir()
+                dir("${OPBEANS_REPO}"){
+                  git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                      url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+                  // The opbeans-go pipeline will trigger a release for the release tag
+                  gitCreateTag(tag: "${env.BRANCH_NAME}")
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## What does this pull request do?

Add a final stage in the release process to bump the opbeans agent dependency.

## Why is it important?

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Create a tag to trigger the release pipeline in the opbeans-frontend. That particular tag will match with the same one that the one in the agent itself.
- [x] Monitor tags which are matching the pattern `@elastic/apm-rum@x.y.z`

The opbeans-frontend pipeline will trigger the build for the just created tag.

## Tasks
- [x] Agree the version should be either x.y.z or agent tag-based, like https://github.com/elastic/apm-agent-rum-js/releases/tag/%40elastic%2Fapm-rum%404.5.1

> Versioning for both will always match with the tag.