### PR TITLE
fix(rum-core): avoid firing transaction-start event on reused transactions

### DIFF
--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -112,6 +112,29 @@ describe('TransactionService', function() {
     expect(trans.name).toBe('transaction')
   })
 
+  fit('should fire onstart hook only once for a transaction', () => {
+    const onStartSpy = jasmine.createSpy()
+    transactionService = new TransactionService(logger, {
+      config: {},
+      events: {
+        send: onStartSpy
+      }
+    })
+    const options = {
+      managed: true,
+      canReuse: true
+    }
+    transactionService.startTransaction('/', 'custom', options)
+    transactionService.startTransaction('/home', '', options)
+
+    expect(onStartSpy).toHaveBeenCalledTimes(1)
+
+    transactionService.startTransaction('/a', 'custom')
+    transactionService.startTransaction('/b', 'custom')
+
+    expect(onStartSpy).toHaveBeenCalledTimes(3)
+  })
+
   it('should capture page load on first transaction', function(done) {
     // todo: can't test hard navigation metrics since karma runs tests inside an iframe
     config.setConfig({


### PR DESCRIPTION
+  fix elastic/apm-agent-rum-js#583 
+ Transaction `onStart` hook should be called only once when the transaction is reused during the lifetime of a transaction. 