### PR TITLE
feat(rum-core): add EventTarget patch

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -100,6 +100,7 @@ const CONFIG_CHANGE = 'config:change'
 const XMLHTTPREQUEST = 'xmlhttprequest'
 const FETCH = 'fetch'
 const HISTORY = 'history'
+const EVENT_TARGET = 'eventtarget'
 const ERROR = 'error'
 
 /**
@@ -142,6 +143,7 @@ export {
   XMLHTTPREQUEST,
   FETCH,
   HISTORY,
+  EVENT_TARGET,
   ERROR,
   BEFORE_EVENT,
   AFTER_EVENT,

--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -122,8 +122,7 @@ export function patchEventTarget(callback) {
 
     existingTasks.push(task)
 
-    function wrappingFn(event) {
-      task.event = event
+    function wrappingFn() {
       callback(SCHEDULE, task)
       let result
       try {
@@ -152,6 +151,9 @@ export function patchEventTarget(callback) {
       if (taskIndex !== -1) {
         let task = existingTasks[taskIndex]
         existingTasks.splice(taskIndex, 1)
+        if (existingTasks.length === 0) {
+          target[eventSymbol] = undefined
+        }
         return task.wrappingFn
       }
     }

--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -1,0 +1,185 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import {
+  SCHEDULE,
+  INVOKE,
+  ADD_EVENT_LISTENER_STR,
+  REMOVE_EVENT_LISTENER_STR,
+  EVENT_TARGET
+} from '../constants'
+
+import { apmSymbol } from './patch-utils'
+
+const eventTypes = ['click']
+
+const eventTypeSymbols = {}
+
+for (let i = 0; i < eventTypes.length; i++) {
+  const et = eventTypes[i]
+  eventTypeSymbols[et] = apmSymbol(et)
+}
+
+export function patchEventTarget(callback) {
+  if (!window.EventTarget) {
+    return
+  }
+
+  let proto = window.EventTarget.prototype
+  const nativeAddEventListener = proto[ADD_EVENT_LISTENER_STR]
+  const nativeRemoveEventListener = proto[REMOVE_EVENT_LISTENER_STR]
+
+  function findTaskIndex(existingTasks, eventType, listenerFn, capture) {
+    for (let i = 0; i < existingTasks.length; i++) {
+      const task = existingTasks[i]
+      if (
+        task.eventType === eventType &&
+        task.listenerFn === listenerFn &&
+        task.capture === capture
+      ) {
+        return i
+      }
+    }
+    return -1
+  }
+
+  function isCapture(options) {
+    let capture
+    if (options === undefined) {
+      capture = false
+    } else if (options === true) {
+      capture = true
+    } else if (options === false) {
+      capture = false
+    } else {
+      capture = options ? !!options.capture : false
+    }
+    return capture
+  }
+
+  function createListenerWrapper(target, eventType, listenerFn, options) {
+    const eventSymbol = eventTypeSymbols[eventType]
+
+    if (!eventSymbol) return listenerFn
+
+    let existingTasks = target[eventSymbol]
+
+    let capture = isCapture(options)
+
+    if (existingTasks) {
+      let taskIndex = findTaskIndex(
+        existingTasks,
+        eventType,
+        listenerFn,
+        capture
+      )
+      if (taskIndex !== -1) {
+        let task = existingTasks[taskIndex]
+        return task.wrappingFn
+      }
+    } else {
+      existingTasks = target[eventSymbol] = []
+    }
+
+    let task = {
+      source: EVENT_TARGET,
+      target,
+      eventType,
+      listenerFn,
+      capture,
+      wrappingFn
+    }
+
+    existingTasks.push(task)
+
+    function wrappingFn(event) {
+      task.event = event
+      callback(SCHEDULE, task)
+      let result
+      try {
+        result = listenerFn.apply(this, arguments)
+      } finally {
+        callback(INVOKE, task)
+      }
+      return result
+    }
+
+    return wrappingFn
+  }
+
+  proto[ADD_EVENT_LISTENER_STR] = function(
+    eventType,
+    listenerFn,
+    optionsOrCapture
+  ) {
+    if (eventTypes.indexOf(eventType) < 0 || typeof listenerFn !== 'function') {
+      return nativeAddEventListener.apply(this, arguments)
+    }
+    const target = this
+
+    const wrappingListenerFn = createListenerWrapper(
+      target,
+      eventType,
+      listenerFn,
+      optionsOrCapture
+    )
+
+    let args = [...arguments]
+    args[1] = wrappingListenerFn
+
+    return nativeAddEventListener.apply(target, args)
+  }
+
+  proto[REMOVE_EVENT_LISTENER_STR] = function(
+    eventType,
+    listenerFn,
+    optionsOrCapture
+  ) {
+    if (eventTypes.indexOf(eventType) < 0 || typeof listenerFn !== 'function') {
+      return nativeRemoveEventListener.apply(this, arguments)
+    }
+    const target = this
+
+    const eventSymbol = eventTypeSymbols[eventType]
+
+    let existingTasks = target[eventSymbol]
+    let capture = isCapture(optionsOrCapture)
+    let args = [...arguments]
+    if (existingTasks) {
+      let taskIndex = findTaskIndex(
+        existingTasks,
+        eventType,
+        listenerFn,
+        capture
+      )
+      if (taskIndex !== -1) {
+        let task = existingTasks[taskIndex]
+        args[1] = task.wrappingFn
+        existingTasks.splice(taskIndex, 1)
+      }
+    }
+    return nativeRemoveEventListener.apply(target, args)
+  }
+}

--- a/packages/rum-core/test/common/event-target-patch.spec.js
+++ b/packages/rum-core/test/common/event-target-patch.spec.js
@@ -25,6 +25,7 @@
 
 import patchEventHandler from './patch'
 import { EVENT_TARGET } from '../../src/common/constants'
+import { createCustomEvent } from '../'
 
 describe('EventTargetPatch', function() {
   let events = []
@@ -47,20 +48,6 @@ describe('EventTargetPatch', function() {
     events = []
   })
 
-  function createEvent(eventType) {
-    let event
-    if (typeof Event === 'function') {
-      event = new Event(eventType)
-    } else {
-      /**
-       * For IE11 support
-       */
-      event = document.createEvent('Event')
-      event.initEvent(eventType, true, true)
-    }
-    return event
-  }
-
   it('should work different argument types', () => {
     let element = document.createElement('div')
     document.body.insertBefore(element, null)
@@ -74,7 +61,7 @@ describe('EventTargetPatch', function() {
 
   it('should not affect other event types', () => {
     const eventType = 'apm-test-event'
-    let event = createEvent(eventType)
+    let event = createCustomEvent(eventType)
 
     let count = 0
     let element = document.createElement('div')
@@ -131,9 +118,10 @@ describe('EventTargetPatch', function() {
       element.addEventListener('click', listener)
       element.addEventListener('click', listener)
       /**
-       * Form with options object is only supported on
+       * Providing object as the third argument is only support on
        * Chrome Mobile 49 and above therefore we can not
-       * pass an object here.
+       * pass an object if we want capture to be false
+       * since an object will be evaluated as a truthy value.
        */
       element.addEventListener('click', listener, false)
 

--- a/packages/rum-core/test/common/event-target-patch.spec.js
+++ b/packages/rum-core/test/common/event-target-patch.spec.js
@@ -47,18 +47,35 @@ describe('EventTargetPatch', function() {
     events = []
   })
 
+  function createEvent(eventType) {
+    let event
+    if (typeof Event === 'function') {
+      event = new Event(eventType)
+    } else {
+      /**
+       * For IE11 support
+       */
+      event = document.createEvent('Event')
+      event.initEvent(eventType, true, true)
+    }
+    return event
+  }
+
   it('should work different argument types', () => {
     let element = document.createElement('div')
-    element.addEventListener('click', undefined)
-    var spy = jasmine.createSpy('spy')
-    element.addEventListener('click', spy)
+    document.body.insertBefore(element, null)
+    let eventType = 'click'
+    element.addEventListener(eventType, undefined)
+    let spy = jasmine.createSpy('spy')
+    element.addEventListener(eventType, spy)
     element.click()
     expect(spy).toHaveBeenCalled()
   })
 
   it('should not affect other event types', () => {
     const eventType = 'apm-test-event'
-    var event = new Event(eventType)
+    let event = createEvent(eventType)
+
     let count = 0
     let element = document.createElement('div')
     const listener = e => {
@@ -75,7 +92,7 @@ describe('EventTargetPatch', function() {
   })
 
   if (window.EventTarget) {
-    it('should patch addEventListener', () => {
+    it('should patch EventTarget', () => {
       let count = 0
       let element = document.createElement('div')
       const listener = e => {
@@ -113,7 +130,12 @@ describe('EventTargetPatch', function() {
 
       element.addEventListener('click', listener)
       element.addEventListener('click', listener)
-      element.addEventListener('click', listener, { capture: false })
+      /**
+       * Form with options object is only supported on
+       * Chrome Mobile 49 and above therefore we can not
+       * pass an object here.
+       */
+      element.addEventListener('click', listener, false)
 
       element.click()
       expect(count).toBe(1)

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -23,7 +23,7 @@
  *
  */
 
-import { createServiceFactory } from '../'
+import { createServiceFactory, createCustomEvent } from '../'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 
 const { agentConfig } = getGlobalConfig('rum-core')
@@ -329,27 +329,6 @@ describe('ErrorLogging', function() {
   })
 
   it('should capture unhandled rejection events', done => {
-    /**
-     * Polyfilling the CustomEvent since they are available as objects
-     * in IE 9-11
-     * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-     */
-    function createCustomEevent(event, params) {
-      params = params || { bubbles: false, cancelable: false, detail: null }
-      if (typeof window.CustomEvent === 'function') {
-        return new CustomEvent(event, params)
-      }
-
-      const evt = document.createEvent('CustomEvent')
-      evt.initCustomEvent(
-        event,
-        params.bubbles,
-        params.cancelable,
-        params.detail
-      )
-      return evt
-    }
-
     configService.setConfig({
       flushInterval: 1
     })
@@ -364,7 +343,7 @@ describe('ErrorLogging', function() {
      * all browsers
      */
     const reason = new Error(testErrorMessage)
-    const event = createCustomEevent('unhandledrejection')
+    const event = createCustomEvent('unhandledrejection')
     event.reason = reason
     window.dispatchEvent(event)
   })

--- a/packages/rum-core/test/index.js
+++ b/packages/rum-core/test/index.js
@@ -45,3 +45,21 @@ export function scheduleTaskCycles(callback, cycles = 0) {
     callback()
   }
 }
+
+/**
+ * Polyfilling the CustomEvent since they are available as objects
+ * in IE 9-11
+ * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+ */
+export function createCustomEvent(
+  event,
+  params = { bubbles: false, cancelable: false, detail: null }
+) {
+  if (typeof window.CustomEvent === 'function') {
+    return new CustomEvent(event, params)
+  }
+
+  const evt = document.createEvent('CustomEvent')
+  evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail)
+  return evt
+}


### PR DESCRIPTION
part of #496 
This PR adds patching for EventTarget. It doesn't not register any event listeners for the EventTarget patch events, will do that in a separate PR.
- [x] Add more tests