### PR TITLE
fix(rum-core): do not capture timing spans for unsampled transactions

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -156,8 +156,6 @@ class TransactionService {
       tr = this.ensureCurrentTransaction(name, type, perfOptions)
     }
 
-    tr.captureTimings = true
-
     if (tr.type === PAGE_LOAD) {
       tr.options.checkBrowserResponsiveness = false
       if (perfOptions.pageLoadTraceId) {
@@ -173,6 +171,14 @@ class TransactionService {
       if (tr.name === NAME_UNKNOWN && perfOptions.pageLoadTransactionName) {
         tr.name = perfOptions.pageLoadTransactionName
       }
+    }
+
+    /**
+     * For unsampled transactions, avoid capturing various timing informations
+     * as spans as they are dropped anyways before sending to the server
+     */
+    if (tr.sampled) {
+      tr.captureTimings = true
     }
 
     this.ensureRespInterval(tr.options.checkBrowserResponsiveness)

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -174,8 +174,8 @@ class TransactionService {
     }
 
     /**
-     * For unsampled transactions, avoid capturing various timing informations
-     * as spans as they are dropped anyways before sending to the server
+     * For unsampled transactions, avoid capturing various timing information
+     * as spans since they are dropped before sending to the server
      */
     if (tr.sampled) {
       tr.captureTimings = true

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -173,10 +173,10 @@ describe('TransactionService', function() {
   it('should not capture timings as spans for unsampled transactions', done => {
     const unMock = mockGetEntriesByType()
 
-    config.events.observe(TRANSACTION_END, () => {
-      expect(tr.sampled).toBe(false)
-      expect(tr.captureTimings).toBe(false)
-      expect(tr.spans.length).toBe(0)
+    config.events.observe(TRANSACTION_END, transaction => {
+      expect(transaction.sampled).toBe(false)
+      expect(transaction.captureTimings).toBe(false)
+      expect(transaction.spans.length).toBe(0)
       unMock()
       done()
     })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -170,6 +170,25 @@ describe('TransactionService', function() {
     tr2.detectFinish()
   })
 
+  it('should not capture timings as spans for unsampled transactions', done => {
+    const unMock = mockGetEntriesByType()
+
+    config.events.observe(TRANSACTION_END, () => {
+      expect(tr.sampled).toBe(false)
+      expect(tr.captureTimings).toBe(false)
+      expect(tr.spans.length).toBe(0)
+      unMock()
+      done()
+    })
+
+    const tr = transactionService.startTransaction(
+      'unsampled-test',
+      PAGE_LOAD,
+      { transactionSampleRate: 0 }
+    )
+    tr.detectFinish()
+  })
+
   it('should reuse Transaction', function() {
     transactionService = new TransactionService(logger, config)
     const reusableTr = new Transaction('test-name', 'test-type', {


### PR DESCRIPTION
+ fix #579 