### PR TITLE
[docs] fix broken doc build script

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -265,8 +265,8 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 
 [float]
 ===== BREAKING CHANGE
-* remove setTags in favor of addTags API ([#28](https://github.com/elastic/apm-agent-js-core/issues/28))
-* introduce subtype and action in Spans {commit}#9](https://github.com/elastic/apm-agent-js-core/issues/9)) ([5fd4af7[#9](https://github.com/elastic/apm-agent-js-core/issues/9)) ([5fd4af7]
+* remove setTags in favor of addTags API  {pull}28[#28]
+* introduce subtype and action in Spans {commit}5fd4af7[5fd4af7] {pull}9[#9]
 
 [float]
 ===== Features
@@ -296,7 +296,7 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 
 [float]
 ===== Features
-* introduce subtype and action in Spans {commit}#9](https://github.com/elastic/apm-agent-js-core/issues/9)) ([5fd4af7[#9](https://github.com/elastic/apm-agent-js-core/issues/9)) ([5fd4af7]
+* introduce subtype and action in Spans {commit}5fd4af7[5fd4af7] {pull}9[#9]
 
 [[release-notes-2.1.1]]
 ==== 2.1.1 (2018-12-05)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "lerna publish && npm run github-release",
     "release-package": "node scripts/publish-package",
     "github-release": "node scripts/github-release",
-    "build-docs": "sh ./scripts/build_docs.sh apm-agent-rum-js ./docs ./build",
+    "build-docs": "PREVIEW=1 sh ./scripts/build_docs.sh apm-agent-rum-js ./docs ./build",
     "lint": "run-p --silent lint:*",
     "lint:js": "eslint . --ext .js,.jsx,.ts",
     "lint:license": "node scripts/license-checker",

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -27,6 +27,6 @@ dest_dir="$html_dir/${name}"
 mkdir -p "$dest_dir"
 params="--chunk=1"
 if [ "$PREVIEW" = "1" ]; then
-  params="--chunk=1 --open"
+  params="$params --open"
 fi
-$docs_dir/build_docs --direct_html $params --doc "$index" --out "$dest_dir"
+$docs_dir/build_docs $params --doc "$index" --out "$dest_dir"


### PR DESCRIPTION
While trying to replicate the bug found in https://github.com/elastic/apm-agent-rum-js/issues/570, I found a different bug with the doc build script. This PR does three things:

1. Updates two broken links in `CHANGELOG.asciidoc`. Looks like my regex wasn't quite good enough when I was changing the changelog from md to asciidoc. On a related note, why does the same release message appear for 2.2, 2.2.1, and 3.0? `* introduce subtype and action in Spans {commit}5fd4af7[5fd4af7] {pull}9[#9]`. This existed in the old md file: https://github.com/elastic/apm-agent-js-core/blob/master/CHANGELOG.md.
2. Removes the `--direct-html` flag as it is now the default option.
3. Opens the documentation by default when running `npm run build-docs`. I don't know of a use case where you wouldn't want this to happen, but please let me know if there is one.