### PR TITLE
feat: capture click user-interaction transactions

### DIFF
--- a/dev-utils/webdriver.js
+++ b/dev-utils/webdriver.js
@@ -345,6 +345,14 @@ function getBrowserInfo() {
   }
 }
 
+function getBrowserFeatures() {
+  return browser.executeAsync(function(done) {
+    done({
+      EventTarget: !!window.EventTarget
+    })
+  })
+}
+
 function isChromeLatest() {
   const { name, version } = getBrowserInfo()
   const isChrome = name.indexOf('chrome') !== -1
@@ -360,5 +368,6 @@ module.exports = {
   isChromeLatest,
   getWebdriveBaseConfig,
   getBrowserInfo,
-  waitForApmServerCalls
+  waitForApmServerCalls,
+  getBrowserFeatures
 }

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -66,6 +66,7 @@ const MAX_SPAN_DURATION = 5 * 60 * 1000
 const PAGE_LOAD = 'page-load'
 const ROUTE_CHANGE = 'route-change'
 const TYPE_CUSTOM = 'custom'
+const USER_INTERACTION = 'user-interaction'
 const HTTP_REQUEST_TYPE = 'http-request'
 const TEMPORARY_TYPE = 'temporary'
 const NAME_UNKNOWN = 'Unknown'
@@ -73,6 +74,7 @@ const NAME_UNKNOWN = 'Unknown'
 const TRANSACTION_TYPE_ORDER = [
   PAGE_LOAD,
   ROUTE_CHANGE,
+  USER_INTERACTION,
   HTTP_REQUEST_TYPE,
   TYPE_CUSTOM,
   TEMPORARY_TYPE
@@ -174,5 +176,6 @@ export {
   BROWSER_RESPONSIVENESS_BUFFER,
   SIMILAR_SPAN_TO_TRANSACTION_RATIO,
   TEMPORARY_TYPE,
+  USER_INTERACTION,
   TRANSACTION_TYPE_ORDER
 }

--- a/packages/rum-core/src/common/instrument.js
+++ b/packages/rum-core/src/common/instrument.js
@@ -23,7 +23,14 @@
  *
  */
 
-import { XMLHTTPREQUEST, FETCH, HISTORY, PAGE_LOAD, ERROR } from './constants'
+import {
+  XMLHTTPREQUEST,
+  FETCH,
+  HISTORY,
+  PAGE_LOAD,
+  ERROR,
+  EVENT_TARGET
+} from './constants'
 
 export function getInstrumentationFlags(instrument, disabledInstrumentations) {
   /**
@@ -34,7 +41,8 @@ export function getInstrumentationFlags(instrument, disabledInstrumentations) {
     [FETCH]: false,
     [HISTORY]: false,
     [PAGE_LOAD]: false,
-    [ERROR]: false
+    [ERROR]: false,
+    [EVENT_TARGET]: false
   }
 
   if (!instrument) {

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -100,16 +100,22 @@ class PerformanceMonitoring {
         task.source === EVENT_TARGET &&
         task.eventType === 'click'
       ) {
-        let target = task.target
-        let name = target.getAttribute('name')
+        const target = task.target
+        const name = target.getAttribute('name')
 
         let additionalInfo = ''
         if (name) {
           additionalInfo = `["${name}"]`
         }
 
-        let tagName = target.tagName.toLowerCase()
-        let tr = transactionService.startTransaction(
+        const tagName = target.tagName.toLowerCase()
+
+        /**
+         * We reduce the reusability threshold to make sure
+         * we only capture async activities (e.g. network)
+         * related to this interaction.
+         */
+        const tr = transactionService.startTransaction(
           `Click >> ${tagName}${additionalInfo}`,
           USER_INTERACTION,
           {

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -68,7 +68,8 @@ class Transaction extends SpanBase {
     this.addMarks({ custom })
   }
 
-  canReuse(threshold = REUSABILITY_THRESHOLD) {
+  canReuse() {
+    let threshold = this.options.reuseThreshold || REUSABILITY_THRESHOLD
     return (
       !!this.options.canReuse && !this.ended && now() - this._start < threshold
     ) // To avoid a stale transaction capture everything

--- a/packages/rum-core/test/common/instrument.spec.js
+++ b/packages/rum-core/test/common/instrument.spec.js
@@ -29,7 +29,8 @@ import {
   XMLHTTPREQUEST,
   FETCH,
   HISTORY,
-  ERROR
+  ERROR,
+  EVENT_TARGET
 } from '../../src/common/constants'
 
 describe('Instrumentation', function() {
@@ -41,7 +42,8 @@ describe('Instrumentation', function() {
       [XMLHTTPREQUEST]: false,
       [FETCH]: false,
       [HISTORY]: false,
-      [ERROR]: false
+      [ERROR]: false,
+      [EVENT_TARGET]: false
     })
   })
 
@@ -53,7 +55,8 @@ describe('Instrumentation', function() {
       [XMLHTTPREQUEST]: false,
       [FETCH]: true,
       [HISTORY]: false,
-      [ERROR]: true
+      [ERROR]: true,
+      [EVENT_TARGET]: true
     })
   })
 })

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -798,6 +798,19 @@ describe('PerformanceMonitoring', function() {
     tr.end()
   })
 
+  it('should filter out managed transactions without any spans', () => {
+    spyOn(logger, 'debug').and.callThrough()
+    const transaction = new Transaction('test', 'custom', { id: 1 })
+    transaction.end()
+    transaction._end = transaction._end + 100
+    expect(performanceMonitoring.filterTransaction(transaction)).toBe(true)
+    transaction.options.managed = true
+    expect(performanceMonitoring.filterTransaction(transaction)).toBe(false)
+    expect(logger.debug).toHaveBeenCalledWith(
+      'transaction(1, test) was discarded! Transaction does not have any spans'
+    )
+  })
+
   if (window.EventTarget) {
     it('should create click transactions', () => {
       let transactionService = performanceMonitoring._transactionService
@@ -817,7 +830,10 @@ describe('PerformanceMonitoring', function() {
 
       let tr = transactionService.getCurrentTransaction()
       expect(tr).toBeDefined()
-      expect(tr.name).toBe('Click >> button.cool-button.purchase-style')
+      expect(tr.name).toBe('Click >> button')
+      expect(tr.context.custom).toEqual({
+        classes: 'cool-button purchase-style'
+      })
       expect(tr.type).toBe('user-interaction')
 
       element.setAttribute('name', 'purchase')
@@ -826,6 +842,38 @@ describe('PerformanceMonitoring', function() {
 
       expect(newTr).toBe(tr)
       expect(newTr.name).toBe('Click >> button["purchase"]')
+    })
+
+    it('should respect the transaction type priority order', function() {
+      const historySubFn = performanceMonitoring.getHistorySub()
+      const cancelHistorySub = patchEventHandler.observe(HISTORY, historySubFn)
+      let etsub = performanceMonitoring.getEventTargetSub()
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
+      const transactionService = performanceMonitoring._transactionService
+
+      let element = document.createElement('button')
+      element.setAttribute('name', 'purchase')
+
+      const listener = () => {
+        let tr = transactionService.getCurrentTransaction()
+        expect(tr.type).toBe('user-interaction')
+        history.pushState(undefined, undefined, 'test')
+      }
+
+      element.addEventListener('click', listener)
+      element.click()
+
+      let tr = transactionService.getCurrentTransaction()
+      expect(tr.name).toBe('Click >> button["purchase"]')
+      expect(tr.type).toBe('route-change')
+
+      cancelHistorySub()
+      cancelEventTargetSub()
     })
   }
 })

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -144,5 +144,13 @@ describe('transaction.Transaction', function() {
 
     transaction._start = transaction._start - 10000
     expect(transaction.canReuse()).toBe(false)
+
+    transaction = new Transaction('transaction', 'transaction', {
+      canReuse: true,
+      reuseThreshold: 100
+    })
+    expect(transaction.canReuse()).toBe(true)
+    transaction._start = transaction._start - 101
+    expect(transaction.canReuse()).toBe(false)
   })
 })

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -111,6 +111,11 @@ generateError.tmp = 'tmp'
 
 testFetch(mockBackendUrl)
 
+let testAction = document.getElementsByName('test-action')[0]
+testAction.addEventListener('click', function() {
+  testXHR(mockBackendUrl)
+})
+
 if (location.hash === '#test-state') {
   const path = location.pathname
   history.pushState(

--- a/packages/rum/test/e2e/general-usecase/index.html
+++ b/packages/rum/test/e2e/general-usecase/index.html
@@ -11,6 +11,7 @@
 
   <body>
     <div id="app"></div>
+    <button name="test-action" id="test-action">Test Action</button>
     <script src="/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret"></script>
   </body>
 </html>


### PR DESCRIPTION
Part of #496 

This PR captures click events as `user-interaction` transactions. 

![image](https://user-images.githubusercontent.com/6134122/73749985-b0faa100-475c-11ea-8cb4-4a359cf4cc0b.png)

