### PR TITLE
fix(rum-core): Only capture events on Elements

### DIFF
--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -40,6 +40,14 @@ for (let i = 0; i < eventTypes.length; i++) {
   eventTypeSymbols[et] = apmSymbol(et)
 }
 
+function shouldInstrumentEvent(target, eventType, listenerFn) {
+  return (
+    target instanceof Element &&
+    eventTypes.indexOf(eventType) >= 0 &&
+    typeof listenerFn === 'function'
+  )
+}
+
 export function patchEventTarget(callback) {
   if (!window.EventTarget) {
     return
@@ -165,10 +173,10 @@ export function patchEventTarget(callback) {
     listenerFn,
     optionsOrCapture
   ) {
-    if (eventTypes.indexOf(eventType) < 0 || typeof listenerFn !== 'function') {
-      return nativeAddEventListener.apply(this, arguments)
-    }
     const target = this
+    if (!shouldInstrumentEvent(target, eventType, listenerFn)) {
+      return nativeAddEventListener.apply(target, arguments)
+    }
 
     const wrappingListenerFn = createListenerWrapper(
       target,
@@ -188,10 +196,10 @@ export function patchEventTarget(callback) {
     listenerFn,
     optionsOrCapture
   ) {
-    if (eventTypes.indexOf(eventType) < 0 || typeof listenerFn !== 'function') {
-      return nativeRemoveEventListener.apply(this, arguments)
-    }
     const target = this
+    if (!shouldInstrumentEvent(target, eventType, listenerFn)) {
+      return nativeRemoveEventListener.apply(target, arguments)
+    }
 
     let wrappingFn = getWrappingFn(
       target,

--- a/packages/rum-core/test/common/event-target-patch.spec.js
+++ b/packages/rum-core/test/common/event-target-patch.spec.js
@@ -148,5 +148,25 @@ describe('EventTargetPatch', function() {
       expect(count).toBe(4)
       expect(events.length).toBe(8)
     })
+
+    it('should not instrument non-Element targets', () => {
+      let count = 0
+      const eventType = 'click'
+      const listener = e => {
+        expect(e.type).toBe(eventType)
+        count++
+      }
+
+      let event = createCustomEvent(eventType)
+      window.addEventListener(eventType, listener)
+      window.dispatchEvent(event)
+      expect(count).toBe(1)
+      expect(events.length).toBe(0)
+
+      window.addEventListener.apply(undefined, [eventType, listener, true])
+      window.dispatchEvent(event)
+      expect(count).toBe(3)
+      expect(events.length).toBe(0)
+    })
   }
 })


### PR DESCRIPTION
This PR makes sure that we only capture events on instances of Element. Furthermore, some frameworks like turbolinks patch `addEventListener` and this might cause the target to be undefined, checking the instance of the target will prevent this as well.