### PR TITLE
chore(rum-core): tests for sending span destination context to server

### DIFF
--- a/packages/rum-core/src/common/truncate.js
+++ b/packages/rum-core/src/common/truncate.js
@@ -50,6 +50,13 @@ const RESPONSE_MODEL = {
   }
 }
 
+const DESTINATION_MODEL = {
+  address: [KEYWORD_LIMIT],
+  service: {
+    '*': [KEYWORD_LIMIT, true]
+  }
+}
+
 const CONTEXT_MODEL = {
   user: {
     id: true,
@@ -63,6 +70,7 @@ const CONTEXT_MODEL = {
   http: {
     response: RESPONSE_MODEL
   },
+  destination: DESTINATION_MODEL,
   /** Transactions */
   response: RESPONSE_MODEL
 }
@@ -174,5 +182,6 @@ export {
   SPAN_MODEL,
   TRANSACTION_MODEL,
   ERROR_MODEL,
-  METADATA_MODEL
+  METADATA_MODEL,
+  RESPONSE_MODEL
 }

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -23,7 +23,11 @@
  *
  */
 
-import { truncate, truncateModel } from '../../src/common/truncate'
+import {
+  truncate,
+  truncateModel,
+  RESPONSE_MODEL
+} from '../../src/common/truncate'
 
 /**
  * Dummy models to make the testing easier
@@ -39,13 +43,6 @@ const getMetadataModel = limit => ({
   }
 })
 
-const RESPONSE_MODEL = {
-  '*': true,
-  headers: {
-    '*': true
-  }
-}
-
 const getContextModel = limit => ({
   user: {
     id: [limit],
@@ -57,6 +54,12 @@ const getContextModel = limit => ({
   },
   http: {
     response: RESPONSE_MODEL
+  },
+  destination: {
+    address: [limit],
+    service: {
+      '*': [limit, true]
+    }
   },
   response: RESPONSE_MODEL
 })
@@ -258,6 +261,15 @@ describe('Truncate', () => {
               fg: ''
             }
           }
+        },
+        destination: {
+          address: generateStr('i', keywordLen),
+          port: 8080,
+          service: {
+            name: generateStr('j', keywordLen),
+            resource: '',
+            type: generateStr('l', keywordLen)
+          }
         }
       }
     }
@@ -290,6 +302,15 @@ describe('Truncate', () => {
           response: {
             cb: 2134,
             headers: {}
+          }
+        },
+        destination: {
+          address: generateStr('i', stringLimit),
+          port: 8080,
+          service: {
+            name: generateStr('j', stringLimit),
+            resource: 'N/A',
+            type: generateStr('l', stringLimit)
           }
         }
       }

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -725,16 +725,15 @@ describe('PerformanceMonitoring', function() {
     setTimeout(() => {
       performanceMonitoring.processAPICalls('invoke', task)
       expect(tr.ended).toBe(true)
-      let payload = performanceMonitoring.convertTransactionsToServerModel([tr])
-      let promise = apmServer.sendTransactions(payload)
-      promise
-        .catch(reason => {
-          fail(
-            'Failed sending http-request transaction to the server, reason: ' +
-              reason
-          )
-        })
-        .then(() => done())
+      const payload = performanceMonitoring.convertTransactionsToServerModel([
+        tr
+      ])
+
+      apmServer.sendTransactions(payload).then(done, reason => {
+        done.fail(
+          `Failed sending http-request transaction to the server, reason: ${reason}`
+        )
+      })
     }, 100)
   })
 
@@ -799,14 +798,11 @@ describe('PerformanceMonitoring', function() {
       expect(payload[0].spans[0].context.destination).toBeDefined()
       expect(payload[0].spans[1].context.destination).toBeDefined()
 
-      apmServer
-        .sendTransactions(payload)
-        .catch(reason => {
-          fail(
-            'Failed sending span destination context details, reason: ' + reason
-          )
-        })
-        .then(() => done())
+      apmServer.sendTransactions(payload).then(done, reason => {
+        done.fail(
+          `Failed sending span destination context details, reason: ${reason}`
+        )
+      })
     })
 
     tr.end()


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#490
+ Tested manually with the latest APM-server master. 