### PR TITLE
docs: interpreting longtasks as spans

### DIFF
--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -1,37 +1,37 @@
 [[advanced-topics]]
 == Advanced Topics
 
-* <<custom-transactions, Custom Transactions>>
-* <<custom-transaction-name, Initial page load transaction names>>
 * <<longtasks>>
 * <<typescript>>
+* <<custom-transactions, Custom Transactions>>
+* <<custom-transaction-name, Initial page load transaction names>>
 
 [[longtasks]]
-=== How to interpret Longtask Spans in the UI
+=== How to interpret long task spans in the UI
 
-Longtasks is a new performance metric that helps measure the responsiveness and
-helps understand the bad user experience on the web. It enables detecting tasks
-that monopolize the UI thread for extended periods (greater than 50 milliseconds) and block other
-critical tasks from being executed as stated in the official spec[https://github.com/w3c/longtasks].
+Long tasks is a new performance metric that can be used for measuring the
+responsiveness of an application and helps developers to understand the bad user
+experience. It enables detecting tasks that monopolize the UI thread for
+extended periods (greater than 50 milliseconds) and block other
+critical tasks from being executed as stated in the https://github.com/w3c/longtasks[official spec].
 
-RUM agent automatically captures these Longtasks and include them as Spans as
-part of the transaction. Since Longtasks currently does not have the full information on
+RUM agent automatically captures these Long tasks and include them as spans as
+part of the transaction. Since long tasks currently does not have the full information on
 which part of code cause slowness, it would be hard to interpret these spans.
-Some tips below would interpret these spans in a meaningful way
+Below you can find some tips to help with interpreting long task spans:
 
-+ Name of the Longtask span could be `self`, `same-origin`, etc. would imply the
++ Name of the long task span (eg: `self`, `same-origin`) would imply the
   origin of the task. It could be the current browsing context or inside iframes.
 
 + Context of the span is enriched with useful information like `attribution`
   (the type of work such as script, layout, etc), `type`, `id` and `name` which
   determines the culprit container(such as window, iframe, embed or object)
-  responsible for the long task
+  responsible for the long task.
 
 With the help of the transaction timeline and the span timings, one could dig
-deeper by marking the slow application code using User Timing
-API[https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark]
-which would be again captured as Spans by the agent and combining them along with Longtasks would
-reveal the true source code location.
+deeper by marking the slow application code using https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark[User Timing
+API] which would be again captured as spans by the agent and combining them along
+with long tasks would reveal the true source code location.
 
 [[typescript]]
 === Using with TypeScript

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -20,12 +20,12 @@ part of the transaction. Since long tasks currently does not have the full infor
 which part of code cause slowness, it would be hard to interpret these spans.
 Below you can find some tips to help with interpreting long task spans:
 
-+ Name of the long task span (eg: `self`, `same-origin`) would imply the
+* The name of the long task span, e.g.: `self`, `same-origin`, etc., implies the
   origin of the task. It could be the current browsing context or inside iframes.
 
-+ Context of the span is enriched with useful information like `attribution`
-  (the type of work such as script, layout, etc), `type`, `id` and `name` which
-  determines the culprit container(such as window, iframe, embed or object)
+* Context of the span is enriched with useful information like `attribution`
+  (the type of work, such as script, layout, etc), `type`, `id` and `name`, which
+  determines the culprit container (such as window, iframe, embed or object)
   responsible for the long task.
 
 With the help of the transaction timeline and the span timings, one could dig

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -3,8 +3,35 @@
 
 * <<custom-transactions, Custom Transactions>>
 * <<custom-transaction-name, Initial page load transaction names>>
+* <<longtasks>>
 * <<typescript>>
 
+[[longtasks]]
+=== How to interpret Longtask Spans in the UI
+
+Longtasks is a new performance metric that helps measure the responsiveness and
+helps understand the bad user experience on the web. It enables detecting tasks
+that monopolize the UI thread for extended periods (greater than 50 milliseconds) and block other
+critical tasks from being executed as stated in the official spec[https://github.com/w3c/longtasks].
+
+RUM agent automatically captures these Longtasks and include them as Spans as
+part of the transaction. Since Longtasks currently does not have the full information on
+which part of code cause slowness, it would be hard to interpret these spans.
+Some tips below would interpret these spans in a meaningful way
+
++ Name of the Longtask span could be `self`, `same-origin`, etc. would imply the
+  origin of the task. It could be the current browsing context or inside iframes.
+
++ Context of the span is enriched with useful information like `attribution`
+  (the type of work such as script, layout, etc), `type`, `id` and `name` which
+  determines the culprit container(such as window, iframe, embed or object)
+  responsible for the long task
+
+With the help of the transaction timeline and the span timings, one could dig
+deeper by marking the slow application code using User Timing
+API[https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark]
+which would be again captured as Spans by the agent and combining them along with Longtasks would
+reveal the true source code location.
 
 [[typescript]]
 === Using with TypeScript

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -28,10 +28,11 @@ Below you can find some tips to help with interpreting long task spans:
   determines the culprit container (such as window, iframe, embed or object)
   responsible for the long task.
 
-With the help of the transaction timeline and the span timings, one could dig
-deeper by marking the slow application code using https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark[User Timing
-API] which would be again captured as spans by the agent and combining them along
-with long tasks would reveal the true source code location.
+With the help of the transaction timeline and span timings,
+one could dig deeper by marking slow application code with the
+https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark[User Timing API].
+When these spans are then captured by the agent again, you could combine them
+with long tasks to reveal the true source code location.
 
 [[typescript]]
 === Using with TypeScript


### PR DESCRIPTION
+ part of elastic/apm-agent-rum-js#478 
+ Added config for monitoring longtasks `monitorLongtasks` which is set to true by default. 
+ Added doc on how to interpret these tasks in the UI. 