### PR TITLE
refactor(rum): small optimizations on the transaction service

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -44,17 +44,16 @@ class TransactionService {
   }
 
   ensureCurrentTransaction(options) {
+    const tr = this.getCurrentTransaction()
+    if (tr) {
+      return tr
+    }
     if (!options) {
       options = this.createOptions()
     }
-    var tr = this.getCurrentTransaction()
-    if (tr) {
-      return tr
-    } else {
-      options.canReuse = true
-      options.managed = true
-      return this.createTransaction(undefined, undefined, options)
-    }
+    options.canReuse = true
+    options.managed = true
+    return this.createTransaction(undefined, undefined, options)
   }
 
   getCurrentTransaction() {
@@ -68,9 +67,9 @@ class TransactionService {
   }
 
   createTransaction(name, type, options) {
-    var tr = new Transaction(name, type, options)
+    const tr = new Transaction(name, type, options)
     this.setCurrentTransaction(tr)
-    if (options.checkBrowserResponsiveness) {
+    if (type !== PAGE_LOAD && options.checkBrowserResponsiveness) {
       this.startCounter(tr)
     }
     return tr

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -123,15 +123,11 @@ class ApmBase {
   }
 
   _sendPageLoadMetrics() {
-    const transactionService = this.serviceFactory.getService(
-      'TransactionService'
-    )
-
     /**
      * Name of the transaction is set in transaction service to
      * avoid duplicating the logic at multiple places
      */
-    const tr = transactionService.startTransaction(undefined, PAGE_LOAD, {
+    const tr = this.startTransaction(undefined, PAGE_LOAD, {
       managed: true,
       canReuse: true
     })


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#522 
+ Options would be created only when there is no transaction exists
+ transaction responsiveness counter should not get started for page-load transactions. We could also get rid of this logic, but I am going to leave it to the other refactor elastic/apm-agent-rum-js#530 