### PR TITLE
chore(tests): fix/remove disabled tests

### DIFF
--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -157,7 +157,7 @@ function getCommonWebpackConfig(bundleType, packageType) {
   const mode = isEnvProduction ? 'production' : 'development'
 
   return {
-    devtool: isEnvProduction ? 'source-map' : false,
+    devtool: isEnvProduction ? false : 'inline-source-map',
     mode,
     stats: {
       colors: true,

--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -157,7 +157,7 @@ function getCommonWebpackConfig(bundleType, packageType) {
   const mode = isEnvProduction ? 'production' : 'development'
 
   return {
-    devtool: isEnvProduction ? false : 'inline-source-map',
+    devtool: isEnvProduction ? 'source-map' : 'inline-cheap-module-source-map',
     mode,
     stats: {
       colors: true,

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -248,47 +248,6 @@ describe('TransactionService', function() {
     })
   })
 
-  xit('should not add duplicate resource spans', function() {
-    transactionService = new TransactionService(logger, config)
-
-    var tr = transactionService.startTransaction('transaction', 'transaction', {
-      managed: true
-    })
-    tr.captureTimings = true
-    var queryString = '?' + Date.now()
-    var testUrl = '/base/test/performance/transactionService.spec.js'
-
-    if (window.performance.getEntriesByType) {
-      if (window.fetch) {
-        window.fetch(testUrl + queryString).then(function() {
-          var entries = window.performance
-            .getEntriesByType('resource')
-            .filter(function(entry) {
-              return entry.name.indexOf(testUrl + queryString) > -1
-            })
-          expect(entries.length).toBe(1)
-
-          tr.donePromise.then(function() {
-            var filtered = tr.spans.filter(function(span) {
-              return span.name.indexOf(testUrl) > -1
-            })
-            expect(filtered.length).toBe(1)
-            console.log(filtered[0])
-            fail()
-          })
-
-          var xhrTask = {
-            source: 'XMLHttpRequest.send',
-            XHR: { url: testUrl, method: 'GET' }
-          }
-          var spanName = xhrTask.XHR.method + ' ' + testUrl
-          var span = transactionService.startSpan(spanName, 'external.http')
-          span.end()
-        })
-      }
-    }
-  })
-
   it('should capture resources from navigation timing', function(done) {
     const unMock = mockGetEntriesByType()
 

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -44,22 +44,6 @@ describe('transaction.Transaction', function() {
     done()
   })
 
-  xit('should not start any spans after transaction has been added to queue', function() {
-    var transaction = new Transaction('/', 'transaction', {})
-    transaction.end()
-    var firstSpan = transaction.startSpan('first-span-name', 'first-span')
-    firstSpan.end()
-    setTimeout(function() {
-      // todo: transaction has already been added to the queue, shouldn't accept more spans
-
-      var lastSpan = transaction.startSpan('last-span-name', 'last-span')
-      fail(
-        'done transaction should not accept more spans, now we simply ignore the newly stared span.'
-      )
-      lastSpan.end()
-    })
-  })
-
   it('should not generate stacktrace if the option is not passed', function(done) {
     var tr = new Transaction('/', 'transaction')
     tr.onEnd = function() {


### PR DESCRIPTION
Part of #620 
This PR fixes some of the previously disabled tests and removes the rest which are unnecessary at this point. Going forward we should add comments to tests that we decided to disable about the reason for it and how/when we can fix and enabled the test.

This PR also fixes the source-map for tests. Note that `inline-source-map` seem to be the only way to get sourcemaps work with karma/jasmine.