### PR TITLE
ci(jenkins): enable benchmark for PRs if changes in the benchmark files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
             script {
               dir("${BASE_DIR}"){
                 def regexps =[
-                  '^packages/rum/test/benchmarks/',
+                  '^packages/.*/test/benchmarks/.*',
                   '^scripts/benchmarks.js',
                   '^packages/rum-core/karma.bench.conf.js'
                 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,17 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            // Look for changes related to the benchmark, if so then set the env variable.
+            script {
+              dir("${BASE_DIR}"){
+                def regexps =[
+                  "^packages/rum/test/benchmarks/",
+                  "^scripts/benchmarks.js$",
+                  "^packages/rum-core/karma.bench.conf.js$"
+                ]
+                env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: regexps)
+              }
+            }
           }
         }
         /**
@@ -129,6 +140,7 @@ pipeline {
                 branch 'master'
                 tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
+                expression { return env.BENCHMARK_UPDATED != "false" }
               }
               expression { return params.bench_ci }
             }
@@ -148,7 +160,13 @@ pipeline {
             always {
               archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
               catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
-                sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
+                script {
+                  if (env.GIT_BUILD_CAUSE?.equals('pr')) {
+                    log(level: 'INFO', text: 'This is a PR, therefore the Benchmark did run but its output was not published to the ES cluster!')
+                  } else {
+                    sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
+                  }
+                }
               }
               catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                 deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,9 +63,9 @@ pipeline {
             script {
               dir("${BASE_DIR}"){
                 def regexps =[
-                  "^packages/rum/test/benchmarks/",
-                  "^scripts/benchmarks.js$",
-                  "^packages/rum-core/karma.bench.conf.js$"
+                  '^packages/rum/test/benchmarks/',
+                  '^scripts/benchmarks.js',
+                  '^packages/rum-core/karma.bench.conf.js'
                 ]
                 env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: regexps)
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
               archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
               catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
                 script {
-                  if (env.GIT_BUILD_CAUSE?.equals('pr')) {
+                  if (env.CHANGE_ID?.trim()) {
                     log(level: 'INFO', text: 'This is a PR, therefore the Benchmark did run but its output was not published to the ES cluster!')
                   } else {
                     sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,12 +160,9 @@ pipeline {
             always {
               archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
               catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
-                script {
-                  if (env.CHANGE_ID?.trim()) {
-                    log(level: 'INFO', text: 'This is a PR, therefore the Benchmark did run but its output was not published to the ES cluster!')
-                  } else {
-                    sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
-                  }
+                log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
+                whenTrue(env.CHANGE_ID == null){
+                  sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
                 }
               }
               catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {


### PR DESCRIPTION
## What

Enable the benchmark without sending the data to ES for the pull requests that change any of the files that are directly related to the benchmark.

## Why

This will help to automatically validate any changes that could affect the benchmark implementation before merging to master.