### PR TITLE
feat(rum-core): add config option to monitor longtasks

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -303,4 +303,4 @@ NOTE: Spans that are captured as part of the ignored transactions would also be 
 
 Instructs the agent to start monitoring for browser tasks that block the UI
 thread and might delay other user inputs by affecting the overall page
-responsiveness. Learn more about <<longtasks, Longtask spans>> and how to interpret them.
+responsiveness. Learn more about <<longtasks, long task spans>> and how to interpret them.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -292,3 +292,15 @@ const options = {
 ----
 
 NOTE: Spans that are captured as part of the ignored transactions would also be ignored.
+
+
+[float]
+[[monitor-longtasks]]
+==== `monitorLongtasks`
+
+* *Type:* Boolean
+* *Default:* `false`
+
+Instructs the agent to start monitoring for browser tasks that block the UI
+thread and might delay other user inputs by affecting the overall page
+responsiveness. Learn more about <<longtasks, Longtask spans>> and how to interpret them.

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -101,6 +101,8 @@ class Config {
       transactionSampleRate: 1.0,
       centralConfig: false,
 
+      monitorLongtasks: false,
+
       context: {}
     }
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -195,7 +195,7 @@ class TransactionService {
     /**
      * Start observing for long tasks for all managed transactions
      */
-    if (!isRedefined) {
+    if (!isRedefined && this._config.get('monitorLongtasks')) {
       this.recorder.start(LONG_TASK)
     }
     /**

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -32,7 +32,9 @@ import { mockGetEntriesByType } from '../utils/globals-mock'
 import {
   TRANSACTION_END,
   PAGE_LOAD,
-  ROUTE_CHANGE
+  ROUTE_CHANGE,
+  LONG_TASK,
+  LARGEST_CONTENTFUL_PAINT
 } from '../../src/common/constants'
 
 describe('TransactionService', function() {
@@ -712,6 +714,7 @@ describe('TransactionService', function() {
       stopSpy.calls.reset()
     }
 
+    beforeAll(() => config.setConfig({ monitorLongtasks: true }))
     afterEach(() => resetSpies())
 
     it('should start/stop performance recorder for managed transaction', async () => {
@@ -720,8 +723,8 @@ describe('TransactionService', function() {
       })
       expect(startSpy).toHaveBeenCalledTimes(2)
       expect(startSpy.calls.allArgs()).toEqual([
-        ['largest-contentful-paint'],
-        ['longtask']
+        [LARGEST_CONTENTFUL_PAINT],
+        [LONG_TASK]
       ])
       await pageLoadTr.end()
       expect(stopSpy).toHaveBeenCalled()
@@ -731,7 +734,7 @@ describe('TransactionService', function() {
         managed: true
       })
       expect(startSpy).toHaveBeenCalled()
-      expect(startSpy.calls.allArgs()).toEqual([['longtask']])
+      expect(startSpy.calls.allArgs()).toEqual([[LONG_TASK]])
       await routeChangeTr.end()
       expect(stopSpy).toHaveBeenCalled()
     })
@@ -741,7 +744,7 @@ describe('TransactionService', function() {
         managed: true,
         canReuse: true
       })
-      expect(startSpy).toHaveBeenCalledWith('longtask')
+      expect(startSpy).toHaveBeenCalledWith(LONG_TASK)
       const managed2 = trService.startTransaction('test', 'custom', {
         managed: true,
         canReuse: true
@@ -758,15 +761,36 @@ describe('TransactionService', function() {
         managed: true,
         canReuse: true
       })
-      expect(startSpy).toHaveBeenCalledWith('longtask')
+      expect(startSpy).toHaveBeenCalledWith(LONG_TASK)
       const managedNonReusable = trService.startTransaction('test', 'custom', {
         managed: true
       })
-      expect(startSpy.calls.allArgs()).toEqual([['longtask'], ['longtask']])
+      expect(startSpy.calls.allArgs()).toEqual([[LONG_TASK], [LONG_TASK]])
       expect(stopSpy).toHaveBeenCalled()
       await managedReusable.end()
       await managedNonReusable.end()
       expect(stopSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not record longtasks when monitorLongtasks is false', async () => {
+      config.setConfig({
+        monitorLongtasks: false
+      })
+      const pageLoadTr = trService.startTransaction('test', PAGE_LOAD, {
+        managed: true
+      })
+      expect(startSpy).toHaveBeenCalledTimes(1)
+      expect(startSpy).toHaveBeenCalledWith(LARGEST_CONTENTFUL_PAINT)
+      await pageLoadTr.end()
+      expect(stopSpy).toHaveBeenCalled()
+      resetSpies()
+
+      const routeChangeTr = trService.startTransaction('test', ROUTE_CHANGE, {
+        managed: true
+      })
+      expect(startSpy).not.toHaveBeenCalled()
+      await routeChangeTr.end()
+      expect(stopSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -124,7 +124,8 @@ describe('TransactionService', function() {
       config: {},
       events: {
         send: onStartSpy
-      }
+      },
+      get: () => {}
     })
     const options = {
       managed: true,


### PR DESCRIPTION
+ part of elastic/apm-agent-rum-js#478 
+ Adds a config option to monitor longtasks as part of all managed transaction
+ The config is set to `false` by default for now. I am trying to understand the performance impact of capturing longtasks and PerformanceObserver in general. will set it to true once I find some details. Right now we use a single PO at the start, but I am not sure if its the correct approach as the spec does not talk about reusability and also if we observer/disconnect using same observer, observing on entry types multiples times triggers warnings. We are still able to measure longtaks, but its safer now to disable it till we learn more.  #601