### PR TITLE
ci(jenkins): support release automation

### DIFF
--- a/.ci/scripts/prepare-git-context.sh
+++ b/.ci/scripts/prepare-git-context.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+# Prepare the git workspace for the release in the CI
+# This is caused by the detached default repository.
+#
+# Some environment variables are required to be exposed beforehand:
+# - GITHUB_USER, the GitHub user account. This is set on the fly with some credentials.
+# - GITHUB_TOKEN , the GitHub api token. This is set on the fly with some credentials.
+# - ORG_NAME, the GitHub organisation. This is set on the fly when using the gitCheckout step.
+# - REPO_NAME, the GitHub repo. This is set on the fly when using the gitCheckout step.
+# - GIT_BASE_COMMIT, the sha commit. This is set on the fly when using the gitCheckout step.
+# - BRANCH_NAME, the branch name. This is set on the fly when using the Multibranch Pipeline.
+#
+
+# Enable git+https. Env variables are created on the fly with the gitCheckout
+git config remote.origin.url "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ORG_NAME}/${REPO_NAME}.git"
+
+# Enable to fetch branches when cloning with a detached and shallow clone
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+
+# Force the git user details when pushing using the last commit details
+USER_MAIL=$(git log -1 --pretty=format:'%ae')
+USER_NAME=$(git log -1 --pretty=format:'%an')
+git config user.email "${USER_MAIL}"
+git config user.name "${USER_NAME}"
+
+# Checkout the branch as it's detached based by default.
+# See https://issues.jenkins-ci.org/browse/JENKINS-33171
+git fetch --all
+git checkout "${BRANCH_NAME}"
+
+# Ensure the branch points to the original commit to avoid commit injection
+# when running the release pipeline.
+# used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
+git reset --hard "${GIT_BASE_COMMIT}"
+
+# Enable upstream with git+https.
+git remote add upstream "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ORG_NAME}/${REPO_NAME}.git"
+git fetch upstream

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,8 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-frontend'
+    NPMRC_SECRET = 'secret/jenkins-ci/npmjs/elasticmachine'
+    TOTP_SECRET = 'totp/code/npmjs-elasticmachine'
     PATH = "${env.PATH}:${env.WORKSPACE}/bin"
     MODE = "none"
   }
@@ -38,6 +40,7 @@ pipeline {
     booleanParam(name: 'saucelab_test', defaultValue: "true", description: "Enable run a Sauce lab test")
     booleanParam(name: 'parallel_test', defaultValue: "true", description: "Enable run tests in parallel")
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
+    booleanParam(name: 'release', defaultValue: false, description: 'Release.')
   }
   stages {
     stage('Initializing'){
@@ -273,28 +276,82 @@ pipeline {
           }
         }
         stage('Release') {
+          options {
+            skipDefaultCheckout()
+            timeout(time: 12, unit: 'HOURS')
+          }
+          environment {
+            HOME = "${env.WORKSPACE}"
+          }
+          when {
+            beforeAgent true
+            allOf {
+              branch 'master'
+              expression { return params.release }
+            }
+          }
+          stages {
+            stage('Notify') {
+              options { skipDefaultCheckout() }
+              steps {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}") {
+                  prepareRelease() {
+                    script {
+                      sh(label: 'Lerna version dry-run', script: 'npx lerna version --no-push --yes', returnStdout: true)
+                      def releaseVersions = sh(label: 'Gather versions from last commit', script: 'git log -1 --format="%b"', returnStdout: true)
+                      log(level: 'INFO', text: "Versions: ${releaseVersions}")
+                      emailext subject: "[${env.REPO}] Release ready to be pushed", to: "${NOTIFY_TO}",
+                               body: "Please go to ${env.BUILD_URL}input to approve or reject within 12 hours.\n Changes: ${releaseVersions}"
+                      input(message: 'Should we release a new version?', ok: 'Yes, we should.',
+                            parameters: [text(description: 'Look at the versions to be released. They cannot be edited here',
+                                              defaultValue: "${releaseVersions}", name: 'versions')])
+                    }
+                  }
+                }
+              }
+            }
+            stage('Release CI') {
+              options { skipDefaultCheckout() }
+              steps {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}") {
+                  prepareRelease() {
+                    sh 'npm run release-ci'
+                  }
+                }
+              }
+              post {
+                always {
+                  script {
+                    currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"
+                  }
+                }
+              }
+            }
+          }
+        }
+        stage('Opbeans') {
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
             tag pattern: '@elastic/apm-rum@\\d+\\.\\d+\\.\\d+$', comparator: 'REGEXP'
           }
-          stages {
-            stage('Opbeans') {
-              environment {
-                REPO_NAME = "${OPBEANS_REPO}"
-              }
-              steps {
-                deleteDir()
-                dir("${OPBEANS_REPO}"){
-                  git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                      url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-                  sh script: ".ci/bump-version.sh '${env.BRANCH_NAME}'", label: 'Bump version'
-                  // The opbeans pipeline will trigger a release for the master branch
-                  gitPush()
-                  // The opbeans pipeline will trigger a release for the release tag
-                  gitCreateTag(tag: "${env.BRANCH_NAME}")
-                }
-              }
+          environment {
+            REPO_NAME = "${OPBEANS_REPO}"
+          }
+          steps {
+            deleteDir()
+            dir("${OPBEANS_REPO}"){
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+              sh script: ".ci/bump-version.sh '${env.BRANCH_NAME}'", label: 'Bump version'
+              // The opbeans pipeline will trigger a release for the master branch
+              gitPush()
+              // The opbeans pipeline will trigger a release for the release tag
+              gitCreateTag(tag: "${env.BRANCH_NAME}")
             }
           }
         }
@@ -385,6 +442,23 @@ def wrappingUp(){
     keepLongStdio: true,
     testResults: "${env.BASE_DIR}/packages/**/reports/TESTS-*.xml")
   archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.BASE_DIR}/.npm/_logs,${env.BASE_DIR}/packages/**/reports/TESTS-*.xml")
+}
+
+def prepareRelease(String nodeVersion='node:lts', Closure body){
+  withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
+    withCredentials([usernamePassword(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+                                      passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+      docker.image(nodeVersion).inside(){
+        withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR}"]) {
+          sh '.ci/scripts/prepare-git-context.sh'
+          sh 'npm ci'
+          withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
+            body()
+          }
+        }
+      }
+    }
+  }
 }
 
 def runAllScopes(){

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Releasing
 
+## Manually
+
 Before releasing a new version of packages to the NPM and GitHub, Set all the environment variables necessary for the testing and release scripts. The required variables are
 - APM_SERVER_URL
 - GITHUB_TOKEN
@@ -35,3 +37,15 @@ Before releasing, be sure to update the following documentation:
 
 - Update `CHANGELOG.asciidoc` to add release notes for the new version. Headings should follow this format: `==== x.x.x (yyyy-MM-dd)`.
 - For Major and minor releases: Add a new row to the EOL table in `docs/upgrading.asciidoc`. The EOL date is the release date plus 18 months.
+
+## CI based
+
+The release process is also automated in the way any specific commit from the master branch can be potentially released, for such it's required the below steps:
+
+1. Login to apm-ci.elastic.co
+1. Go to the [master](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/master/) pipeline.
+1. Click on `Build with parameters` and choose the `release` checkbox.
+1. Wait for an email to confirm the release is ready to be approved, it might take roughly 30 minutes.
+1. Confirm if the list of changes are the ones that are expected.
+1. Approve or abort.
+1. Then you can go to the https://registry.npmjs.org and GitHub repo to validate that the bundles and release notes have been published.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3972,16 +3972,6 @@
         }
       }
     },
-    "@lerna/prompt": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.18.5.tgz",
-      "integrity": "sha512-rkKj4nm1twSbBEb69+Em/2jAERK8htUuV8/xSjN0NPC+6UjzAwY52/x9n5cfmpa9lyKf/uItp7chCI7eDmNTKQ==",
-      "dev": true,
-      "requires": {
-        "inquirer": "^6.2.0",
-        "npmlog": "^4.1.2"
-      }
-    },
     "@lerna/publish": {
       "version": "3.18.5",
       "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.5.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "serve": "node ./dev-utils/run-script.js startTestServers",
     "coverage": "lerna run build:module && lerna run karma:coverage",
     "bench:dev": "lerna run build:module && node ./scripts/benchmarks.js",
-    "clean": "npx lerna exec -- rm -rf dist/"
+    "clean": "npx lerna exec -- rm -rf dist/",
+    "release-ci": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
   },
   "lint-staged": {
     "*.{js,jsx,ts}": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "coverage": "lerna run build:module && lerna run karma:coverage",
     "bench:dev": "lerna run build:module && node ./scripts/benchmarks.js",
     "clean": "npx lerna exec -- rm -rf dist/",
-    "release-ci": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
+    "release-ci": "lerna publish --otp=${TOTP_CODE} && npm run github-release"
   },
   "lint-staged": {
     "*.{js,jsx,ts}": [
@@ -86,7 +86,6 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@lerna/child-process": "^3.16.5",
-    "@lerna/prompt": "^3.18.5",
     "@types/jasmine": "^3.5.0",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "coverage": "lerna run build:module && lerna run karma:coverage",
     "bench:dev": "lerna run build:module && node ./scripts/benchmarks.js",
     "clean": "npx lerna exec -- rm -rf dist/",
-    "release-ci": "lerna publish --otp=${TOTP_CODE} && npm run github-release"
+    "release-ci": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
   },
   "lint-staged": {
     "*.{js,jsx,ts}": [

--- a/scripts/prompt-release.js
+++ b/scripts/prompt-release.js
@@ -24,7 +24,6 @@
  */
 
 const log = require('npmlog')
-const PromptUtils = require('@lerna/prompt')
 const childProcess = require('@lerna/child-process')
 
 !(async () => {
@@ -39,21 +38,7 @@ const childProcess = require('@lerna/child-process')
       './packages/rum/src/apm-base.js'
     ])
 
-    /**
-     * Prompt for working directory clean
-     */
-    const answer = await PromptUtils.confirm(
-      'Are these changes ok (Check your working directory before continuing)'
-    )
-
-    if (!answer) {
-      log.error(
-        'release',
-        'Aborting the release process',
-        `Please run 'npm run release' again to start`
-      )
-      process.exit(1)
-    }
+    childProcess.execSync('git', ['add', './packages/rum/src/apm-base.js'])
   } catch (err) {
     log.error(err)
   }


### PR DESCRIPTION
### What

Release automation from the master branch, with the below support:

- Email notification when a new release is triggered by the Jenkins UI.
- Input approval to confirm the release should be out with 12 hours waiting for.
- Release automation with 2FA.
- Update docs regarding the release process with the CI.

### Why

No hands!

### Actions
- [x] Release from the upstream, so it's required to change the repo accordingly.
- [x] Gather the versions to be updated with some git diff and lerna version commands


### Issues

Caused by https://github.com/elastic/apm-agent-rum-js/issues/518

### UI
- Input approval with the list of changes to be released

BO view:

![image](https://user-images.githubusercontent.com/2871786/73674432-64558e00-46a8-11ea-9756-1080b31a7aae.png)

Traditional view:

![image](https://user-images.githubusercontent.com/2871786/73766321-c3c9a180-476d-11ea-90f9-e24f0dfc81cd.png)

### Tests

I just verified the production credentials worked as expected, for the repo https://github.com/v1v/test-2fa/commits/master I did run the pipeline

![image](https://user-images.githubusercontent.com/2871786/78535047-668cb380-77e3-11ea-8d0c-7bc87040e567.png)

That released 1.4.0 (see the collaborators):

![image](https://user-images.githubusercontent.com/2871786/78535074-74dacf80-77e3-11ea-946a-b928ca41ca70.png)
