### PR TITLE
chore: enable id_field_data for elasticsearch

### DIFF
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "cluster.routing.allocation.disk.threshold_enabled=false"
       - "discovery.type=single-node"
       - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION}"
+      - "indices.id_field_data.enabled=true"
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
This PR enables id_field_data for elasticsearch instance defined in the docker-compose file. This option is required to avoid elasticsearch warnings. For more see https://github.com/elastic/apm-integration-testing/pull/696