### PR TITLE
ci(jenkins): benchmark fails with playwright in the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,8 +137,8 @@ pipeline {
             beforeAgent true
             allOf {
               anyOf {
-                branch 'master'
-                tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
+                //branch 'master'
+                //tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
                 expression { return env.BENCHMARK_UPDATED != "false" }
               }


### PR DESCRIPTION
Let's disable the benchmark execution for the time being since the benchmark stage fails and gets stalled until the 3 hours timeout happens.

https://github.com/elastic/apm-agent-rum-js/pull/650 might rollback this PR.