### PR TITLE
chore: apmbase export types must reflect constructor properties

### DIFF
--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -28,6 +28,7 @@ declare module '@elastic/apm-rum' {
   const init: Init
 
   class ApmBase {
+    serviceFactory: ServiceFactory
     constructor(serviceFactory: ServiceFactory, disable: boolean)
     init: Init
     /**
@@ -53,8 +54,9 @@ declare module '@elastic/apm-rum' {
     captureError(error: Error | string): void
     addFilter(fn: FilterFn): void
   }
-  export { init, ApmBase as apm, ApmBase as apmBase, ApmBase }
+  const apmBase: ApmBase
   export default init
+  export { init, apmBase, ApmBase, apmBase as apm }
 }
 
 declare class BaseSpan {
@@ -160,6 +162,7 @@ interface Labels {
  * once available
  */
 interface ServiceFactory {
+  registerServiceInstance(name: string, instance: any): void
   getService: (name: string) => any
 }
 

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -28,6 +28,9 @@ declare module '@elastic/apm-rum' {
   const init: Init
 
   class ApmBase {
+    /**
+     * undocumented, might be removed in future versions
+     */
     serviceFactory: ServiceFactory
     constructor(serviceFactory: ServiceFactory, disable: boolean)
     init: Init

--- a/packages/rum/test/types/index.spec.ts
+++ b/packages/rum/test/types/index.spec.ts
@@ -39,6 +39,7 @@ apmBase.addLabels({})
 
 // dummy service factory
 const serviceFactory = {
+  registerServiceInstance: () => undefined,
   getService(name: string) {
     return name
   }


### PR DESCRIPTION
+ Hope this the last , figured out this from this test file https://github.com/elastic/apm-agent-rum-js/blob/master/packages/rum-angular/test/index.ts. 
+ Also matched the exported members with the one from JS to keep it clear. 

We dont use `apmBase` directly on most test so it was hard to figure out this case. 