### PR TITLE
feat(rum-vue): capture errors in vue app automatically

### DIFF
--- a/docs/vue-integration.asciidoc
+++ b/docs/vue-integration.asciidoc
@@ -14,6 +14,21 @@ npm install --save @elastic/apm-rum-vue
 ----
 
 [float]
+==== Using APM Plugin
+[source,js]
+----
+Vue.use(ApmVuePlugin, options)
+----
+
+===== Options
+
+* `config` (required) - RUM agent <<configuration,configuration options>>.
+* `router` (optional) - Instance of Vue Router. If provided, will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
+* `captureErrors` (optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. Defaults to `true`.
+  The plugin captures the component name, lifecycle hook and file name (if it's available) as part of the error context.
+
+
+[float]
 ==== Instrumenting your Vue application
 
 The package exposes `ApmVuePlugin` which is a Vue Plugin and can be installed in your application using `Vue.use` method. 
@@ -46,12 +61,6 @@ Vue.use(ApmVuePlugin, {
 // app specific code
 ----
 
-[float]
-==== Options
-
-* `config` (required) - RUM agent <<configuration,configuration options>>.
-* `router` (optional) - Instance of Vue Router. If provided, will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
-* `captureErrors` (optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. Defaults to `true`.
 
 [float]
 ==== Accessing agent instance inside components

--- a/docs/vue-integration.asciidoc
+++ b/docs/vue-integration.asciidoc
@@ -51,7 +51,7 @@ Vue.use(ApmVuePlugin, {
 
 * `config` (required) - RUM agent <<configuration,configuration options>>.
 * `router` (optional) - Instance of Vue Router. If provided, will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
-* `errors` (optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. Defaults to `true`.
+* `captureErrors` (optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. Defaults to `true`.
 
 [float]
 ==== Accessing agent instance inside components

--- a/docs/vue-integration.asciidoc
+++ b/docs/vue-integration.asciidoc
@@ -49,9 +49,9 @@ Vue.use(ApmVuePlugin, {
 [float]
 ==== Options
 
-* config(required) - RUM <<configuration, agent configuration options>> as described
-* router(optional) - Instance of Vue Router, if provided will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
-* errors(optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. (Defaults to `true`)
+* `config` (required) - RUM agent <<configuration,configuration options>>.
+* `router` (optional) - Instance of Vue Router. If provided, will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
+* `errors` (optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. Defaults to `true`.
 
 [float]
 ==== Accessing agent instance inside components

--- a/docs/vue-integration.asciidoc
+++ b/docs/vue-integration.asciidoc
@@ -46,6 +46,12 @@ Vue.use(ApmVuePlugin, {
 // app specific code
 ----
 
+[float]
+==== Options
+
+* config(required) - RUM <<configuration, agent configuration options>> as described
+* router(optional) - Instance of Vue Router, if provided will start capturing both page load and SPA navigation events as transactions with path of the route as its name.
+* errors(optional) - If enabled, will install a global Vue error handler to capture render errors inside the components. (Defaults to `true`)
 
 [float]
 ==== Accessing agent instance inside components
@@ -72,8 +78,6 @@ export default {
     this.span && this.span.end()
   }
 }
-</script>
-
 </script>
 ----
 

--- a/packages/rum-vue/src/error-handler.js
+++ b/packages/rum-vue/src/error-handler.js
@@ -33,8 +33,14 @@ export function getErrorHandler(Vue, apm) {
   return (error, vm, info) => {
     if (vm && vm.$options) {
       const options = vm.$options
+      let component
+      if (vm.$root === vm) {
+        component = 'Root'
+      } else {
+        component = options.name || options._componentTag || 'Anonymous'
+      }
 
-      error.component = options.name || options._componentTag || 'anonymous'
+      error.component = component
       error.file = options.__file || ''
     }
 

--- a/packages/rum-vue/src/error-handler.js
+++ b/packages/rum-vue/src/error-handler.js
@@ -23,7 +23,7 @@
  *
  */
 
-export function setUpErrorHandler(Vue, apm) {
+export function getErrorHandler(Vue, apm) {
   /**
    * If the user already installed a global error handler
    * we should call them after capturing it internally
@@ -33,9 +33,8 @@ export function setUpErrorHandler(Vue, apm) {
   return (error, vm, info) => {
     if (vm && vm.$options) {
       const options = vm.$options
-      const component = options.name || options._componentTag
 
-      error.component = component || 'anonymous'
+      error.component = options.name || options._componentTag || 'anonymous'
       error.file = options.__file || ''
     }
 

--- a/packages/rum-vue/src/index.js
+++ b/packages/rum-vue/src/index.js
@@ -25,11 +25,11 @@
 
 import { apmBase } from '@elastic/apm-rum'
 import { routeHooks } from './route-hooks'
-import { setUpErrorHandler } from './error-handler'
+import { getErrorHandler } from './error-handler'
 
 export const ApmVuePlugin = {
   install: (Vue, options) => {
-    const { router, apm = apmBase, config, errors = true } = options
+    const { router, apm = apmBase, config, captureErrors = true } = options
     /**
      * Initialize the APM with the config
      */
@@ -42,12 +42,12 @@ export const ApmVuePlugin = {
       routeHooks(router, apm)
     }
 
-    if (errors) {
+    if (captureErrors) {
       /**
        * Global error handler for capturing errors during
        * component renders
        */
-      Vue.config.errorHandler = setUpErrorHandler(Vue, apm)
+      Vue.config.errorHandler = getErrorHandler(Vue, apm)
     }
     /**
      * Provide the APM instance via $apm to be accessed in all Vue Components

--- a/packages/rum-vue/test/specs/error-handler.spec.js
+++ b/packages/rum-vue/test/specs/error-handler.spec.js
@@ -34,7 +34,7 @@ describe('Error handler', () => {
     const apm = new ApmBase(createServiceFactory(), false)
     const error = new Error('Component Error')
     /**
-     * To prevent the logging erorrs to the console
+     * To prevent the logging errors to the console
      */
     spyOn(window.console, 'error')
 

--- a/packages/rum-vue/test/specs/error-handler.spec.js
+++ b/packages/rum-vue/test/specs/error-handler.spec.js
@@ -23,12 +23,11 @@
  *
  */
 
-import '../polyfill'
 import Vue from 'vue'
 import { mount } from '@vue/test-utils'
 import { ApmBase } from '@elastic/apm-rum'
 import { createServiceFactory } from '@elastic/apm-rum-core'
-import { setUpErrorHandler } from '../../src/error-handler'
+import { getErrorHandler } from '../../src/error-handler'
 
 describe('Error handler', () => {
   it('should capture errors via global error handler', done => {
@@ -40,19 +39,19 @@ describe('Error handler', () => {
     spyOn(window.console, 'error')
 
     const original = Vue.config.errorHandler
-    Vue.config.errorHandler = setUpErrorHandler(Vue, apm)
+    Vue.config.errorHandler = getErrorHandler(Vue, apm)
 
     const ErrorComponent = {
       name: 'Error',
       template: '<div>error</div>',
       created: () => {
-        throw new Error('Component Error')
+        throw error
       }
     }
 
     spyOn(apm, 'captureError').and.callFake(err => {
       expect(err).toEqual(error)
-      expect(err.component).toEqual(ErrorComponent.name)
+      expect(err.component).toEqual('Error')
       expect(err.file).toEqual('')
       expect(err.lifecycleHook).toEqual('created hook')
       done()


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#555 
+ Send extra information available from Vue instance and add it to the error context. This includes
    - `component` - component responsible for the error. `anonymous` if name is not set. 
    - `lifecycleHook` on where the error occurred
    - `file` pointing to the actual component file `<component>.vue`

TODO
+ [x] Add tests
+ [x] Update docs