### PR TITLE
chore(rum-vue): remove vue-router from peer dependencies

### DIFF
--- a/packages/rum-vue/package.json
+++ b/packages/rum-vue/package.json
@@ -48,8 +48,5 @@
   "dependencies": {
     "@elastic/apm-rum": "file:../rum",
     "@elastic/apm-rum-core": "file:../rum-core"
-  },
-  "peerDependencies": {
-    "vue-router": "^3.0.0"
   }
 }


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#574 
+ Vue plugin does not depend on Vue router and can work without router option being provided. 