### PR TITLE
chore(benchmark): run benchmarks on chromium, firefox and webkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,7 +5767,8 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5901,7 +5902,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -6176,6 +6178,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6355,7 +6358,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -7211,12 +7215,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -8222,7 +8228,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -8476,6 +8483,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -9462,6 +9470,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -10295,6 +10304,7 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
       "requires": {
         "concat-stream": "1.6.2",
         "debug": "2.6.9",
@@ -10306,6 +10316,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10313,7 +10324,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -10397,6 +10409,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -10721,7 +10734,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.9",
@@ -11853,6 +11867,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12691,6 +12706,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12699,7 +12715,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -13147,7 +13164,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -13523,7 +13541,8 @@
     "jpeg-js": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.6.tgz",
-      "integrity": "sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw=="
+      "integrity": "sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw==",
+      "dev": true
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -15136,6 +15155,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -15316,6 +15336,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -15323,7 +15344,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -15376,7 +15398,8 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "multimatch": {
       "version": "3.0.0",
@@ -16006,6 +16029,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16387,7 +16411,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -16442,7 +16467,8 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -16511,6 +16537,7 @@
       "version": "0.9.24",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.9.24.tgz",
       "integrity": "sha512-CdSY4rcrzkNkLIBhbu2qlhMrQdVXZzdL/Ybufh+SB+OLutNBnfFiZsnOJ6vow2W0ik1MWM1fabqXNnyoQsVItg==",
+      "dev": true,
       "requires": {
         "playwright-core": "=0.9.24"
       }
@@ -16519,6 +16546,7 @@
       "version": "0.9.24",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.9.24.tgz",
       "integrity": "sha512-4yxhmbk9wQGnhOsh8C6NLeQcez/uKzCgGAVwru47/1JrQV/MNyr+t4E+VBwGEcgnjzI9F33IaKsMuYDrqhBz4w==",
+      "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
@@ -16537,6 +16565,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
           "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -16545,6 +16574,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
           "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+          "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -16554,6 +16584,7 @@
               "version": "3.2.6",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -16563,12 +16594,14 @@
         "mime": {
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -16576,12 +16609,14 @@
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -16600,7 +16635,8 @@
     "pngjs": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -16764,12 +16800,14 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "progress-stream": {
       "version": "2.0.0",
@@ -16884,7 +16922,8 @@
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -17414,6 +17453,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -17821,7 +17861,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -19077,6 +19118,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -19899,7 +19941,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "3.7.3",
@@ -20171,7 +20214,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util-extend": {
       "version": "1.0.3",
@@ -20972,7 +21016,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -21269,6 +21314,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
       "requires": {
         "fd-slicer": "~1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,8 +5767,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5902,8 +5901,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -6178,7 +6176,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6358,8 +6355,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -7215,14 +7211,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -8228,8 +8222,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -8483,7 +8476,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -9470,7 +9462,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -10304,7 +10295,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "dev": true,
       "requires": {
         "concat-stream": "1.6.2",
         "debug": "2.6.9",
@@ -10316,7 +10306,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10324,8 +10313,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -10409,7 +10397,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -10734,8 +10721,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -11867,7 +11853,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12706,7 +12691,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12715,8 +12699,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -13164,8 +13147,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -13537,6 +13519,11 @@
           }
         }
       }
+    },
+    "jpeg-js": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.6.tgz",
+      "integrity": "sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw=="
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -15149,7 +15136,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -15330,7 +15316,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -15338,8 +15323,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -15392,8 +15376,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multimatch": {
       "version": "3.0.0",
@@ -16023,7 +16006,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16405,8 +16387,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -16461,8 +16442,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -16527,6 +16507,87 @@
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
+    "playwright": {
+      "version": "0.9.24",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.9.24.tgz",
+      "integrity": "sha512-CdSY4rcrzkNkLIBhbu2qlhMrQdVXZzdL/Ybufh+SB+OLutNBnfFiZsnOJ6vow2W0ik1MWM1fabqXNnyoQsVItg==",
+      "requires": {
+        "playwright-core": "=0.9.24"
+      }
+    },
+    "playwright-core": {
+      "version": "0.9.24",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.9.24.tgz",
+      "integrity": "sha512-4yxhmbk9wQGnhOsh8C6NLeQcez/uKzCgGAVwru47/1JrQV/MNyr+t4E+VBwGEcgnjzI9F33IaKsMuYDrqhBz4w==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^3.0.0",
+        "jpeg-js": "^0.3.6",
+        "mime": "^2.0.3",
+        "pngjs": "^3.4.0",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "uuid": "^3.4.0",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -16535,6 +16596,11 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -16698,14 +16764,12 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "progress-stream": {
       "version": "2.0.0",
@@ -16820,8 +16884,7 @@
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
-      "dev": true
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "prr": {
       "version": "1.0.1",
@@ -17351,7 +17414,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -17759,8 +17821,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -19016,7 +19077,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -19839,8 +19899,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
       "version": "3.7.3",
@@ -20112,8 +20171,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-extend": {
       "version": "1.0.3",
@@ -20914,8 +20972,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -21212,7 +21269,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
       "requires": {
         "fd-slicer": "~1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@elastic/apm-rum-angular": "file:packages/rum-angular",
     "@elastic/apm-rum-core": "file:packages/rum-core",
     "@elastic/apm-rum-react": "file:packages/rum-react",
-    "@elastic/apm-rum-vue": "file:packages/rum-vue"
+    "@elastic/apm-rum-vue": "file:packages/rum-vue",
+    "playwright": "^0.9.24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "lint-staged": "^9.5.0",
     "npm-run-all": "^4.1.5",
     "npmlog": "^4.1.2",
+    "playwright": "^0.9.24",
     "prettier": "^1.19.1",
     "puppeteer": "^1.20.0",
     "react": "^16.2.0",
@@ -143,7 +144,6 @@
     "@elastic/apm-rum-angular": "file:packages/rum-angular",
     "@elastic/apm-rum-core": "file:packages/rum-core",
     "@elastic/apm-rum-react": "file:packages/rum-react",
-    "@elastic/apm-rum-vue": "file:packages/rum-vue",
-    "playwright": "^0.9.24"
+    "@elastic/apm-rum-vue": "file:packages/rum-vue"
   }
 }

--- a/packages/rum-core/karma.bench.conf.js
+++ b/packages/rum-core/karma.bench.conf.js
@@ -65,13 +65,17 @@ module.exports = function(config) {
       formatOutput(results) {
         const summary = results.map(
           ({ suite, name, mean, count, cycle, browser, hz }) => {
+            /**
+             * Ignore version and os in browser
+             */
+            const browserName = browser.toLowerCase().split(' ')[0]
             return {
               suite,
               name,
               mean,
               count,
               cycle,
-              browser,
+              browser: browserName,
               hz,
               unit: 'ops/sec'
             }

--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -179,10 +179,6 @@ function calculateResults(resultMap) {
     let result = {}
     Object.keys(metricObj).forEach(metricName => {
       const value = metricObj[metricName]
-      console.log('value', value)
-      if (value == null) {
-        return
-      }
       /**
        * Add consumed memory in bytes per each function to the result
        */
@@ -200,6 +196,13 @@ function calculateResults(resultMap) {
          */
         result[metricName] = value
       } else {
+        /**
+         * Skip if the value inside the array is null
+         * which means the metric type is not captured inside the browser
+         */
+        if (value[0] == null) {
+          return
+        }
         const unit = getUnit(metricName)
         const mean = stats.mean(value)
         const p90 = stats.percentile(value, 90)

--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -103,7 +103,7 @@ function getCommonFields({ browser, url, scenario }) {
   const { minified, gzip } = getApmBundleSize()
   return {
     scenario,
-    'parameters.browser': browser,
+    browser,
     'parameters.url': url,
     'parameters.runs': runs,
     'parameters.images': scenario === 'heavy' ? noOfImages : 0,
@@ -130,47 +130,43 @@ function getUnit(metricName) {
 }
 
 async function analyzeMetrics(metric, resultMap) {
-  try {
-    const { cpu, payload, navigation, measure, url, scenario, memory } = metric
+  const { cpu, payload, navigation, measure, url, scenario, memory } = metric
 
-    const loadTime =
-      getFromEntries(navigation, url, 'loadEventEnd') -
-      getFromEntries(navigation, url, 'fetchStart')
-    const initializationTime = getFromEntries(measure, 'init', 'duration')
-    const parseAndExecTime = getFromEntries(
-      measure,
-      'parse-and-execute',
-      'duration'
-    )
+  const loadTime =
+    getFromEntries(navigation, url, 'loadEventEnd') -
+    getFromEntries(navigation, url, 'fetchStart')
+  const initializationTime = getFromEntries(measure, 'init', 'duration')
+  const parseAndExecTime = getFromEntries(
+    measure,
+    'parse-and-execute',
+    'duration'
+  )
 
-    /**
-     * Analysis of each run
-     */
-    const analysis = {
-      'page-load-time': loadTime,
-      'rum-init-time': initializationTime,
-      'parse-and-execute-time': parseAndExecTime,
-      'total-cpu-time': cpu.cpuTime,
-      'rum-cpu-time': cpu.cpuTimeFiltered,
-      'payload-size': payload.size,
-      transactions: payload.transactions,
-      spans: payload.spans,
-      memory
-    }
-
-    /**
-     * Accumulate result of each run in the corresponding scenario
-     */
-    Object.keys(analysis).forEach(key => {
-      const metricObj = resultMap.get(scenario)
-      if (!metricObj[key]) {
-        metricObj[key] = []
-      }
-      metricObj[key].push(analysis[key])
-    })
-  } catch (e) {
-    throw e
+  /**
+   * Analysis of each run
+   */
+  const analysis = {
+    'page-load-time': loadTime,
+    'rum-init-time': initializationTime,
+    'parse-and-execute-time': parseAndExecTime,
+    'total-cpu-time': cpu.cpuTime,
+    'rum-cpu-time': cpu.cpuTimeFiltered,
+    'payload-size': payload.size,
+    transactions: payload.transactions,
+    spans: payload.spans,
+    memory
   }
+
+  /**
+   * Accumulate result of each run in the corresponding scenario
+   */
+  Object.keys(analysis).forEach(key => {
+    const metricObj = resultMap.get(scenario)
+    if (!metricObj[key]) {
+      metricObj[key] = []
+    }
+    metricObj[key].push(analysis[key])
+  })
 }
 
 function calculateResults(resultMap) {

--- a/packages/rum/test/benchmarks/analyzer.js
+++ b/packages/rum/test/benchmarks/analyzer.js
@@ -99,11 +99,11 @@ function getApmBundleSize() {
   }
 }
 
-function getCommonFields({ version, url, scenario }) {
+function getCommonFields({ browser, url, scenario }) {
   const { minified, gzip } = getApmBundleSize()
   return {
     scenario,
-    'parameters.browser': version,
+    'parameters.browser': browser,
     'parameters.url': url,
     'parameters.runs': runs,
     'parameters.images': scenario === 'heavy' ? noOfImages : 0,
@@ -130,43 +130,47 @@ function getUnit(metricName) {
 }
 
 async function analyzeMetrics(metric, resultMap) {
-  const { cpu, payload, navigation, measure, url, scenario, memory } = metric
+  try {
+    const { cpu, payload, navigation, measure, url, scenario, memory } = metric
 
-  const loadTime =
-    getFromEntries(navigation, url, 'loadEventEnd') -
-    getFromEntries(navigation, url, 'fetchStart')
-  const initializationTime = getFromEntries(measure, 'init', 'duration')
-  const parseAndExecTime = getFromEntries(
-    measure,
-    'parse-and-execute',
-    'duration'
-  )
+    const loadTime =
+      getFromEntries(navigation, url, 'loadEventEnd') -
+      getFromEntries(navigation, url, 'fetchStart')
+    const initializationTime = getFromEntries(measure, 'init', 'duration')
+    const parseAndExecTime = getFromEntries(
+      measure,
+      'parse-and-execute',
+      'duration'
+    )
 
-  /**
-   * Analysis of each run
-   */
-  const analysis = {
-    'page-load-time': loadTime,
-    'rum-init-time': initializationTime,
-    'parse-and-execute-time': parseAndExecTime,
-    'total-cpu-time': cpu.cpuTime,
-    'rum-cpu-time': cpu.cpuTimeFiltered,
-    'payload-size': payload.size,
-    transactions: payload.transactions,
-    spans: payload.spans,
-    memory
-  }
-
-  /**
-   * Accumulate result of each run in the corresponding scenario
-   */
-  Object.keys(analysis).forEach(key => {
-    const metricObj = resultMap.get(scenario)
-    if (!metricObj[key]) {
-      metricObj[key] = []
+    /**
+     * Analysis of each run
+     */
+    const analysis = {
+      'page-load-time': loadTime,
+      'rum-init-time': initializationTime,
+      'parse-and-execute-time': parseAndExecTime,
+      'total-cpu-time': cpu.cpuTime,
+      'rum-cpu-time': cpu.cpuTimeFiltered,
+      'payload-size': payload.size,
+      transactions: payload.transactions,
+      spans: payload.spans,
+      memory
     }
-    metricObj[key].push(analysis[key])
-  })
+
+    /**
+     * Accumulate result of each run in the corresponding scenario
+     */
+    Object.keys(analysis).forEach(key => {
+      const metricObj = resultMap.get(scenario)
+      if (!metricObj[key]) {
+        metricObj[key] = []
+      }
+      metricObj[key].push(analysis[key])
+    })
+  } catch (e) {
+    throw e
+  }
 }
 
 function calculateResults(resultMap) {
@@ -175,6 +179,10 @@ function calculateResults(resultMap) {
     let result = {}
     Object.keys(metricObj).forEach(metricName => {
       const value = metricObj[metricName]
+      console.log('value', value)
+      if (value == null) {
+        return
+      }
       /**
        * Add consumed memory in bytes per each function to the result
        */

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -25,9 +25,10 @@
 
 const port = 9000
 module.exports = {
-  scenarios: ['basic', 'heavy'],
-  runs: 3,
+  scenarios: ['basic'],
+  runs: 1,
   noOfImages: 30,
+  browserTypes: ['firefox', 'webkit'],
   port,
   chrome: {
     /**

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -25,10 +25,10 @@
 
 const port = 9000
 module.exports = {
-  scenarios: ['basic'],
-  runs: 1,
+  scenarios: ['basic', 'heavy'],
+  runs: 3,
   noOfImages: 30,
-  browserTypes: ['firefox', 'webkit'],
+  browserTypes: ['chromium', 'firefox', 'webkit'],
   port,
   chrome: {
     /**

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -23,7 +23,7 @@
  *
  */
 
-const puppeteer = require('puppeteer')
+const playwright = require('playwright')
 const { chrome } = require('./config')
 const {
   filterCpuMetrics,
@@ -31,8 +31,8 @@ const {
   getMemoryAllocationPerFunction
 } = require('./analyzer')
 
-async function launchBrowser() {
-  return await puppeteer.launch(chrome.launchOptions)
+async function launchBrowser(type) {
+  return await playwright[type].launch(chrome.launchOptions)
 }
 
 function gatherRawMetrics(browser, url) {
@@ -40,26 +40,34 @@ function gatherRawMetrics(browser, url) {
     /**
      * Create a separate browsing context for each run
      */
-    const context = await browser.createIncognitoBrowserContext()
+    const context = await browser.newContext()
     const page = await context.newPage()
-    const client = await page.target().createCDPSession()
+
+    let client = null
+    try {
+      client = await browser.pageTarget(page).createCDPSession()
+    } catch (_) {}
+
     /**
      * Disable cache for each run
      */
     await page.setCacheEnabled(false)
-    /**
-     * Enable events from Chrome devtools protocol
-     */
-    await client.send('Page.enable')
-    await client.send('Profiler.enable')
-    await client.send('HeapProfiler.enable')
-    /**
-     * Tune the CPU sampler to get control the
-     * number of samples generated
-     */
-    await client.send('Profiler.setSamplingInterval', {
-      interval: chrome.cpuSamplingInterval
-    })
+
+    if (client) {
+      /**
+       * Enable events from Chrome devtools protocol
+       */
+      await client.send('Page.enable')
+      await client.send('Profiler.enable')
+      await client.send('HeapProfiler.enable')
+      /**
+       * Tune the CPU sampler to get control the
+       * number of samples generated
+       */
+      await client.send('Profiler.setSamplingInterval', {
+        interval: chrome.cpuSamplingInterval
+      })
+    }
 
     /**
      * Result metrics that will be filled at various
@@ -74,11 +82,15 @@ function gatherRawMetrics(browser, url) {
          * Stop the profiler once we post the transaction to
          * the apm server
          */
-        const result = await client.send('Profiler.stop')
-        const sample = await client.send('HeapProfiler.stopSampling')
+        let filteredCpuMetrics = {}
+        let memoryMetrics = []
+        if (client) {
+          const result = await client.send('Profiler.stop')
+          const sample = await client.send('HeapProfiler.stopSampling')
 
-        const memoryMetrics = getMemoryAllocationPerFunction(sample)
-        const filteredCpuMetrics = filterCpuMetrics(result.profile, url)
+          memoryMetrics = getMemoryAllocationPerFunction(sample)
+          filteredCpuMetrics = filterCpuMetrics(result.profile, url)
+        }
         const response = request.postData()
         const payload = capturePayloadInfo(response)
 
@@ -91,17 +103,26 @@ function gatherRawMetrics(browser, url) {
          * Resolve the promise once we measure the size
          * of the payload to APM Server
          */
+        // await context.close()
         resolve(metrics)
       }
     })
 
-    client.on('Page.loadEventFired', async function() {
+    page.on('load', async function() {
       const timings = await page.evaluate(() => {
         // Serializing the outputs otherwise it will be undefined
+        let entries = performance.getEntriesByType('navigation')
+        /**
+         * Webkit does not support navigation entry types
+         */
+        if (entries.length === 0) {
+          const { loadEventEnd, fetchStart } = performance.timing
+          let entry = { loadEventEnd, fetchStart, name: window.location.href }
+          entries = [entry]
+        }
+
         return {
-          navigation: JSON.stringify(
-            performance.getEntriesByType('navigation')
-          ),
+          navigation: JSON.stringify(entries),
           resource: JSON.stringify(performance.getEntriesByType('resource')),
           measure: JSON.stringify(performance.getEntriesByType('measure'))
         }
@@ -109,17 +130,19 @@ function gatherRawMetrics(browser, url) {
 
       Object.assign(metrics, timings)
     })
-    /**
-     * Perform a garbage collection to do a clean check everytime
-     */
-    await client.send('HeapProfiler.collectGarbage')
-    /**
-     * Start the CPU and Memory profiler before navigating to the URL
-     */
-    await client.send('Profiler.start')
-    await client.send('HeapProfiler.startSampling', {
-      interval: chrome.memorySamplingInterval
-    })
+    if (client) {
+      /**
+       * Perform a garbage collection to do a clean check everytime
+       */
+      await client.send('HeapProfiler.collectGarbage')
+      /**
+       * Start the CPU and Memory profiler before navigating to the URL
+       */
+      await client.send('Profiler.start')
+      await client.send('HeapProfiler.startSampling', {
+        interval: chrome.memorySamplingInterval
+      })
+    }
 
     await page.goto(url)
   })

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -43,6 +43,11 @@ function gatherRawMetrics(browser, url) {
     const context = await browser.newContext()
     const page = await context.newPage()
 
+    /**
+     * CDP session is only available on chromium based browsers which follows
+     * the devtools protocol
+     * https://chromedevtools.github.io/devtools-protocol/
+     */
     let client = null
     try {
       client = await browser.pageTarget(page).createCDPSession()
@@ -103,7 +108,6 @@ function gatherRawMetrics(browser, url) {
          * Resolve the promise once we measure the size
          * of the payload to APM Server
          */
-        // await context.close()
         resolve(metrics)
       }
     })

--- a/scripts/benchmarks.js
+++ b/scripts/benchmarks.js
@@ -126,7 +126,11 @@ function runBenchmarks() {
       let resultObj = {}
       for (let result of results) {
         const metricKey = result.name || result.scenario
-        resultObj[metricKey] = result
+        const browser = result.browser
+        if (!resultObj[metricKey]) {
+          resultObj[metricKey] = {}
+        }
+        resultObj[metricKey][browser] = result
       }
 
       const output = Object.assign({}, baseOutput, {


### PR DESCRIPTION
+ Just playing around and understanding how our agent performs in different browsers. 
+ uses the https://github.com/microsoft/playwright to run the benchmarks instead of puppeteer. 
+ Puppeteer now also released v2.1.0 which supports launching firefox. https://github.com/puppeteer/puppeteer/releases/tag/v2.1.0

