### PR TITLE
test: allow to disable certificates verification on ITs

### DIFF
--- a/dev-utils/integration-test.js
+++ b/dev-utils/integration-test.js
@@ -28,7 +28,7 @@ const puppeteer = require('puppeteer')
 async function runIntegrationTest(pageUrl) {
   const browser = await puppeteer.launch({
     headless: true,
-    ignoreHTTPSErrors: process.env.ELASTIC_APM_VERIFY_SERVER_CERT == 'true'
+    ignoreHTTPSErrors: process.env.ELASTIC_APM_VERIFY_SERVER_CERT == 'true',
     args: ['--no-sandbox', '--disable-setuid-sandbox']
   })
   const result = {}

--- a/dev-utils/integration-test.js
+++ b/dev-utils/integration-test.js
@@ -28,6 +28,7 @@ const puppeteer = require('puppeteer')
 async function runIntegrationTest(pageUrl) {
   const browser = await puppeteer.launch({
     headless: true,
+    ignoreHTTPSErrors: process.env.ELASTIC_APM_VERIFY_SERVER_CERT == 'true'
     args: ['--no-sandbox', '--disable-setuid-sandbox']
   })
   const result = {}


### PR DESCRIPTION
## What does this PR do?

it evaluates an environment variable to enable or disable the certificates validation.

## Why is it important?

It allows using self-signed certificates for ITs.

## Related issues
related to https://github.com/elastic/apm-integration-testing/issues/13 and https://github.com/elastic/apm-integration-testing/issues/221
