### PR TITLE
chore(benchmark): get predictable results on each run

### DIFF
--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -37,9 +37,16 @@ async function launchBrowser() {
 
 function gatherRawMetrics(browser, url) {
   return new Promise(async resolve => {
-    const page = await browser.newPage()
+    /**
+     * Create a separate browsing context for each run
+     */
+    const context = await browser.createIncognitoBrowserContext()
+    const page = await context.newPage()
     const client = await page.target().createCDPSession()
-
+    /**
+     * Disable cache for each run
+     */
+    await page.setCacheEnabled(false)
     /**
      * Enable events from Chrome devtools protocol
      */


### PR DESCRIPTION
+ Since the disk cache was shared between runs, the results for `basic` and `heavy` scenarios were varying by a small margin which is not the case. Now, we run the benchmark on a incognito browser context which does not share cache for each session. Makes the results predictable.  