### PR TITLE
chore: run e2e tests locally on chrome & firefox headless

### DIFF
--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -26,7 +26,11 @@
 const { Promise } = require('es6-promise')
 const { join } = require('path')
 const glob = require('glob')
-const { getSauceConnectOptions, getBrowserList } = require('./test-config')
+const {
+  getSauceConnectOptions,
+  getBrowserList,
+  getTestEnvironmentVariables
+} = require('./test-config')
 
 const logLevels = {
   ALL: { value: Number.MIN_VALUE },
@@ -155,7 +159,7 @@ function getWebdriveBaseConfig(
     ...capability
   }))
 
-  return {
+  const baseConfig = {
     runner: 'local',
     specs: glob.sync(join(path, specs)),
     maxInstancesPerCapability: 3,
@@ -203,6 +207,30 @@ function getWebdriveBaseConfig(
       }
     }
   }
+
+  const { sauceLabs } = getTestEnvironmentVariables()
+
+  if (!sauceLabs) {
+    Object.assign(baseConfig, {
+      automationProtocol: 'devtools',
+      capabilities: [
+        {
+          browserName: 'chrome',
+          'goog:chromeOptions': {
+            headless: true
+          }
+        },
+        {
+          browserName: 'firefox',
+          'moz:firefoxOptions': {
+            headless: true
+          }
+        }
+      ]
+    })
+  }
+
+  return baseConfig
 }
 
 function waitForApmServerCalls(errorCount = 0, transactionCount = 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6837,6 +6837,30 @@
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
+    "chrome-launcher": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.11.2.tgz",
+      "integrity": "sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "is-wsl": "^2.1.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "^2.6.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -8806,6 +8830,44 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
+    "devtools": {
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-5.18.4.tgz",
+      "integrity": "sha512-TxYUwRQNL3I9FLjJ0ac7qNuo9EDCL4lnncZp0cVfuEnFGpdtYOW6Vm8GyG3VWXSEgxWpDGTRqhd9ytsIe3Q20g==",
+      "dev": true,
+      "requires": {
+        "@wdio/config": "5.18.4",
+        "@wdio/logger": "5.16.10",
+        "@wdio/protocols": "5.16.7",
+        "@wdio/utils": "5.16.15",
+        "chrome-launcher": "^0.11.1",
+        "puppeteer-core": "^1.18.1",
+        "puppeteer-firefox": "^0.5.0"
+      },
+      "dependencies": {
+        "@wdio/config": {
+          "version": "5.18.4",
+          "resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.18.4.tgz",
+          "integrity": "sha512-HQugjG+BABDYG/1dPR6KA+IQilsg1MSQ/NVIg8R6I8ER9MA2JNIoaxvXZ+CnDfgY/QpyIHEeqJhfgw8GElaPdw==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "5.16.10",
+            "deepmerge": "^4.0.0",
+            "glob": "^7.1.2"
+          }
+        },
+        "@wdio/utils": {
+          "version": "5.16.15",
+          "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-5.16.15.tgz",
+          "integrity": "sha512-xeZSAeDtzm1+zVRjTuhsEKpcXokOZU1NrnXBacNNwyKIfRMwPUmyOX3WvKtHL+2OuLXjKP9dlRMHbPgX/nsz4w==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "5.16.10",
+            "deepmerge": "^4.0.0"
+          }
+        }
+      }
+    },
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -9408,6 +9470,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -12338,6 +12401,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
       "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -12347,6 +12411,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
           "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -12355,6 +12420,7 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -14041,6 +14107,33 @@
         "immediate": "~3.0.5"
       }
     },
+    "lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -14853,6 +14946,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marky": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+      "dev": true
+    },
     "matchmedia-polyfill": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/matchmedia-polyfill/-/matchmedia-polyfill-0.3.2.tgz",
@@ -15293,7 +15392,8 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "multimatch": {
       "version": "3.0.0",
@@ -16818,6 +16918,94 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "puppeteer-core": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-1.20.0.tgz",
+      "integrity": "sha512-akoSCMDVv6BFd/4+dtW6mVgdaRQhy/cmkGzXcx9HAXZqnY9zXYbsfoXMiMpwt3+53U9zFGSjgvsi0mDKNJLfqg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "puppeteer-firefox": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-firefox/-/puppeteer-firefox-0.5.0.tgz",
+      "integrity": "sha512-80wl29/Lb0URQ1f77yVXfq+cxCW30Q+1GbpRb32HbzTR9/amOn6D5G99xo8OsDJ6kIfuLyYTLj6HZgwMuDPBBQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "codecov": "^3.6.1",
     "core-js": "^3.5.0",
     "cpuprofile-filter": "^1.1.0",
+    "devtools": "^5.18.4",
     "ejs": "^2.7.4",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",


### PR DESCRIPTION
+ fix #176 
+ Uses the new `devtools` package to run both chrome and firefox on headless mode to run E2E tests.

When the mode is set to `none` which is on local, we run it by default on Headless and when set to `saucelabs`,we run it on all configured test browsers. 