### PR TITLE
feat(rum-core): enrich span context with desination metadata

### DIFF
--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -99,7 +99,7 @@ function getDestination(parsedUrl, type) {
       type
     },
     address,
-    port: portNumber
+    port: Number(portNumber)
   }
 }
 

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -68,7 +68,7 @@ function getExternalContext(data) {
   const { url, method, target, response } = data
   const parsedUrl = new Url(url)
 
-  const { href, port, protocol, hostname } = parsedUrl
+  const { href, port, protocol, hostname, origin } = parsedUrl
   const isDefaultPort = port === '80' || port === '443'
 
   const context = {
@@ -86,8 +86,9 @@ function getExternalContext(data) {
       port
     }
   }
+
   let statusCode
-  if (target && typeof target.status !== 'undefined') {
+  if (target) {
     statusCode = target.status
   } else if (response) {
     statusCode = response.status

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -1,0 +1,131 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import Url from './url'
+import { PAGE_LOAD } from './constants'
+import { getPageMetadata, getServerTimingInfo } from './utils'
+
+/**
+ * Both Navigation and Resource timing level 2 exposes these below information
+ *
+ * for CORS requests without Timing-Allow-Origin header, transferSize & encodedBodySize will be 0
+ */
+function getResponseContext(perfTimingEntry) {
+  const {
+    transferSize,
+    encodedBodySize,
+    decodedBodySize,
+    serverTiming
+  } = perfTimingEntry
+
+  const respContext = {
+    transfer_size: transferSize,
+    encoded_body_size: encodedBodySize,
+    decoded_body_size: decodedBodySize
+  }
+  const serverTimingStr = getServerTimingInfo(serverTiming)
+  if (serverTimingStr) {
+    respContext.headers = {
+      'server-timing': serverTimingStr
+    }
+  }
+  return respContext
+}
+
+function getResourceContext(data) {
+  const { entry, url } = data
+  return {
+    http: {
+      url,
+      response: getResponseContext(entry)
+    }
+  }
+}
+
+function getExternalContext(data) {
+  const { url, method, target, response } = data
+  const parsedUrl = new Url(url)
+
+  const { href, port, protocol, hostname } = parsedUrl
+  const isDefaultPort = port === '80' || port === '443'
+
+  const context = {
+    http: {
+      method,
+      url: href
+    },
+    destination: {
+      service: {
+        name: !isDefaultPort ? origin : protocol + '//' + hostname,
+        resource: hostname + ':' + port,
+        type: 'external'
+      },
+      address: hostname,
+      port
+    }
+  }
+  let statusCode
+  if (target && typeof target.status !== 'undefined') {
+    statusCode = target.status
+  } else if (response) {
+    statusCode = response.status
+  }
+  context.http.status_code = statusCode
+  return context
+}
+
+export function addSpanContext(span, data) {
+  if (!data) {
+    return
+  }
+  const { type } = span
+  let context
+  switch (type) {
+    case 'external':
+      context = getExternalContext(data)
+      break
+    case 'resource':
+      context = getResourceContext(data)
+      break
+  }
+  span.addContext(context)
+}
+
+export function addTransactionContext(transaction, configContext) {
+  const pageContext = getPageMetadata()
+  let responseContext = {}
+  if (
+    transaction.type === PAGE_LOAD &&
+    typeof performance.getEntriesByType === 'function'
+  ) {
+    let entries = performance.getEntriesByType('navigation')
+    if (entries && entries.length > 0) {
+      responseContext = {
+        response: getResponseContext(entries[0])
+      }
+    }
+  }
+  transaction.addContext(pageContext, responseContext, configContext)
+}

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -88,7 +88,7 @@ function getExternalContext(data) {
   }
 
   let statusCode
-  if (target) {
+  if (target && typeof target.status !== 'undefined') {
     statusCode = target.status
   } else if (response) {
     statusCode = response.status

--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -26,6 +26,7 @@
 import { Promise } from 'es6-promise'
 import { globalState } from './patch-utils'
 import { SCHEDULE, INVOKE, FETCH } from '../constants'
+import { scheduleMicroTask } from '../utils'
 
 export function patchFetch(callback) {
   if (!window.fetch || !window.Request) {
@@ -85,18 +86,17 @@ export function patchFetch(callback) {
       }
 
       promise.then(
-        function(response) {
+        response => {
           resolve(response)
-
           // invokeTask in the next execution cycle to let the promise resolution complete
-          Promise.resolve().then(() => {
+          scheduleMicroTask(() => {
             task.data.response = response
             invokeTask(task)
           })
         },
-        function(error) {
+        error => {
           reject(error)
-          Promise.resolve().then(() => {
+          scheduleMicroTask(() => {
             task.data.error = error
             invokeTask(task)
           })

--- a/packages/rum-core/src/common/url.js
+++ b/packages/rum-core/src/common/url.js
@@ -142,8 +142,8 @@ class Url {
      */
     if (/:\d+$/.test(this.host)) {
       const value = this.host.split(':')
-      this.port = value[1]
-      this.hostname = value[0]
+      this.port = value.pop()
+      this.hostname = value.join(':')
     } else {
       this.hostname = this.host
       this.port =

--- a/packages/rum-core/src/common/url.js
+++ b/packages/rum-core/src/common/url.js
@@ -58,7 +58,7 @@ const RULES = [
   ['?', 'query'],
   ['/', 'path'],
   ['@', 'auth', 1],
-  [NaN, 'host', undefined, 1] //
+  [NaN, 'host', undefined, 1]
 ]
 const PROTOCOL_REGEX = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\S\s]*)/i
 
@@ -135,6 +135,20 @@ class Url {
     this.relative = relative
 
     this.protocol = protocol || location.protocol
+
+    /**
+     * Construct port and hostname from host and assign defaults based
+     * on http and https protocols
+     */
+    if (/:\d+$/.test(this.host)) {
+      const value = this.host.split(':')
+      this.port = value[1]
+      this.hostname = value[0]
+    } else {
+      this.hostname = this.host
+      this.port =
+        this.protocol === 'http:' ? 80 : this.protocol === 'https:' ? 443 : ''
+    }
 
     this.origin =
       this.protocol && this.host && this.protocol !== 'file:'

--- a/packages/rum-core/src/common/url.js
+++ b/packages/rum-core/src/common/url.js
@@ -147,7 +147,11 @@ class Url {
     } else {
       this.hostname = this.host
       this.port =
-        this.protocol === 'http:' ? 80 : this.protocol === 'https:' ? 443 : ''
+        this.protocol === 'http:'
+          ? '80'
+          : this.protocol === 'https:'
+          ? '443'
+          : ''
     }
 
     this.origin =

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -213,9 +213,7 @@ class PerformanceMonitoring {
     if (duration > transactionDurationThreshold) {
       if (__DEV__) {
         this._logginService.debug(
-          `transaction(${tr.id}, ${
-            tr.name
-          }) was discarded! Transaction duration (${duration}) is greater than the transactionDurationThreshold configuration (${transactionDurationThreshold})`
+          `transaction(${tr.id}, ${tr.name}) was discarded! Transaction duration (${duration}) is greater than the transactionDurationThreshold configuration (${transactionDurationThreshold})`
         )
       }
       return false
@@ -224,9 +222,7 @@ class PerformanceMonitoring {
     if (tr.spans.length === 0) {
       if (__DEV__) {
         this._logginService.debug(
-          `transaction(${tr.id}, ${
-            tr.name
-          }) was discarded! Transaction does not include any spans`
+          `transaction(${tr.id}, ${tr.name}) was discarded! Transaction does not include any spans`
         )
       }
       return false
@@ -254,9 +250,7 @@ class PerformanceMonitoring {
       if (!wasBrowserResponsive) {
         if (__DEV__) {
           this._logginService.debug(
-            `transaction(${tr.id}, ${
-              tr.name
-            }) was discarded! Browser was not responsive enough during the transaction.`,
+            `transaction(${tr.id}, ${tr.name}) was discarded! Browser was not responsive enough during the transaction.`,
             ' duration:',
             duration,
             ' browserResponsivenessCounter:',

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -213,7 +213,9 @@ class PerformanceMonitoring {
     if (duration > transactionDurationThreshold) {
       if (__DEV__) {
         this._logginService.debug(
-          `transaction(${tr.id}, ${tr.name}) was discarded! Transaction duration (${duration}) is greater than the transactionDurationThreshold configuration (${transactionDurationThreshold})`
+          `transaction(${tr.id}, ${
+            tr.name
+          }) was discarded! Transaction duration (${duration}) is greater than the transactionDurationThreshold configuration (${transactionDurationThreshold})`
         )
       }
       return false
@@ -222,7 +224,9 @@ class PerformanceMonitoring {
     if (tr.spans.length === 0) {
       if (__DEV__) {
         this._logginService.debug(
-          `transaction(${tr.id}, ${tr.name}) was discarded! Transaction does not include any spans`
+          `transaction(${tr.id}, ${
+            tr.name
+          }) was discarded! Transaction does not include any spans`
         )
       }
       return false
@@ -250,7 +254,9 @@ class PerformanceMonitoring {
       if (!wasBrowserResponsive) {
         if (__DEV__) {
           this._logginService.debug(
-            `transaction(${tr.id}, ${tr.name}) was discarded! Browser was not responsive enough during the transaction.`,
+            `transaction(${tr.id}, ${
+              tr.name
+            }) was discarded! Browser was not responsive enough during the transaction.`,
             ' duration:',
             duration,
             ' browserResponsivenessCounter:',

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -77,10 +77,10 @@ class SpanBase {
     keys.forEach(k => setLabel(k, tags[k], ctx.tags))
   }
 
-  addContext(context) {
-    if (!context) return
+  addContext(...context) {
+    if (context.length === 0) return
     this.ensureContext()
-    merge(this.context, context)
+    merge(this.context, ...context)
   }
 
   end(endTime) {

--- a/packages/rum-core/src/performance-monitoring/span.js
+++ b/packages/rum-core/src/performance-monitoring/span.js
@@ -24,6 +24,7 @@
  */
 
 import SpanBase from './span-base'
+import { addSpanContext } from '../common/context'
 
 class Span extends SpanBase {
   constructor(name, type, options) {
@@ -38,6 +39,11 @@ class Span extends SpanBase {
       this.action = fields[2]
     }
     this.sync = this.options.sync
+  }
+
+  end(endTime, data) {
+    super.end(endTime)
+    addSpanContext(this, data)
   }
 }
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -34,6 +34,7 @@ import {
   TRANSACTION_END,
   BROWSER_RESPONSIVENESS_INTERVAL
 } from '../common/constants'
+import { addTransactionContext } from '../common/context'
 import { __DEV__ } from '../env'
 
 class TransactionService {
@@ -221,6 +222,9 @@ class TransactionService {
         if (breakdownMetrics) {
           tr.captureBreakdown()
         }
+        const configContext = this._config.get('context')
+        addTransactionContext(tr, configContext)
+
         this._config.events.send(TRANSACTION_END, [tr])
         if (__DEV__) {
           this._logger.debug(`end transaction(${tr.id}, ${tr.name})`, tr)

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -31,7 +31,6 @@ import {
   now,
   getTime,
   extend,
-  getPageMetadata,
   removeInvalidChars
 } from '../common/utils'
 import { REUSABILITY_THRESHOLD } from '../common/constants'
@@ -130,10 +129,6 @@ class Transaction extends SpanBase {
       span.type = span.type + '.truncated'
       span.end(endTime)
     }
-
-    const metadata = getPageMetadata()
-    this.addContext(metadata)
-
     this.callOnEnd()
   }
 

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -45,8 +45,6 @@ function generateTransaction(count, breakdown = false) {
     span1.end()
     span1.id = 'span-id-' + i + '-1'
     tr.end()
-    tr.context.page.referer = 'referer'
-    tr.context.page.url = 'url'
     tr._start = 10
     tr._end = 1000
     span1._start = 20
@@ -403,9 +401,9 @@ describe('ApmServer', function() {
     var result = apmServer.ndjsonTransactions(trs)
     /* eslint-disable max-len */
     var expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n'
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n'
     ]
     expect(result).toEqual(expected)
   })
@@ -416,7 +414,7 @@ describe('ApmServer', function() {
     const result = apmServer.ndjsonTransactions(payload)
     /* eslint-disable max-len */
     const expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"context":{"page":{"referer":"referer","url":"url"}},"span_count":{"started":1},"sampled":true}}\n',
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true}}\n',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -70,7 +70,7 @@ describe('Context', () => {
           type: 'external'
         },
         address: 'testing.local',
-        port: '1234'
+        port: 1234
       }
     })
 
@@ -89,7 +89,7 @@ describe('Context', () => {
           type: 'external'
         },
         address: 'www.elastic.co',
-        port: '443'
+        port: 443
       }
     })
 
@@ -108,7 +108,7 @@ describe('Context', () => {
           type: 'external'
         },
         address: '::1',
-        port: '80'
+        port: 80
       }
     })
 
@@ -131,7 +131,7 @@ describe('Context', () => {
           type: 'external'
         },
         address: '::1',
-        port: '80'
+        port: 80
       }
     })
   })
@@ -160,7 +160,7 @@ describe('Context', () => {
           type: 'resource'
         },
         address: 'example.com',
-        port: '80'
+        port: 80
       }
     })
   })

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -79,7 +79,7 @@ describe('Context', () => {
     expect(span.context).toEqual({
       http: {
         method: 'GET',
-        url,
+        url: 'https://www.elastic.co/products/apm',
         status_code: 200
       },
       destination: {
@@ -112,6 +112,10 @@ describe('Context', () => {
       }
     })
 
+    /**
+     * Explicit test to account for service name
+     * default scheme and port
+     */
     url = 'https://[::1]:80/'
     span = createSpanWithData(url)
     expect(span.context).toEqual({
@@ -153,7 +157,7 @@ describe('Context', () => {
         service: {
           name: 'http://example.com',
           resource: 'example.com:80',
-          type: 'external'
+          type: 'resource'
         },
         address: 'example.com',
         port: '80'

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -1,0 +1,170 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { addSpanContext, addTransactionContext } from '../../src/common/context'
+import resourceEntries from '../fixtures/resource-entries'
+import Span from '../../src/performance-monitoring/span'
+import Transaction from '../../src/performance-monitoring/transaction'
+import { PAGE_LOAD } from '../../src/common/constants'
+import { mockGetEntriesByType } from '../utils/globals-mock'
+
+describe('Context', () => {
+  function createSpanWithData(url) {
+    const span = new Span(`GET ${url}`, 'external')
+    const data = {
+      url,
+      method: 'GET',
+      response: {
+        status: 200
+      }
+    }
+    span.end()
+    addSpanContext(span, data)
+    return span
+  }
+
+  it('should add external span context with all fields', () => {
+    let url = 'http://user:pass@testing.local:1234/path?query'
+    let span = createSpanWithData(url)
+    expect(span.context).toEqual({
+      http: {
+        method: 'GET',
+        url: 'http://[REDACTED]:[REDACTED]@testing.local:1234/path?query',
+        status_code: 200
+      },
+      destination: {
+        service: {
+          name: 'http://testing.local:1234',
+          resource: 'testing.local:1234',
+          type: 'external'
+        },
+        address: 'testing.local',
+        port: '1234'
+      }
+    })
+
+    url = 'https://www.elastic.co:443/products/apm'
+    span = createSpanWithData(url)
+    expect(span.context).toEqual({
+      http: {
+        method: 'GET',
+        url,
+        status_code: 200
+      },
+      destination: {
+        service: {
+          name: 'https://www.elastic.co',
+          resource: 'www.elastic.co:443',
+          type: 'external'
+        },
+        address: 'www.elastic.co',
+        port: '443'
+      }
+    })
+
+    url = 'http://[::1]/'
+    span = createSpanWithData(url)
+    expect(span.context).toEqual({
+      http: {
+        method: 'GET',
+        url,
+        status_code: 200
+      },
+      destination: {
+        service: {
+          name: 'http://[::1]',
+          resource: '[::1]:80',
+          type: 'external'
+        },
+        address: '[::1]',
+        port: 80
+      }
+    })
+  })
+
+  it('should add resource timing span context correctly', () => {
+    const url = 'http://example.com'
+
+    const entry = resourceEntries.filter(({ name }) => name === url)[0]
+    const span = new Span(url, 'resource')
+    span.end()
+    addSpanContext(span, { url, entry })
+
+    expect(span.context).toEqual({
+      http: {
+        url,
+        response: {
+          transfer_size: 97918,
+          encoded_body_size: 97717,
+          decoded_body_size: 97717
+        }
+      }
+    })
+  })
+
+  it('should enrich transaction with context info based on type', () => {
+    const transaction = new Transaction('test', 'custom')
+    transaction.end()
+    const configContext = {
+      user: {
+        email: 'test@example.com',
+        id: '123'
+      },
+      tags: {
+        message: 'test'
+      }
+    }
+    addTransactionContext(transaction, configContext)
+    expect(transaction.context).toEqual({
+      page: {
+        referer: jasmine.any(String),
+        url: jasmine.any(String)
+      },
+      ...configContext
+    })
+
+    const unmock = mockGetEntriesByType()
+    const pageloadTr = new Transaction('test', PAGE_LOAD)
+    pageloadTr.end()
+    addTransactionContext(pageloadTr, configContext)
+    expect(pageloadTr.context).toEqual({
+      page: {
+        referer: jasmine.any(String),
+        url: jasmine.any(String)
+      },
+      response: {
+        transfer_size: 26941,
+        encoded_body_size: 105297,
+        decoded_body_size: 42687,
+        headers: {
+          'server-timing': 'edge;dur=4, cdn-cache;desc=HIT'
+        }
+      },
+      ...configContext
+    })
+
+    unmock()
+  })
+})

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -227,24 +227,36 @@ describe('Url parser', function() {
   it('should parse port and hostname correctly from host', () => {
     expect(new Url('http://test.com')).toEqual(
       jasmine.objectContaining({
-        port: 80,
+        port: '80',
         host: 'test.com',
         hostname: 'test.com'
       })
     )
     expect(new Url('https://test.com')).toEqual(
       jasmine.objectContaining({
-        port: 443,
+        port: '443',
         host: 'test.com',
         hostname: 'test.com'
       })
     )
-    const result = new Url('http://[::1]/')
-
-    expect(result).toEqual(
+    expect(new Url('https://test.com')).toEqual(
       jasmine.objectContaining({
-        port: 80,
+        port: '443',
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    expect(new Url('http://[::1]/')).toEqual(
+      jasmine.objectContaining({
+        port: '80',
         host: '[::1]',
+        hostname: '[::1]'
+      })
+    )
+    expect(new Url('https://[::1]:8080/')).toEqual(
+      jasmine.objectContaining({
+        port: '8080',
+        host: '[::1]:8080',
         hostname: '[::1]'
       })
     )

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -223,4 +223,30 @@ describe('Url parser', function() {
       })
     )
   })
+
+  it('should parse port and hostname correctly from host', () => {
+    expect(new Url('http://test.com')).toEqual(
+      jasmine.objectContaining({
+        port: 80,
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    expect(new Url('https://test.com')).toEqual(
+      jasmine.objectContaining({
+        port: 443,
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    const result = new Url('http://[::1]/')
+
+    expect(result).toEqual(
+      jasmine.objectContaining({
+        port: 80,
+        host: '[::1]',
+        hostname: '[::1]'
+      })
+    )
+  })
 })

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -224,31 +224,38 @@ describe('Url parser', function() {
     )
   })
 
-  it('should parse port and hostname correctly from host', () => {
+  it('should parse port and hostname correctly for different schemes', () => {
     expect(new Url('http://test.com')).toEqual(
       jasmine.objectContaining({
+        port: '',
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    expect(new Url('https://test.com')).toEqual(
+      jasmine.objectContaining({
+        port: '',
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    expect(new Url('https://test.com:443')).toEqual(
+      jasmine.objectContaining({
+        port: '',
+        host: 'test.com',
+        hostname: 'test.com'
+      })
+    )
+    expect(new Url('https://test.com:80')).toEqual(
+      jasmine.objectContaining({
         port: '80',
-        host: 'test.com',
-        hostname: 'test.com'
-      })
-    )
-    expect(new Url('https://test.com')).toEqual(
-      jasmine.objectContaining({
-        port: '443',
-        host: 'test.com',
-        hostname: 'test.com'
-      })
-    )
-    expect(new Url('https://test.com')).toEqual(
-      jasmine.objectContaining({
-        port: '443',
-        host: 'test.com',
+        host: 'test.com:80',
         hostname: 'test.com'
       })
     )
     expect(new Url('http://[::1]/')).toEqual(
       jasmine.objectContaining({
-        port: '80',
+        port: '',
         host: '[::1]',
         hostname: '[::1]'
       })

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -497,6 +497,15 @@ describe('PerformanceMonitoring', function() {
               method: 'GET',
               url: 'http://localhost:9876/?a=b&c=d',
               status_code: 200
+            },
+            destination: {
+              service: {
+                name: 'http://localhost:9876',
+                resource: 'localhost:9876',
+                type: 'external'
+              },
+              address: 'localhost',
+              port: '9876'
             }
           })
           expect(dTHeaderValue).toBeDefined()

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -505,7 +505,7 @@ describe('PerformanceMonitoring', function() {
                 type: 'external'
               },
               address: 'localhost',
-              port: '9876'
+              port: 9876
             }
           })
           expect(dTHeaderValue).toBeDefined()

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -76,13 +76,6 @@ describe('transaction.Transaction', function() {
     tr.end()
   })
 
-  it('should store context.page.url', function() {
-    var tr = new Transaction('/', 'transaction')
-    tr.detectFinish()
-    var location = tr.context.page.url
-    expect(location).toBe(window.location.href)
-  })
-
   it('should redefine transaction', function() {
     var tr = new Transaction('/', 'transaction')
     tr.redefine('name', 'type', { test: 'test' })


### PR DESCRIPTION
+ relates elastic/apm-agent-rum-js#490 elastic/apm-agent-rum-js#513 
+ Add the necessary `span.desination.*` fields for all outgoing spans to help with service maps and siem intergration
+ This PR changes the overall context addition which happens across multiple place and unifies them in a single place to ease the development and addition of new fields on context easier. 
+ Custom URL parser is enhanced with more fields `port` and `hostname` to make the destinations fields addition easier. 
+ Context addition happens on span end and transaction end instead of doing it during the middle of the transaction and span creation process. 

## TODO
+ [x] Fix parsing of hostname for `http://[::1]:8080/`
+ [x] Add tests for context
+ [x] Add tests for URL parsing of port and hostname