### PR TITLE
BREAKING CHANGE: use the official traceparent header

### DIFF
--- a/dev-utils/test-servers.js
+++ b/dev-utils/test-servers.js
@@ -39,14 +39,14 @@ function startBackendAgentServer(port = 8003) {
     if (req.method === 'OPTIONS') {
       res.header(
         'Access-Control-Allow-Headers',
-        'Origin, elastic-apm-traceparent, Content-Type, Accept'
+        'Origin, traceparent, Content-Type, Accept'
       )
     }
     next()
   })
 
   function dTRespond(req, res) {
-    const header = req.headers['elastic-apm-traceparent']
+    const header = req.headers['traceparent']
     let payload = { noHeader: true }
     if (header) {
       const splited = header.split('-')
@@ -56,7 +56,7 @@ function startBackendAgentServer(port = 8003) {
         parentId: splited[2],
         flags: splited[3]
       }
-      console.log('elastic-apm-traceparent:', header)
+      console.log('traceparent:', header)
     }
 
     res.setHeader('Content-Type', 'application/json')

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -91,7 +91,7 @@ class Config {
 
       distributedTracing: true,
       distributedTracingOrigins: [],
-      distributedTracingHeaderName: 'elastic-apm-traceparent',
+      distributedTracingHeaderName: 'traceparent',
 
       pageLoadTraceId: '',
       pageLoadSpanId: '',


### PR DESCRIPTION
Part of #477
This PR uses the official W3C tracecontext `traceparent` header instead `elastic-apm-traceparent` which we previously used. 