### PR TITLE
chore(rum-core): add native URL parser tests aganist polyfill

### DIFF
--- a/packages/rum-core/karma.conf.js
+++ b/packages/rum-core/karma.conf.js
@@ -37,4 +37,5 @@ module.exports = function(config) {
   )
   preparedConfig.files.unshift(promisepolyfill)
   config.set(preparedConfig)
+  config.files = ['test/common/url.spec.js']
 }

--- a/packages/rum-core/karma.conf.js
+++ b/packages/rum-core/karma.conf.js
@@ -37,5 +37,4 @@ module.exports = function(config) {
   )
   preparedConfig.files.unshift(promisepolyfill)
   config.set(preparedConfig)
-  config.files = ['test/common/url.spec.js']
 }

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -271,10 +271,13 @@ describe('Url parser', function() {
 })
 
 /**
+ * Test native URL implementation only on supported platforms
  * In IE 11 - window.URL is not supported but it exists as an object
- * Run these tests only on supported platforms
+ * Microsoft Edge URL parsing for IPv6 is broken on `host` and `hostnames`
  */
-if (window.URL.toString().indexOf('native code') !== -1) {
+const userAgent = window.navigator.userAgent
+const browsersToIgnore = /(Trident|Edge)/
+if (userAgent && !browsersToIgnore.test(userAgent)) {
   describe('Native URL API Compatability', () => {
     function commonFields(url) {
       const native = new URL(url)

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -273,12 +273,10 @@ describe('Url parser', function() {
 /**
  * Test native URL implementation only on supported platforms
  * In IE 11 - window.URL is not supported but it exists as an object
- * Microsoft Edge URL parsing for IPv6 is broken on `host` and `hostnames`
  */
 const userAgent = window.navigator.userAgent
-const browsersToIgnore = /(Trident|Edge)/
-if (userAgent && !browsersToIgnore.test(userAgent)) {
-  describe('Native URL API Compatability', () => {
+if (window.URL.toString().indexOf('native code') !== -1) {
+  describe('Native URL API Compatibility', () => {
     function commonFields(url) {
       const native = new URL(url)
       const polyfill = new Url(url)
@@ -296,8 +294,6 @@ if (userAgent && !browsersToIgnore.test(userAgent)) {
       commonFields('https://test.com/path')
       commonFields('https://test.com:443/path#d')
       commonFields('https://test.com:8080/path?a=c#d')
-      commonFields('http://[::1]/')
-      commonFields('https://[::1]:8080/')
     })
 
     it('field names that are different name from native', () => {
@@ -339,6 +335,25 @@ if (userAgent && !browsersToIgnore.test(userAgent)) {
       expect(native.href).toBe(polyfill.href)
       expect(native.origin).toBe(polyfill.origin)
       expect(native.pathname).toBe(polyfill.path)
+    })
+
+    /**
+     * Microsoft Edge URL parsing for IPv6  works differently
+     * for `host` and `hostnames`
+     */
+    const isMsEdge = /Edge/.test(userAgent)
+
+    it('IPv6 parisng works different in Edge native URL implementation', () => {
+      const url = 'http://[::1]:8080/'
+
+      if (isMsEdge) {
+        const native = new URL(url)
+        expect(native.host).toBe('::1:8080')
+        expect(native.hotname).toBe('::1')
+        expect(native.origin).toBe('http://::1:8080')
+      } else {
+        commonFields(url)
+      }
     })
   })
 }

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -269,3 +269,26 @@ describe('Url parser', function() {
     )
   })
 })
+
+describe('Native URL API Compatability', () => {
+  function commonFields(url) {
+    const native = new URL(url)
+    const polyfill = new Url(url)
+    expect(native.href).toBe(polyfill.href)
+    expect(native.origin).toBe(polyfill.origin)
+    expect(native.protocol).toBe(polyfill.protocol)
+    expect(native.host).toBe(polyfill.host)
+    expect(native.hostname).toBe(polyfill.hostname)
+    expect(native.port).toBe(polyfill.port)
+  }
+
+  it('should be close to native implementation on most of the fields', () => {
+    commonFields('http://test.com/path')
+    commonFields('https://test.com/path')
+    commonFields('https://test.com:443/path')
+    commonFields('https://test.com:8080/path')
+    commonFields('http://[::1]/')
+    commonFields('https://[::1]:8080/')
+    commonFields('http://a@b?@c')
+  })
+})

--- a/packages/rum-core/test/common/url.spec.js
+++ b/packages/rum-core/test/common/url.spec.js
@@ -305,24 +305,6 @@ if (window.URL.toString().indexOf('native code') !== -1) {
       expect(native.search).toBe(polyfill.query)
     })
 
-    it('url with authentication parsing varies', () => {
-      let url = 'http://a@b?@c'
-      let native = new URL(url)
-      let polyfill = new Url(url)
-
-      expect(native.username).toBe(polyfill.auth)
-      expect(native.host).toBe(polyfill.host)
-      expect(native.search).toBe(polyfill.query)
-
-      url = 'http://a:b@c/'
-      native = new URL(url)
-      polyfill = new Url(url)
-
-      expect(`${native.username}:${native.password}`).toBe(polyfill.auth)
-      expect(native.href).toBe(url)
-      expect(polyfill.href).toBe('http://[REDACTED]:[REDACTED]@c/')
-    })
-
     it('relative URL parsing varies ', () => {
       let url = '/test/?a=b'
       /**
@@ -337,23 +319,47 @@ if (window.URL.toString().indexOf('native code') !== -1) {
       expect(native.pathname).toBe(polyfill.path)
     })
 
+    const isMsEdge = /Edge/.test(userAgent)
     /**
      * Microsoft Edge URL parsing for IPv6  works differently
      * for `host` and `hostnames`
      */
-    const isMsEdge = /Edge/.test(userAgent)
 
-    it('IPv6 parisng works different in Edge native URL implementation', () => {
+    it('should parse IPv6 addres correctly', () => {
       const url = 'http://[::1]:8080/'
 
       if (isMsEdge) {
         const native = new URL(url)
         expect(native.host).toBe('::1:8080')
-        expect(native.hotname).toBe('::1')
+        expect(native.hostname).toBe('::1')
         expect(native.origin).toBe('http://::1:8080')
       } else {
         commonFields(url)
       }
     })
+
+    /**
+     * Microsoft Edge URL parsing would throw Security Error
+     * when URL has a username and password fields associated.
+     */
+    if (!isMsEdge) {
+      it('url with authentication parsing varies', () => {
+        let url = 'http://a@b?@c'
+        let native = new URL(url)
+        let polyfill = new Url(url)
+
+        expect(native.username).toBe(polyfill.auth)
+        expect(native.host).toBe(polyfill.host)
+        expect(native.search).toBe(polyfill.query)
+
+        url = 'http://a:b@c/'
+        native = new URL(url)
+        polyfill = new Url(url)
+
+        expect(`${native.username}:${native.password}`).toBe(polyfill.auth)
+        expect(native.href).toBe(url)
+        expect(polyfill.href).toBe('http://[REDACTED]:[REDACTED]@c/')
+      })
+    }
   })
 }


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#534 
+ Added incompatible tests in separate level to identify if we can align with spec closer in future. 