### PR TITLE
fix: pass correct properties to payload filters

### DIFF
--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -423,6 +423,25 @@ describe('ApmServer', function() {
     expect(result).toEqual([expected])
   })
 
+  it('should pass correct payload to filters', () => {
+    configService.setConfig({
+      serviceName: 'serviceName'
+    })
+    let type = ''
+    configService.addFilter(function(payload) {
+      expect(payload[type]).toBeDefined()
+      return payload
+    })
+
+    type = 'errors'
+    let result = apmServer.sendErrors([{ test: 'test' }])
+    expect(result).toBeDefined()
+
+    type = 'transactions'
+    result = apmServer.sendTransactions([{ test: 'test' }])
+    expect(result).toBeDefined()
+  })
+
   if (isVersionInRange(testConfig.stackVersion, '7.3.0')) {
     it('should fetch remote config', async () => {
       spyOn(configService, 'setLocalConfig')

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -427,19 +427,22 @@ describe('ApmServer', function() {
     configService.setConfig({
       serviceName: 'serviceName'
     })
+    /**
+     * We don't want to send these payloads to the apm server
+     * since they are only tests and not valid payloads.
+     */
+    spyOn(apmServer, '_postJson')
     let type = ''
     configService.addFilter(function(payload) {
-      expect(payload[type]).toBeDefined()
+      expect(payload[type]).toEqual([{ test: type }])
       return payload
     })
 
     type = 'errors'
-    let result = apmServer.sendErrors([{ test: 'test' }])
-    expect(result).toBeDefined()
+    apmServer.sendErrors([{ test: 'errors' }])
 
     type = 'transactions'
-    result = apmServer.sendTransactions([{ test: 'test' }])
-    expect(result).toBeDefined()
+    apmServer.sendTransactions([{ test: 'transactions' }])
   })
 
   if (isVersionInRange(testConfig.stackVersion, '7.3.0')) {


### PR DESCRIPTION
This bug was introduced around 4.0.2 release and therefore affects nearly all 4.x versions. I've added more tests to cover this case. I've also removed the undocumented `service` property from the payload passed to filters.