### PR TITLE
chore(bundlesize): add github workflows to check compressed size

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -9,8 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
     - uses: preactjs/compressed-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         build-script: "npx lerna run build:module"
-      
+        pattern: "{packages/rum/dist/bundles/*.js}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: preactjs/compressed-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        build-script: "npx lerna run build:module"
+      


### PR DESCRIPTION
+ trying out the compressed size plugin to know size per file. 
https://github.com/marketplace/actions/compressed-size-action

Might delete it if its not super useful for us. 