### PR TITLE
feat(rum-vue): only hook router if provided

### DIFF
--- a/packages/rum-vue/src/index.js
+++ b/packages/rum-vue/src/index.js
@@ -34,7 +34,13 @@ export const ApmVuePlugin = {
      */
     apm.init(config)
 
-    routeHooks(router, apm)
+    /**
+     * Hook router if provided
+     */
+    if (router) {
+      routeHooks(router, apm)
+    }
+
     /**
      * Provide it via $apm to be accessed in all Vue Components
      */


### PR DESCRIPTION
Not all projects will use router, but the plugin currently assumes router is always provided.