### PR TITLE
BREAKING CHANGE: change agent name to rum-js

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -63,7 +63,7 @@ class ApmServer {
         name: cfg.get('serviceName'),
         version: cfg.get('serviceVersion'),
         agent: {
-          name: 'js-base',
+          name: 'rum-js',
           version: cfg.version
         },
         language: {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -373,7 +373,7 @@ describe('ApmServer', function() {
         version: '0.0.1',
         environment: 'staging',
         agent: {
-          name: 'js-base',
+          name: 'rum-js',
           version: '4.0.1'
         },
         language: { name: 'javascript' }


### PR DESCRIPTION
This PR changes the agent name to `rum-js`.
- Both APM UI and APM server already support both names on 7.x versions, however this is a breaking change for version 6.x 

Fixes #379
**Please don't merge yet.**