### PR TITLE
ci(jenkins): use changeRequest()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     SAUCELABS_SECRET = 'secret/apm-team/ci/apm-agent-rum-saucelabs'
     DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-763'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-frontend'
   }
   options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,15 +162,12 @@ pipeline {
           agent none
           when {
             beforeAgent true
-            allOf {
-              anyOf {
-                environment name: 'GIT_BUILD_CAUSE', value: 'pr'
-                expression { return !params.Run_As_Master_Branch }
-              }
+            anyOf {
+              changeRequest()
+              expression { return !params.Run_As_Master_Branch }
             }
           }
           steps {
-            log(level: 'INFO', text: 'Launching Async ITs')
             build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                   parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'RUM'),
                                string(name: 'BUILD_OPTS', value: "--rum-agent-branch ${env.GIT_BASE_COMMIT}"),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     SAUCELABS_SECRET = 'secret/apm-team/ci/apm-agent-rum-saucelabs'
     DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-763'
     OPBEANS_REPO = 'opbeans-frontend'
   }
   options {


### PR DESCRIPTION
Cosmetic change in the pipeline, and validate if the opbeans validation with PRs works as expected

Depends on https://github.com/elastic/apm-integration-testing/pull/763

### Screenshots

This pipeline will trigger another downstream job that will evaluate the `apm-integration-testing` for the given agent version and also the opbeans app.

The look and feel can be seen below:

![image](https://user-images.githubusercontent.com/2871786/74846648-b9d89e80-5328-11ea-8e49-cc2567147c19.png)
