### PR TITLE
ci(jenkins): test pipeline optimisation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-frontend'
+    PATH = "${env.PATH}:${env.WORKSPACE}/bin"
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -48,9 +49,6 @@ pipeline {
   stages {
     stage('Initializing'){
       options { skipDefaultCheckout() }
-      environment {
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-      }
       stages {
         /**
         Checkout the code and stash it, to use it on other stages.
@@ -97,23 +95,23 @@ pipeline {
             }
           }
         }
-        /**
-        Execute code coverange only once.
-        */
-        stage('Coverage') {
-          steps {
-            withGithubNotify(context: 'Coverage') {
-              // No scope is required as the coverage should run for all of them
-              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
-              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
+        stage('Integration Tests') {
+          agent none
+          when {
+            beforeAgent true
+            anyOf {
+              changeRequest()
+              expression { return !params.Run_As_Master_Branch }
             }
           }
-          post {
-            always {
-              coverageReport("${BASE_DIR}/packages/**")
-              publishCoverage(adapters: [coberturaAdapter("${BASE_DIR}/packages/**/coverage-*-report.xml")],
-                              sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
-            }
+          steps {
+            build(job: env.ITS_PIPELINE, propagate: false, wait: false,
+                  parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'RUM'),
+                               string(name: 'BUILD_OPTS', value: "--rum-agent-branch ${env.GIT_BASE_COMMIT}"),
+                               string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                               string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                               string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
           }
         }
         /**
@@ -158,26 +156,24 @@ pipeline {
             }
           }
         }
-        stage('Integration Tests') {
-          agent none
-          when {
-            beforeAgent true
-            allOf {
-              anyOf {
-                environment name: 'GIT_BUILD_CAUSE', value: 'pr'
-                expression { return !params.Run_As_Master_Branch }
-              }
+        /**
+        Execute code coverage only once.
+        */
+        stage('Coverage') {
+          options { skipDefaultCheckout() }
+          steps {
+            withGithubNotify(context: 'Coverage') {
+              // No scope is required as the coverage should run for all of them
+              runScript(label: 'coverage', stack: '7.0.0', scope: '', goal: 'coverage')
+              codecov(repo: env.REPO, basedir: "${env.BASE_DIR}", secret: "${env.CODECOV_SECRET}")
             }
           }
-          steps {
-            log(level: 'INFO', text: 'Launching Async ITs')
-            build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                  parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'RUM'),
-                               string(name: 'BUILD_OPTS', value: "--rum-agent-branch ${env.GIT_BASE_COMMIT}"),
-                               string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                               string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                               string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+          post {
+            always {
+              coverageReport("${BASE_DIR}/packages/**")
+              publishCoverage(adapters: [coberturaAdapter("${BASE_DIR}/packages/**/coverage-*-report.xml")],
+                              sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
+            }
           }
         }
         stage('Release') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,20 @@ pipeline {
             }
           }
         }
+        /**
+        Execute unit tests.
+        */
+        stage('Test') {
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                runParallelTest()
+              }
+            }
+          }
+        }
         stage('Integration Tests') {
           agent none
           when {
@@ -98,20 +112,6 @@ pipeline {
                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-          }
-        }
-        /**
-        Execute unit tests.
-        */
-        stage('Test') {
-          steps {
-            withGithubNotify(context: 'Test', tab: 'tests') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                runParallelTest()
-              }
-            }
           }
         }
         /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,20 +81,6 @@ pipeline {
             }
           }
         }
-        /**
-        Execute unit tests.
-        */
-        stage('Test') {
-          steps {
-            withGithubNotify(context: 'Test', tab: 'tests') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                runParallelTest()
-              }
-            }
-          }
-        }
         stage('Integration Tests') {
           agent none
           when {
@@ -112,6 +98,20 @@ pipeline {
                                string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
             githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+          }
+        }
+        /**
+        Execute unit tests.
+        */
+        stage('Test') {
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                runParallelTest()
+              }
+            }
           }
         }
         /**


### PR DESCRIPTION
### Highlights
- Run APM-ITs after running the tests.
- Run Coverage at the very end

The `Integration Tests` stage cannot be easily triggered in parallel with the `Test` stage. So there were two options, either run the ITs firstly and then the Test stage or the other way around. As agreed we will run after the `Test` stage.

Closes https://github.com/elastic/apm-agent-rum-js/issues/640