### PR TITLE
ci(jenkins): less verbose console output

### DIFF
--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures
-docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO build --quiet --force-rm
+docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO build --force-rm >docker-compose.log 2>docker-compose.err
+if [ $? -gt 0 ] ; then
+  echo "Docker compose failed, see the below log output"
+  cat docker-compose.log && rm docker-compose.log
+  cat docker-compose.err && rm docker-compose.err
+  exit 1
+else
+  rm docker-compose.log docker-compose.err
+fi

--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-docker-compose -f ./dev-utils/docker-compose.yml pull --ignore-pull-failures
-docker-compose -f ./dev-utils/docker-compose.yml build --force-rm
+docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures
+docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO build --quiet --force-rm

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 USER_ID="$(id -u):$(id -g)" \
-docker-compose -f ./dev-utils/docker-compose.yml up \
+docker-compose -f ./dev-utils/docker-compose.yml \
+  --log-level INFO \
+  up \
+  --quiet-pull \
   --abort-on-container-exit \
   --exit-code-from node-puppeteer \
   --remove-orphans \


### PR DESCRIPTION
Reduces the verbose output that's generated when pulling and building the docker images for the test stage.

This will help to debug console log outputs in the CI

I did test this with a mock error in the Dockerfile ( `RUN exit 1` ) and the outcome was something like the below snippet

```
+ docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO build --quiet --force-rm
WARNING: The STACK_VERSION variable is not set. Defaulting to a blank string.
WARNING: The SCOPE variable is not set. Defaulting to a blank string.
WARNING: The APM_SERVER_URL variable is not set. Defaulting to a blank string.
WARNING: The BUILD_NUMBER variable is not set. Defaulting to a blank string.
WARNING: The BRANCH_NAME variable is not set. Defaulting to a blank string.
WARNING: The JENKINS_URL variable is not set. Defaulting to a blank string.
WARNING: The SAUCE_USERNAME variable is not set. Defaulting to a blank string.
WARNING: The SAUCE_ACCESS_KEY variable is not set. Defaulting to a blank string.
WARNING: The MODE variable is not set. Defaulting to a blank string.
WARNING: The GOAL variable is not set. Defaulting to a blank string.
WARNING: The WORKSPACE variable is not set. Defaulting to a blank string.
WARNING: The BASE_DIR variable is not set. Defaulting to a blank string.
WARNING: The USER_ID variable is not set. Defaulting to a blank string.
WARNING: The REPORT_FILE variable is not set. Defaulting to a blank string.
ERROR: Service 'node-puppeteer' failed to build: The command '/bin/sh -c exit 1' returned a non-zero code: 1
```