### PR TITLE
chore(dev): fix uncaughtException handler from consuming test errors

### DIFF
--- a/dev-utils/run-script.js
+++ b/dev-utils/run-script.js
@@ -169,11 +169,9 @@ function exitHandler(exitCode) {
     }
   })
   cleanUps = []
-  process.exit(exitCode)
 }
 
 process.on('exit', exitHandler)
-process.on('uncaughtException', exitHandler)
 process.on('SIGINT', exitHandler)
 
 const scripts = {


### PR DESCRIPTION
+ fix #649 
+ Overriding `uncaughtException` would result in exitCode resulting in 0 and consuming our test errors. 
+ process.exit(exitcode) is unnecessary as the process would be exited anyways when error happens. 

This PR would result in node tests being broken because of this issue #646. 