### PR TITLE
[4.x][docs] Add placeholder changelog.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,0 +1,1 @@
+This is a placeholder file. Release notes are published in CHANGELOG.md


### PR DESCRIPTION
As discussed on slack, this adds a placeholder `changelog.asciidoc` file so that your next release doesn't blow up the doc build.

For https://github.com/elastic/apm-agent-rum-js/issues/511.