### PR TITLE
chore(benchmarks): memory allocation per function during page-load [s…

### DIFF
--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -192,7 +192,10 @@ function getWebpackConfig(bundleType, packageType) {
         minimizer: [
           new UglifyJSPlugin({
             sourceMap: true,
-            extractComments: true
+            extractComments: true,
+            uglifyOptions: {
+              keep_fnames: true
+            }
           })
         ]
       },

--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -192,10 +192,7 @@ function getWebpackConfig(bundleType, packageType) {
         minimizer: [
           new UglifyJSPlugin({
             sourceMap: true,
-            extractComments: true,
-            uglifyOptions: {
-              keep_fnames: true
-            }
+            extractComments: true
           })
         ]
       },

--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -37,7 +37,7 @@ const { runs, noOfImages } = require('./config')
 
 const dist = path.join(__dirname, '../../dist')
 
-function customApmBuild() {
+function customApmBuild(filename) {
   /**
    * Match it with the default webpack prod build of elasticApm
    * expect the function names are not mangled
@@ -45,8 +45,8 @@ function customApmBuild() {
   const config = {
     entry: path.join(__dirname, '../../src/index.js'),
     output: {
-      filename: '[name].umd.js',
-      path: path.join(dist, ' bundles'),
+      filename,
+      path: path.join(dist, 'bundles'),
       library: '[name]',
       libraryTarget: 'umd'
     },
@@ -58,20 +58,18 @@ function customApmBuild() {
       if (err) {
         reject(err)
       }
+      console.info('custom apm build - ', filename, 'generated')
       resolve()
     })
   })
 }
 
-function getMinifiedApmBundle() {
-  return readFileSync(
-    path.join(dist, 'bundles/elastic-apm-rum.umd.min.js'),
-    'utf-8'
-  )
+function getMinifiedApmBundle(filename) {
+  return readFileSync(path.join(dist, 'bundles', filename), 'utf-8')
 }
 
 function getApmBundleSize() {
-  const content = getMinifiedApmBundle()
+  const content = getMinifiedApmBundle('elastic-apm-rum.umd.min.js')
   /**
    * To match the level with our bundlesize check
    */

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -38,6 +38,7 @@ module.exports = {
      * https://chromedevtools.github.io/devtools-protocol/tot/Profiler#method-setSamplingInterval
      */
     cpuSamplingInterval: 200,
+    memorySamplingInterval: 10,
     launchOptions: {
       headless: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox']

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -25,7 +25,11 @@
 
 const puppeteer = require('puppeteer')
 const { chrome } = require('./config')
-const { filterCpuMetrics, capturePayloadInfo } = require('./analyzer')
+const {
+  filterCpuMetrics,
+  capturePayloadInfo,
+  getMemoryAllocationPerFunction
+} = require('./analyzer')
 
 async function launchBrowser() {
   return await puppeteer.launch(chrome.launchOptions)
@@ -41,6 +45,7 @@ function gatherRawMetrics(browser, url) {
      */
     await client.send('Page.enable')
     await client.send('Profiler.enable')
+    await client.send('HeapProfiler.enable')
     /**
      * Tune the CPU sampler to get control the
      * number of samples generated
@@ -63,11 +68,18 @@ function gatherRawMetrics(browser, url) {
          * the apm server
          */
         const result = await client.send('Profiler.stop')
+        const sample = await client.send('HeapProfiler.stopSampling')
+
+        const memoryMetrics = getMemoryAllocationPerFunction(sample)
         const filteredCpuMetrics = filterCpuMetrics(result.profile, url)
         const response = request.postData()
         const payload = capturePayloadInfo(response)
 
-        Object.assign(metrics, { cpu: filteredCpuMetrics, payload })
+        Object.assign(metrics, {
+          cpu: filteredCpuMetrics,
+          payload,
+          memory: memoryMetrics
+        })
         /**
          * Resolve the promise once we measure the size
          * of the payload to APM Server
@@ -91,9 +103,17 @@ function gatherRawMetrics(browser, url) {
       Object.assign(metrics, timings)
     })
     /**
-     * Start the profiler before navigating to the URL
+     * Perform a garbage collection to do a clean check everytime
+     */
+    await client.send('HeapProfiler.collectGarbage')
+    /**
+     * Start the CPU and Memory profiler before navigating to the URL
      */
     await client.send('Profiler.start')
+    await client.send('HeapProfiler.startSampling', {
+      interval: chrome.memorySamplingInterval
+    })
+
     await page.goto(url)
   })
 }

--- a/packages/rum/test/benchmarks/run.js
+++ b/packages/rum/test/benchmarks/run.js
@@ -42,8 +42,10 @@ const REPORTS_DIR = join(__dirname, '../../reports')
     /**
      * Generate custom apm build
      */
-    await customApmBuild()
-    const server = await startServer()
+    const filename = 'apm-rum-with-name.umd.min.js'
+    await customApmBuild(filename)
+
+    const server = await startServer(filename)
     /**
      * object cache holding the metrics accumlated in each run and
      * helps in processing the overall results

--- a/packages/rum/test/benchmarks/run.js
+++ b/packages/rum/test/benchmarks/run.js
@@ -29,7 +29,8 @@ const { gatherRawMetrics, launchBrowser } = require('./profiler')
 const {
   analyzeMetrics,
   calculateResults,
-  getCommonFields
+  getCommonFields,
+  customApmBuild
 } = require('./analyzer')
 const { runs, port, scenarios } = require('./config')
 const startServer = require('./server')
@@ -38,6 +39,10 @@ const REPORTS_DIR = join(__dirname, '../../reports')
 
 !(async function run() {
   try {
+    /**
+     * Generate custom apm build
+     */
+    await customApmBuild()
     const server = await startServer()
     /**
      * object cache holding the metrics accumlated in each run and

--- a/packages/rum/test/benchmarks/server.js
+++ b/packages/rum/test/benchmarks/server.js
@@ -40,27 +40,27 @@ function generateImageUrls(port, number) {
 }
 
 /**
- * Strip license and sourcemap url
- */
-const APM_BUNDLE = getMinifiedApmBundle()
-  .replace(
-    '/*! For license information please see elastic-apm-rum.umd.min.js.LICENSE */',
-    ''
-  )
-  .replace('//# sourceMappingURL=elastic-apm-rum.umd.min.js.map', '')
-
-/**
  * Adding a random value at the end of the script text prevents
  * Chrome from caching the parsed/JITed script
  */
-function getRandomBundleContent() {
-  let content = APM_BUNDLE
+function getRandomBundleContent(apmBundle) {
+  let content = apmBundle
   content += `var scriptId = ${Date.now()};`
   return content
 }
 
-const startServer = (module.exports = () => {
+const startServer = (module.exports = filename => {
   return new Promise(resolve => {
+    /**
+     * Strip license and sourcemap url
+     */
+    const apmBundle = getMinifiedApmBundle(filename)
+      .replace(
+        `/*! For license information please see ${filename}.LICENSE */`,
+        ''
+      )
+      .replace(`//# sourceMappingURL=${filename}.map`, '')
+
     const app = express()
     let server
     /**
@@ -75,7 +75,9 @@ const startServer = (module.exports = () => {
 
     app.get('/basic', (req, res) => {
       res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
-      res.render('basic', { apmBundleContent: getRandomBundleContent() })
+      res.render('basic', {
+        apmBundleContent: getRandomBundleContent(apmBundle)
+      })
     })
 
     app.get('/heavy', (req, res) => {
@@ -83,7 +85,7 @@ const startServer = (module.exports = () => {
       const { port } = server.address()
       const images = generateImageUrls(port, noOfImages)
       res.render('heavy', {
-        apmBundleContent: getRandomBundleContent(),
+        apmBundleContent: getRandomBundleContent(apmBundle),
         images
       })
     })

--- a/packages/rum/test/benchmarks/server.js
+++ b/packages/rum/test/benchmarks/server.js
@@ -99,6 +99,6 @@ const startServer = (module.exports = filename => {
 
 !(async () => {
   if (require.main === module) {
-    await startServer()
+    await startServer('elastic-apm-rum.umd.min.js')
   }
 })()

--- a/packages/rum/test/benchmarks/server.js
+++ b/packages/rum/test/benchmarks/server.js
@@ -59,7 +59,7 @@ function getRandomBundleContent() {
   return content
 }
 
-module.exports = function startServer() {
+const startServer = (module.exports = () => {
   return new Promise(resolve => {
     const app = express()
     let server
@@ -93,4 +93,10 @@ module.exports = function startServer() {
       resolve(server)
     })
   })
-}
+})
+
+!(async () => {
+  if (require.main === module) {
+    await startServer()
+  }
+})()

--- a/packages/rum/test/benchmarks/server.js
+++ b/packages/rum/test/benchmarks/server.js
@@ -49,7 +49,7 @@ function getRandomBundleContent(apmBundle) {
   return content
 }
 
-const startServer = (module.exports = filename => {
+function startServer(filename) {
   return new Promise(resolve => {
     /**
      * Strip license and sourcemap url
@@ -95,7 +95,9 @@ const startServer = (module.exports = filename => {
       resolve(server)
     })
   })
-})
+}
+
+module.exports = startServer
 
 !(async () => {
   if (require.main === module) {


### PR DESCRIPTION
+ part of elastic/apm-agent-rum-js#26 
+ This PR uses the chrome allocation profiler to measure the memory allocation of top functions from the agent that might help identify memory leaks
+ Generates a new build with keeping the function names of the apm agent to help with identify the functions with more memory allocation. 

Adds some keys to the benchmark documents that matches with the function names that uses the most memory 

```
   "memory.createResourceTimingSpan.bytes": 65664,
    "memory.generateRandomId.bytes": 33280,
    "memory.createResourceTimingSpans.bytes": 32864,
    "memory.getCurrentScript.bytes": 32816,
    "memory.patchFetch.bytes": 32816,
    "memory.baseExtend.bytes": 32784,
    "memory.isCORSSupported.bytes": 38376,
```