### PR TITLE
docs: Fix release build

### DIFF
--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -127,7 +127,7 @@ curl http://localhost:8200/assets/v1/sourcemaps -X POST \
 [[secret-token]]
 === Using a secret token
 
-You can {apm-server-ref-v}/secure-communication-agents.html#secret-token[configure a secret token on APM Server] to restrict uploading sourcemaps.
+You can {apm-server-ref-v}/secure-communication-agents.html[configure a secret token on APM Server] to restrict uploading sourcemaps.
 
 Here's how to add the secret token to a curl command:
 


### PR DESCRIPTION
The release build isn't having a fun day. This fixes one of the broken links. I'm sorry, but I need to backport this to `4.x`, `3.x`, and `2.x`.

The API Key documentation moved around some of the secret token documentation, which is why this problem is occurring. I'll also open an issue to update the documentation to add API key information later.

Context: https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/12089/console