### PR TITLE
feat(rum-core): capture long tasks and lcp using performance observer

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -115,10 +115,15 @@ const LOCAL_CONFIG_KEY = 'elastic_apm_config'
 
 /**
  * List of entry types that could be observed by the PerformaneObserver Interface
+ * or can be captured via Performance Timeline API
  */
 const LONG_TASK = 'longtask'
+const PAINT = 'paint'
+const MEASURE = 'measure'
+const NAVIGATION = 'navigation'
+const RESOURCE = 'resource'
+const FIRST_CONTENTFUL_PAINT = 'first-contentful-paint'
 const LARGEST_CONTENTFUL_PAINT = 'largest-contentful-paint'
-const ENTRY_TYPES = [LONG_TASK, LARGEST_CONTENTFUL_PAINT]
 
 /**
  * Default configs used on top of extensible configs from ConfigService
@@ -155,8 +160,12 @@ export {
   LOCAL_CONFIG_KEY,
   HTTP_REQUEST_TYPE,
   LONG_TASK,
+  PAINT,
+  MEASURE,
+  NAVIGATION,
+  RESOURCE,
+  FIRST_CONTENTFUL_PAINT,
   LARGEST_CONTENTFUL_PAINT,
-  ENTRY_TYPES,
   KEYWORD_LIMIT,
   SERVER_URL_PREFIX,
   BROWSER_RESPONSIVENESS_INTERVAL,

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -114,6 +114,13 @@ const AFTER_EVENT = ':after'
 const LOCAL_CONFIG_KEY = 'elastic_apm_config'
 
 /**
+ * List of entry types that could be observed by the PerformaneObserver Interface
+ */
+const LONG_TASK = 'longtask'
+const LARGEST_CONTENTFUL_PAINT = 'largest-contentful-paint'
+const ENTRY_TYPES = [LONG_TASK, LARGEST_CONTENTFUL_PAINT]
+
+/**
  * Default configs used on top of extensible configs from ConfigService
  */
 const KEYWORD_LIMIT = 1024
@@ -147,6 +154,9 @@ export {
   AFTER_EVENT,
   LOCAL_CONFIG_KEY,
   HTTP_REQUEST_TYPE,
+  LONG_TASK,
+  LARGEST_CONTENTFUL_PAINT,
+  ENTRY_TYPES,
   KEYWORD_LIMIT,
   SERVER_URL_PREFIX,
   BROWSER_RESPONSIVENESS_INTERVAL,

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -24,8 +24,13 @@
  */
 
 import Url from './url'
-import { PAGE_LOAD } from './constants'
-import { getPageMetadata, getServerTimingInfo } from './utils'
+import { PAGE_LOAD, NAVIGATION } from './constants'
+import {
+  getPageMetadata,
+  getServerTimingInfo,
+  PERF,
+  isPTSupported
+} from './utils'
 
 const LEFT_SQUARE_BRACKET = 91 // [
 const RIGHT_SQUARE_BRACKET = 93 // ]
@@ -161,11 +166,8 @@ export function addSpanContext(span, data) {
 export function addTransactionContext(transaction, configContext) {
   const pageContext = getPageMetadata()
   let responseContext = {}
-  if (
-    transaction.type === PAGE_LOAD &&
-    typeof performance.getEntriesByType === 'function'
-  ) {
-    let entries = performance.getEntriesByType('navigation')
+  if (transaction.type === PAGE_LOAD && isPTSupported()) {
+    let entries = PERF.getEntriesByType(NAVIGATION)
     if (entries && entries.length > 0) {
       responseContext = {
         response: getResponseContext(entries[0])

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -29,7 +29,7 @@ import {
   getPageMetadata,
   getServerTimingInfo,
   PERF,
-  isPTSupported
+  isPerfTimelineSupported
 } from './utils'
 
 const LEFT_SQUARE_BRACKET = 91 // [
@@ -166,7 +166,7 @@ export function addSpanContext(span, data) {
 export function addTransactionContext(transaction, configContext) {
   const pageContext = getPageMetadata()
   let responseContext = {}
-  if (transaction.type === PAGE_LOAD && isPTSupported()) {
+  if (transaction.type === PAGE_LOAD && isPerfTimelineSupported()) {
     let entries = PERF.getEntriesByType(NAVIGATION)
     if (entries && entries.length > 0) {
       responseContext = {

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -349,9 +349,10 @@ function scheduleMicroTask(callback) {
 }
 
 /**
- * Check if performancce Timeline is supported in browsers
+ * Check if performance Timeline is supported in browsers
+ * Performane Timeline imples `getEntriesByType`
  */
-function isPTSupported() {
+function isPerfTimelineSupported() {
   return typeof PERF.getEntriesByType === 'function'
 }
 
@@ -389,5 +390,5 @@ export {
   find,
   removeInvalidChars,
   PERF,
-  isPTSupported
+  isPerfTimelineSupported
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -27,6 +27,7 @@ import rng from 'uuid/lib/rng-browser'
 import { Promise } from 'es6-promise'
 
 const slice = [].slice
+const PERF = window.performance
 
 function isCORSSupported() {
   var xhr = new window.XMLHttpRequest()
@@ -126,8 +127,8 @@ function isPlatformSupported() {
     typeof Array.prototype.forEach === 'function' &&
     typeof JSON.stringify === 'function' &&
     typeof Function.bind === 'function' &&
-    window.performance &&
-    typeof window.performance.now === 'function' &&
+    PERF &&
+    typeof PERF.now === 'function' &&
     isCORSSupported()
   )
 }
@@ -148,64 +149,6 @@ function setLabel(key, value, obj) {
   }
   obj[skey] = value
   return obj
-}
-
-const navigationTimingKeys = [
-  'fetchStart',
-  'domainLookupStart',
-  'domainLookupEnd',
-  'connectStart',
-  'connectEnd',
-  'secureConnectionStart',
-  'requestStart',
-  'responseStart',
-  'responseEnd',
-  'domLoading',
-  'domInteractive',
-  'domContentLoadedEventStart',
-  'domContentLoadedEventEnd',
-  'domComplete',
-  'loadEventStart',
-  'loadEventEnd'
-]
-
-function getNavigationTimingMarks() {
-  var timing = window.performance.timing
-  var fetchStart = timing.fetchStart
-  var marks = {}
-  navigationTimingKeys.forEach(function(timingKey) {
-    var m = timing[timingKey]
-    if (m && m >= fetchStart) {
-      marks[timingKey] = m - fetchStart
-    }
-  })
-  return marks
-}
-
-/**
- * Paint Timing Metrics that is available during page load
- * https://www.w3.org/TR/paint-timing/
- */
-function getPaintTimingMarks() {
-  var paints = {}
-  var perf = window.performance
-  if (typeof perf.getEntriesByType === 'function') {
-    var entries = perf.getEntriesByType('paint')
-    if (entries.length > 0) {
-      var timings = perf.timing
-      /**
-       * To avoid capturing the unload event handler effect in paint timings
-       */
-      var unloadDiff = timings.fetchStart - timings.navigationStart
-      for (var i = 0; i < entries.length; i++) {
-        var data = entries[i]
-        var calcPaintTime =
-          unloadDiff >= 0 ? data.startTime - unloadDiff : data.startTime
-        paints[data.name] = calcPaintTime
-      }
-    }
-  }
-  return paints
 }
 
 /**
@@ -244,7 +187,7 @@ function getServerTimingInfo(serverTimingEntries = []) {
 }
 
 function getTimeOrigin() {
-  return window.performance.timing.fetchStart
+  return PERF.timing.fetchStart
 }
 
 function getPageMetadata() {
@@ -382,25 +325,8 @@ function getEarliestSpan(spans) {
   return earliestSpan
 }
 
-function getPageLoadMarks() {
-  const marks = getNavigationTimingMarks()
-  const paintMarks = getPaintTimingMarks()
-  const agent = {
-    timeToFirstByte: marks.responseStart,
-    domInteractive: marks.domInteractive,
-    domComplete: marks.domComplete
-  }
-  if (paintMarks['first-contentful-paint']) {
-    agent.firstContentfulPaint = paintMarks['first-contentful-paint']
-  }
-  return {
-    navigationTiming: marks,
-    agent
-  }
-}
-
 function now() {
-  return window.performance.now()
+  return PERF.now()
 }
 
 function getTime(time) {
@@ -422,6 +348,13 @@ function scheduleMicroTask(callback) {
   Promise.resolve().then(callback)
 }
 
+/**
+ * Check if performancce Timeline is supported in browsers
+ */
+function isPTSupported() {
+  return typeof PERF.getEntriesByType === 'function'
+}
+
 export {
   extend,
   merge,
@@ -435,8 +368,6 @@ export {
   isPlatformSupported,
   isDtHeaderValid,
   parseDtHeaderValue,
-  getNavigationTimingMarks,
-  getPaintTimingMarks,
   getServerTimingInfo,
   getDtHeaderValue,
   getPageMetadata,
@@ -446,7 +377,6 @@ export {
   generateRandomId,
   getEarliestSpan,
   getLatestNonXHRSpan,
-  getPageLoadMarks,
   getDuration,
   now,
   getTime,
@@ -457,5 +387,7 @@ export {
   setLabel,
   stripQueryStringFromUrl,
   find,
-  removeInvalidChars
+  removeInvalidChars,
+  PERF,
+  isPTSupported
 }

--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -23,7 +23,7 @@
  *
  */
 
-import { getDuration } from '../common/utils'
+import { getDuration, PERF } from '../common/utils'
 import { PAGE_LOAD } from '../common/constants'
 
 /**
@@ -148,10 +148,7 @@ function getSpanBreakdown(
  * Capture breakdown metrics for the transaction based on the
  * transaction type
  */
-export function captureBreakdown(
-  transaction,
-  timings = window.performance.timing
-) {
+export function captureBreakdown(transaction, timings = PERF.timing) {
   const breakdowns = []
   const trDuration = transaction.duration()
   const { name, type, sampled } = transaction

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -34,7 +34,11 @@ import {
   MEASURE,
   FIRST_CONTENTFUL_PAINT
 } from '../common/constants'
-import { stripQueryStringFromUrl, PERF, isPTSupported } from '../common/utils'
+import {
+  stripQueryStringFromUrl,
+  PERF,
+  isPerfTimelineSupported
+} from '../common/utils'
 
 /**
  * Navigation Timing Spans
@@ -245,18 +249,19 @@ function getNavigationTimingMarks() {
 }
 
 /**
- * Paint Timing Metrics that is available during page load
- * `first-paint` and `first-contentful-paint`
- * https://www.w3.org/TR/paint-timing/
+ * Get the `first-contentful-paint` metric that is available during
+ * page-load using the Paint Timing Metrics API
+ * SPEC - https://www.w3.org/TR/paint-timing/
  */
 function getFirstContentfulPaint() {
   let fcp
-  if (isPTSupported()) {
+  if (isPerfTimelineSupported()) {
     const entries = PERF.getEntriesByType(PAINT)
     if (entries.length > 0) {
       const timing = PERF.timing
       /**
-       * To avoid capturing the unload event handler effect in paint timings
+       * To avoid capturing the unload event handler effect
+       * as part of the transaction duration
        */
       const unloadDiff = timing.fetchStart - timing.navigationStart
       const fcpEntry = entries.filter(
@@ -344,7 +349,7 @@ function captureNavigation(transaction) {
     transaction.addMarks(getPageLoadMarks())
   }
 
-  if (isPTSupported()) {
+  if (isPerfTimelineSupported()) {
     const trStart = transaction._start
     /**
      * Capture resource timing information as spans

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -28,9 +28,13 @@ import {
   RESOURCE_INITIATOR_TYPES,
   MAX_SPAN_DURATION,
   USER_TIMING_THRESHOLD,
-  PAGE_LOAD
+  PAGE_LOAD,
+  PAINT,
+  RESOURCE,
+  MEASURE,
+  FIRST_CONTENTFUL_PAINT
 } from '../common/constants'
-import { stripQueryStringFromUrl, getPageLoadMarks } from '../common/utils'
+import { stripQueryStringFromUrl, PERF, isPTSupported } from '../common/utils'
 
 /**
  * Navigation Timing Spans
@@ -208,6 +212,80 @@ function getApiSpanNames({ spans }) {
   return apiCalls
 }
 
+const navigationTimingKeys = [
+  'fetchStart',
+  'domainLookupStart',
+  'domainLookupEnd',
+  'connectStart',
+  'connectEnd',
+  'secureConnectionStart',
+  'requestStart',
+  'responseStart',
+  'responseEnd',
+  'domLoading',
+  'domInteractive',
+  'domContentLoadedEventStart',
+  'domContentLoadedEventEnd',
+  'domComplete',
+  'loadEventStart',
+  'loadEventEnd'
+]
+
+function getNavigationTimingMarks() {
+  const timing = PERF.timing
+  const fetchStart = timing.fetchStart
+  const marks = {}
+  navigationTimingKeys.forEach(function(timingKey) {
+    const m = timing[timingKey]
+    if (m && m >= fetchStart) {
+      marks[timingKey] = m - fetchStart
+    }
+  })
+  return marks
+}
+
+/**
+ * Paint Timing Metrics that is available during page load
+ * `first-paint` and `first-contentful-paint`
+ * https://www.w3.org/TR/paint-timing/
+ */
+function getFirstContentfulPaint() {
+  let fcp
+  if (isPTSupported()) {
+    const entries = PERF.getEntriesByType(PAINT)
+    if (entries.length > 0) {
+      const timing = PERF.timing
+      /**
+       * To avoid capturing the unload event handler effect in paint timings
+       */
+      const unloadDiff = timing.fetchStart - timing.navigationStart
+      const fcpEntry = entries.filter(
+        entry => entry.name === FIRST_CONTENTFUL_PAINT
+      )
+      const { startTime } = fcpEntry[0]
+      fcp = unloadDiff >= 0 ? startTime - unloadDiff : startTime
+    }
+  }
+  return fcp
+}
+
+function getPageLoadMarks() {
+  const marks = getNavigationTimingMarks()
+  const agent = {
+    timeToFirstByte: marks.responseStart,
+    domInteractive: marks.domInteractive,
+    domComplete: marks.domComplete
+  }
+  const fcp = getFirstContentfulPaint()
+  if (fcp) {
+    agent.firstContentfulPaint = fcp
+  }
+  return {
+    navigationTiming: marks,
+    agent
+  }
+}
+
 function captureNavigation(transaction) {
   /**
    * Do not capture timing related information when the
@@ -218,7 +296,6 @@ function captureNavigation(transaction) {
     return
   }
 
-  const perf = window.performance
   /**
    * Both start and end threshold decides if a span must be
    * captured as part of the transaction
@@ -246,7 +323,7 @@ function captureNavigation(transaction) {
     const trStart = 0
     transaction._start = trStart
 
-    const timings = perf.timing
+    const timings = PERF.timing
     createNavigationTimingSpans(
       timings,
       timings.fetchStart,
@@ -267,12 +344,12 @@ function captureNavigation(transaction) {
     transaction.addMarks(getPageLoadMarks())
   }
 
-  if (typeof perf.getEntriesByType === 'function') {
+  if (isPTSupported()) {
     const trStart = transaction._start
     /**
      * Capture resource timing information as spans
      */
-    const resourceEntries = perf.getEntriesByType('resource')
+    const resourceEntries = PERF.getEntriesByType(RESOURCE)
     const apiCalls = getApiSpanNames(transaction)
 
     createResourceTimingSpans(
@@ -285,7 +362,7 @@ function captureNavigation(transaction) {
     /**
      * Capture user timing measures as spans
      */
-    const userEntries = perf.getEntriesByType('measure')
+    const userEntries = PERF.getEntriesByType(MEASURE)
     createUserTimingSpans(userEntries, trStart, trEnd).forEach(span =>
       transaction.spans.push(span)
     )

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -89,6 +89,14 @@ export function onPerformanceEntry(list, transaction) {
 /**
  * Records all performance entry events available via Performance Observer
  * and fallbacks to Performance Timeline if not supported
+ *
+ * Entry types such as `resource`, `paint` and `measure` are recorded via
+ * Performance Timeline instead of the Observer since the buffering for
+ * certian events are not supported and we would end up in using both
+ * in certian browsers which adds performance cost.
+ *
+ * So we stick to PerformanceObserver only for new entry types like `longtask` and
+ * `largest-contentful-paint`
  */
 export class PerfEntryRecorder {
   constructor(callback) {

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { LONG_TASK, LARGEST_CONTENTFUL_PAINT } from '../common/constants'
+import { noop } from '../common/utils'
+import Span from './span'
+
+function createLongTaskSpans(longtasks) {
+  if (longtasks.length === 0) {
+    return
+  }
+
+  const longTaskSpans = []
+  for (let i = 0; i < longtasks.length; i++) {
+    const { name, startTime, duration } = longtasks[i]
+    const end = startTime + duration
+
+    const kind = LONG_TASK
+    const span = new Span(`Longtask(${name})`, kind, { startTime })
+    span.end(end)
+
+    longTaskSpans.push(span)
+  }
+  return longTaskSpans
+}
+
+export function onPerformanceEntry(entryList, transactionService) {
+  const longtaskEntries = entryList.getEntriesByType(LONG_TASK)
+  const lcpEntries = entryList.getEntriesByType(LARGEST_CONTENTFUL_PAINT)
+
+  const lastLcpEntry = lcpEntries[lcpEntries.length - 1]
+  const tr = transactionService.getCurrentTransaction()
+
+  if (!tr) {
+    return
+  }
+
+  if (lastLcpEntry) {
+    tr.addMarks({
+      agent: {
+        largestContentfulPaint: lastLcpEntry.renderTime || lastLcpEntry.loadTime
+      }
+    })
+  }
+
+  const longTaskSpans = createLongTaskSpans(longtaskEntries)
+  tr.spans.push(...longTaskSpans)
+}
+
+export class PerfEntryRecorder {
+  constructor(callback) {
+    this.po = {
+      observe: noop,
+      disconnect: noop
+    }
+    if (window.PerformanceObserver) {
+      this.po = new PerformanceObserver(callback)
+    }
+  }
+
+  start(entryTypes) {
+    /**
+     * Safari throws an error when PerformanceObserver is
+     * observed for unknown entry typess
+     */
+    try {
+      this.po.observe({ entryTypes })
+    } catch (_) {}
+  }
+
+  stop() {
+    this.po.disconnect()
+  }
+}

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -46,27 +46,26 @@ function createLongTaskSpans(longtasks) {
   return longTaskSpans
 }
 
-export function onPerformanceEntry(entryList, transactionService) {
+export function onPerformanceEntry(entryList, transaction) {
   const longtaskEntries = entryList.getEntriesByType(LONG_TASK)
   const lcpEntries = entryList.getEntriesByType(LARGEST_CONTENTFUL_PAINT)
-
   const lastLcpEntry = lcpEntries[lcpEntries.length - 1]
-  const tr = transactionService.getCurrentTransaction()
 
-  if (!tr) {
-    return
-  }
+  console.log(lastLcpEntry)
 
   if (lastLcpEntry) {
-    tr.addMarks({
+    transaction.addMarks({
       agent: {
+        /**
+         * `renderTime` will not be available for Image element and if the element
+         * is loaded cross-origin without the `Timing-Allow-Origin` header.
+         */
         largestContentfulPaint: lastLcpEntry.renderTime || lastLcpEntry.loadTime
       }
     })
   }
 
-  const longTaskSpans = createLongTaskSpans(longtaskEntries)
-  tr.spans.push(...longTaskSpans)
+  transaction.spans.push(...createLongTaskSpans(longtaskEntries))
 }
 
 export class PerfEntryRecorder {
@@ -83,7 +82,7 @@ export class PerfEntryRecorder {
   start(entryTypes) {
     /**
      * Safari throws an error when PerformanceObserver is
-     * observed for unknown entry typess
+     * observed for unknown entry types
      */
     try {
       this.po.observe({ entryTypes })

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -66,9 +66,12 @@ class PerformanceMonitoring {
   }
 
   init(flags = {}) {
-    const recorder = new PerfEntryRecorder(list =>
-      onPerformanceEntry(list, this._transactionService)
-    )
+    const recorder = new PerfEntryRecorder(list => {
+      const transaction = this._transactionService.getCurrentTransaction()
+      if (transaction) {
+        onPerformanceEntry(list, transaction)
+      }
+    })
 
     this._configService.events.observe(TRANSACTION_START + BEFORE_EVENT, () => {
       recorder.start(ENTRY_TYPES)

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -78,7 +78,7 @@ class PerformanceMonitoring {
      */
     this._configService.events.observe(
       TRANSACTION_START + BEFORE_EVENT,
-      transaction => recorder.start(transaction.type)
+      transaction => recorder.start(transaction)
     )
     /**
      * We need to run this event listener after all of user-registered listener,
@@ -87,7 +87,7 @@ class PerformanceMonitoring {
     this._configService.events.observe(
       TRANSACTION_END + AFTER_EVENT,
       transaction => {
-        recorder.stop()
+        recorder.stop(transaction)
         const payload = this.createTransactionPayload(transaction)
         if (payload) {
           this._apmServer.addTransaction(payload)

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -70,19 +70,6 @@ describe('lib/utils', function() {
     html.removeChild(script)
   })
 
-  it('should getNavigationTimingMarks', function() {
-    var marks = utils.getNavigationTimingMarks()
-    expect(marks.fetchStart).toBeGreaterThanOrEqual(0)
-    expect(marks.domInteractive).toBeGreaterThanOrEqual(0)
-    expect(marks.domComplete).toBeGreaterThanOrEqual(0)
-    expect(marks.loadEventEnd).toBeGreaterThanOrEqual(0)
-  })
-
-  it('should getPaintTimingMarks', function() {
-    var marks = utils.getPaintTimingMarks()
-    expect(marks).toEqual({})
-  })
-
   it('should generate random ids', function() {
     var result = utils.bytesToHex(utils.rng())
     expect(result.length).toBe(32)

--- a/packages/rum-core/test/fixtures/lcp-entries.js
+++ b/packages/rum-core/test/fixtures/lcp-entries.js
@@ -23,20 +23,29 @@
  *
  */
 
-const path = require('path')
-const {
-  getWebpackConfig,
-  BUNDLE_TYPES,
-  PACKAGE_TYPES
-} = require('../../../../dev-utils/build')
-
-module.exports = {
-  entry: {
-    app: path.join(__dirname, 'app.js')
+export default [
+  {
+    renderTime: 298.51500000222586,
+    loadTime: 295.4050000116695,
+    size: 3000,
+    id: '',
+    url: 'http://example.com/logo.svg',
+    element: null, // points to a DOM element
+    name: '',
+    entryType: 'largest-contentful-paint',
+    startTime: 298.51500000222586,
+    duration: 0
   },
-  output: {
-    path: path.resolve(__dirname),
-    filename: 'app.e2e-bundle.js'
-  },
-  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_PROD, PACKAGE_TYPES.VUE)
-}
+  {
+    renderTime: 1040.0399999925867,
+    loadTime: 0,
+    size: 5250,
+    id: '',
+    url: '',
+    element: null,
+    name: '',
+    entryType: 'largest-contentful-paint',
+    startTime: 1040.0399999925867,
+    duration: 0
+  }
+]

--- a/packages/rum-core/test/fixtures/longtask-entries.js
+++ b/packages/rum-core/test/fixtures/longtask-entries.js
@@ -23,9 +23,13 @@
  *
  */
 
+/**
+ * Entries are copied from the demo link available as part of
+ * longtask repo - https://w3c.github.io/longtasks/demo.html
+ */
 export default [
   {
-    name: 'unknown',
+    name: 'self',
     entryType: 'longtask',
     startTime: 745.4100000031758,
     duration: 54.56999997841194,
@@ -35,7 +39,7 @@ export default [
         entryType: 'taskattribution',
         startTime: 0,
         duration: 0,
-        containerType: 'iframe',
+        containerType: 'window',
         containerSrc: '',
         containerId: '',
         containerName: ''
@@ -43,10 +47,10 @@ export default [
     ]
   },
   {
-    name: 'self',
+    name: 'same-origin-descendant',
     entryType: 'longtask',
-    startTime: 865.7799999928102,
-    duration: 53.874999983236194,
+    startTime: 1023.40999995591,
+    duration: 187.19000002602115,
     attribution: [
       {
         name: 'unknown',
@@ -54,6 +58,24 @@ export default [
         startTime: 0,
         duration: 0,
         containerType: 'iframe',
+        containerSrc: 'demo-child.html',
+        containerId: '',
+        containerName: 'childA'
+      }
+    ]
+  },
+  {
+    name: 'same-origin-ancestor',
+    entryType: 'longtask',
+    startTime: 1923.40999995591,
+    duration: 158.16999995149672,
+    attribution: [
+      {
+        name: 'unknown',
+        entryType: 'taskattribution',
+        startTime: 0,
+        duration: 0,
+        containerType: 'window',
         containerSrc: '',
         containerId: '',
         containerName: ''

--- a/packages/rum-core/test/fixtures/longtask-entries.js
+++ b/packages/rum-core/test/fixtures/longtask-entries.js
@@ -23,20 +23,41 @@
  *
  */
 
-const path = require('path')
-const {
-  getWebpackConfig,
-  BUNDLE_TYPES,
-  PACKAGE_TYPES
-} = require('../../../../dev-utils/build')
-
-module.exports = {
-  entry: {
-    app: path.join(__dirname, 'app.js')
+export default [
+  {
+    name: 'unknown',
+    entryType: 'longtask',
+    startTime: 745.4100000031758,
+    duration: 54.56999997841194,
+    attribution: [
+      {
+        name: 'unknown',
+        entryType: 'taskattribution',
+        startTime: 0,
+        duration: 0,
+        containerType: 'iframe',
+        containerSrc: '',
+        containerId: '',
+        containerName: ''
+      }
+    ]
   },
-  output: {
-    path: path.resolve(__dirname),
-    filename: 'app.e2e-bundle.js'
-  },
-  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_PROD, PACKAGE_TYPES.VUE)
-}
+  {
+    name: 'self',
+    entryType: 'longtask',
+    startTime: 865.7799999928102,
+    duration: 53.874999983236194,
+    attribution: [
+      {
+        name: 'unknown',
+        entryType: 'taskattribution',
+        startTime: 0,
+        duration: 0,
+        containerType: 'iframe',
+        containerSrc: '',
+        containerId: '',
+        containerName: ''
+      }
+    ]
+  }
+]

--- a/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
+++ b/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
@@ -1,0 +1,71 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+import Transaction from '../../src/performance-monitoring/transaction'
+import { PAGE_LOAD, TYPE_CUSTOM, LONG_TASK } from '../../src/common/constants'
+import {
+  onPerformanceEntry,
+  PerfEntryRecorder
+} from '../../src/performance-monitoring/perf-entry-recorder'
+import { mockObserverEntryTypes } from '../utils/globals-mock'
+
+describe('PerfEntryRecorder', () => {
+  const mockEntryList = {
+    getEntriesByType: mockObserverEntryTypes
+  }
+
+  it('should create long tasks spans for all transaction types', () => {
+    const pageLoadTransaction = new Transaction('/', PAGE_LOAD)
+    onPerformanceEntry(mockEntryList, pageLoadTransaction)
+
+    const getLtSpans = tr => tr.spans.filter(span => span.type === LONG_TASK)
+
+    expect(getLtSpans(pageLoadTransaction).length).toEqual(2)
+
+    const customTransaction = new Transaction('/', TYPE_CUSTOM)
+    onPerformanceEntry(mockEntryList, customTransaction)
+
+    expect(getLtSpans(customTransaction).length).toEqual(2)
+  })
+
+  it('should mark largest contentful paint only for page-load transaction', () => {
+    const pageLoadTransaction = new Transaction('/', PAGE_LOAD)
+    onPerformanceEntry(mockEntryList, pageLoadTransaction)
+
+    expect(pageLoadTransaction.marks.agent.largestContentfulPaint).toEqual(
+      1040.0399999925867
+    )
+
+    const customTransaction = new Transaction('/', TYPE_CUSTOM)
+    onPerformanceEntry(mockEntryList, customTransaction)
+
+    expect(customTransaction.marks).toBeUndefined()
+  })
+
+  it('should start recording on all browsers without errors', () => {
+    const recorder = new PerfEntryRecorder(() => {})
+    recorder.start()
+    recorder.stop()
+  })
+})

--- a/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
+++ b/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
@@ -63,9 +63,30 @@ describe('PerfEntryRecorder', () => {
     expect(customTransaction.marks).toBeUndefined()
   })
 
-  it('should start recording on all browsers without errors', () => {
+  it('should start recording based on managed vs custom transaction', () => {
     const recorder = new PerfEntryRecorder(() => {})
-    recorder.start()
-    recorder.stop()
+    const onStartSpy = jasmine.createSpy()
+    const onStopSpy = jasmine.createSpy()
+    recorder.po = {
+      observe: onStartSpy,
+      disconnect: onStopSpy
+    }
+
+    const pageLoadTransaction = new Transaction('/', PAGE_LOAD)
+    pageLoadTransaction.captureTimings = true
+    recorder.start(pageLoadTransaction)
+    recorder.stop(pageLoadTransaction)
+
+    expect(onStartSpy).toHaveBeenCalled()
+    expect(onStopSpy).toHaveBeenCalled()
+
+    onStartSpy.calls.reset()
+    onStopSpy.calls.reset()
+    const customTransaction = new Transaction('/', TYPE_CUSTOM)
+    customTransaction.captureTimings = false
+    recorder.start(customTransaction)
+    recorder.stop(customTransaction)
+    expect(onStartSpy).not.toHaveBeenCalled()
+    expect(onStopSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -29,7 +29,11 @@ import Span from '../../src/performance-monitoring/span'
 import Config from '../../src/common/config-service'
 import LoggingService from '../../src/common/logging-service'
 import { mockGetEntriesByType } from '../utils/globals-mock'
-import { TRANSACTION_END, PAGE_LOAD } from '../../src/common/constants'
+import {
+  TRANSACTION_END,
+  PAGE_LOAD,
+  ROUTE_CHANGE
+} from '../../src/common/constants'
 
 describe('TransactionService', function() {
   var transactionService
@@ -690,5 +694,63 @@ describe('TransactionService', function() {
 
     tr = transactionService.getCurrentTransaction()
     expect(tr.type).toBe('page-load')
+  })
+
+  describe('performance entry recorder', () => {
+    const logger = new LoggingService()
+    const config = new Config()
+    const trService = new TransactionService(logger, config)
+    const startSpy = jasmine.createSpy()
+    const stopSpy = jasmine.createSpy()
+
+    trService.recorder = {
+      start: startSpy,
+      stop: stopSpy
+    }
+    const resetSpies = () => {
+      startSpy.calls.reset()
+      stopSpy.calls.reset()
+    }
+
+    afterEach(() => resetSpies())
+
+    it('should start/stop performance recorder for managed transaction', async () => {
+      const pageLoadTr = trService.startTransaction('test', PAGE_LOAD, {
+        managed: true
+      })
+      expect(startSpy).toHaveBeenCalledTimes(2)
+      expect(startSpy.calls.allArgs()).toEqual([
+        ['largest-contentful-paint'],
+        ['longtask']
+      ])
+      await pageLoadTr.end()
+      expect(stopSpy).toHaveBeenCalled()
+      resetSpies()
+
+      const routeChangeTr = trService.startTransaction('test', ROUTE_CHANGE, {
+        managed: true
+      })
+      expect(startSpy).toHaveBeenCalled()
+      expect(startSpy.calls.allArgs()).toEqual([['longtask']])
+      await routeChangeTr.end()
+      expect(stopSpy).toHaveBeenCalled()
+    })
+
+    it('should start recorder only once during redefining', async () => {
+      const managed1 = trService.startTransaction('test', 'test', {
+        managed: true,
+        canReuse: true
+      })
+      expect(startSpy).toHaveBeenCalledWith('longtask')
+      const managed2 = trService.startTransaction('test', 'custom', {
+        managed: true,
+        canReuse: true
+      })
+      expect(startSpy).toHaveBeenCalledTimes(1)
+      await managed1.end()
+      await managed2.end()
+
+      expect(stopSpy).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -752,5 +752,21 @@ describe('TransactionService', function() {
 
       expect(stopSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('should stop recorder before starting a non-reusable transaction', async () => {
+      const managedReusable = trService.startTransaction('test', 'test', {
+        managed: true,
+        canReuse: true
+      })
+      expect(startSpy).toHaveBeenCalledWith('longtask')
+      const managedNonReusable = trService.startTransaction('test', 'custom', {
+        managed: true
+      })
+      expect(startSpy.calls.allArgs()).toEqual([['longtask'], ['longtask']])
+      expect(stopSpy).toHaveBeenCalled()
+      await managedReusable.end()
+      await managedNonReusable.end()
+      expect(stopSpy).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/rum-core/test/utils/globals-mock.js
+++ b/packages/rum-core/test/utils/globals-mock.js
@@ -27,19 +27,39 @@ import resourceEntries from '../fixtures/resource-entries'
 import paintEntries from '../fixtures/paint-entries'
 import userTimingEntries from '../fixtures/user-timing-entries'
 import { TIMING_LEVEL2_ENTRIES } from '../fixtures/navigation-entries'
+import longtaskEntries from '../fixtures/longtask-entries'
+import largestContentfulPaintEntries from '../fixtures/lcp-entries'
+import {
+  LONG_TASK,
+  LARGEST_CONTENTFUL_PAINT,
+  MEASURE,
+  PAINT,
+  NAVIGATION,
+  RESOURCE
+} from '../../src/common/constants'
+
+export function mockObserverEntryTypes(type) {
+  if (type === LONG_TASK) {
+    return longtaskEntries
+  } else if (type === LARGEST_CONTENTFUL_PAINT) {
+    return largestContentfulPaintEntries
+  }
+
+  return []
+}
 
 export function mockGetEntriesByType() {
   const _getEntriesByType = window.performance.getEntriesByType
 
   window.performance.getEntriesByType = function(type) {
-    expect(['resource', 'paint', 'measure', 'navigation']).toContain(type)
-    if (type === 'resource') {
+    expect([RESOURCE, PAINT, MEASURE, NAVIGATION]).toContain(type)
+    if (type === RESOURCE) {
       return resourceEntries
-    } else if (type === 'paint') {
+    } else if (type === PAINT) {
       return paintEntries
-    } else if (type === 'measure') {
+    } else if (type === MEASURE) {
       return userTimingEntries
-    } else if (type === 'navigation') {
+    } else if (type === NAVIGATION) {
       return TIMING_LEVEL2_ENTRIES
     } else {
       return []

--- a/packages/rum-vue/test/e2e/webpack.config.js
+++ b/packages/rum-vue/test/e2e/webpack.config.js
@@ -38,5 +38,5 @@ module.exports = {
     path: path.resolve(__dirname),
     filename: 'app.e2e-bundle.js'
   },
-  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_PROD, PACKAGE_TYPES.VUE)
+  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_DEV, PACKAGE_TYPES.VUE)
 }


### PR DESCRIPTION
+ part of elastic/apm-agent-rum-js#478 
+ fix #376 
+ Introduces **Performance Observer** to capture `Longtask` and `Largest contentful paint` during transaction lifetime. 
<img width="1200" alt="Screenshot 2020-01-27 at 12 21 47" src="https://user-images.githubusercontent.com/3902525/73171522-377e0580-4101-11ea-87da-1d1750febc3e.png">


+ LCP is added as a mark whereas `Longtasks` are created as spans to associate them in the breakdowns which provides a overview of how much time it spent on doing long tasks.
<img width="1099" alt="Screenshot 2020-01-27 at 12 21 24" src="https://user-images.githubusercontent.com/3902525/73171519-351bab80-4101-11ea-8b38-a35c21372093.png">

