### PR TITLE
fix(rum-core): export browser responsiveness interval correctly

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -129,6 +129,11 @@ const FIRST_CONTENTFUL_PAINT = 'first-contentful-paint'
 const LARGEST_CONTENTFUL_PAINT = 'largest-contentful-paint'
 
 /**
+ * Managed transaction configs
+ */
+const BROWSER_RESPONSIVENESS_INTERVAL = 500
+
+/**
  * Default configs used on top of extensible configs from ConfigService
  */
 const KEYWORD_LIMIT = 1024
@@ -171,5 +176,6 @@ export {
   SERVER_URL_PREFIX,
   TEMPORARY_TYPE,
   USER_INTERACTION,
-  TRANSACTION_TYPE_ORDER
+  TRANSACTION_TYPE_ORDER,
+  BROWSER_RESPONSIVENESS_INTERVAL
 }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -44,7 +44,8 @@ import {
   EVENT_TARGET,
   HTTP_REQUEST_TYPE,
   USER_INTERACTION,
-  PAGE_LOAD
+  PAGE_LOAD,
+  BROWSER_RESPONSIVENESS_INTERVAL
 } from '../common/constants'
 import {
   truncateModel,
@@ -56,7 +57,6 @@ import { __DEV__ } from '../env'
 /**
  * Parameters used for Managed Transactions
  */
-const BROWSER_RESPONSIVENESS_INTERVAL = 500
 const BROWSER_RESPONSIVENESS_BUFFER = 3
 const SIMILAR_SPAN_TO_TRANSACTION_RATIO = 0.05
 const TRANSACTION_DURATION_THRESHOLD = 60000

--- a/packages/rum/test/bundle/bundle.spec.js
+++ b/packages/rum/test/bundle/bundle.spec.js
@@ -64,6 +64,9 @@ function getConfig(entry) {
   }
 }
 
+// Since bundling happens inside tests, it needs more time on the CI
+const TEST_TIMEOUT = 15000
+
 describe('Browser bundle test', () => {
   afterEach(() => {
     rimraf.sync(BUNDLE_DIST_DIR)
@@ -71,23 +74,31 @@ describe('Browser bundle test', () => {
 
   describe('main version', () => {
     const mainEntry = require.resolve('@elastic/apm-rum/dist/lib/index.js')
-    it('not produce any errors when run without babel', done => {
-      const config = getConfig(mainEntry)
-      return runWebpack(config, error => {
-        expect(error).toEqual(null)
-        done()
-      })
-    })
+    it(
+      'not produce any errors when run without babel',
+      done => {
+        const config = getConfig(mainEntry)
+        return runWebpack(config, error => {
+          expect(error).toEqual(null)
+          done()
+        })
+      },
+      TEST_TIMEOUT
+    )
   })
 
   describe('module version', () => {
     const moduleEntry = require.resolve('@elastic/apm-rum/dist/es/index.js')
-    it('not produce any errors when run without babel', done => {
-      const config = getConfig(moduleEntry)
-      return runWebpack(config, error => {
-        expect(error).toEqual(null)
-        done()
-      })
-    })
+    it(
+      'not produce any errors when run without babel',
+      done => {
+        const config = getConfig(moduleEntry)
+        return runWebpack(config, error => {
+          expect(error).toEqual(null)
+          done()
+        })
+      },
+      TEST_TIMEOUT
+    )
   })
 })


### PR DESCRIPTION
+ hit us because of sideeffect of allowing failures on bundlesize
+ webpack warnings was not considered as blockers.

Added the fix in bundle tests that would error out on warnings as well and also used the default webpack config to make sure we align with release bundles. 