### PR TITLE
chore: fix test script for running locally

### DIFF
--- a/dev-utils/run-script.js
+++ b/dev-utils/run-script.js
@@ -44,6 +44,14 @@ const { sauceLabs } = getTestEnvironmentVariables()
 
 let cleanUps = []
 
+function startServersWithCleanups() {
+  let servers = startTestServers.apply(this, arguments)
+  cleanUps.push(() => {
+    servers.map(s => s.close())
+  })
+  return servers
+}
+
 function runUnitTests(packagePath, startSauceConnect = 'false') {
   const karmaConfigFile = join(PROJECT_DIR, packagePath, 'karma.conf.js')
   if (startSauceConnect === 'true') {
@@ -116,13 +124,9 @@ function runSauceTests(packagePath, serve = 'true', ...scripts) {
    * we launch the sauce connect tunnel before starting all the saucelab tests
    */
 
-  let servers = []
   if (serve === 'true') {
-    servers = startTestServers(join(PROJECT_DIR, packagePath))
+    startServersWithCleanups(join(PROJECT_DIR, packagePath))
   }
-  cleanUps.push(() => {
-    servers.map(s => s.close())
-  })
 
   launchSauceConnect(async sauceConnectProcess => {
     if (!sauceLabs) {
@@ -193,13 +197,7 @@ const scripts = {
   runNodeTests,
   runBundleTests,
   buildE2eBundles,
-  startTestServers() {
-    let servers = startTestServers.apply(this, arguments)
-    cleanUps.push(() => {
-      servers.map(s => s.close())
-    })
-    return servers
-  }
+  startTestServers: startServersWithCleanups
 }
 
 function runScript() {

--- a/dev-utils/run-script.js
+++ b/dev-utils/run-script.js
@@ -164,7 +164,7 @@ function runSauceTests(packagePath, serve = 'true', ...scripts) {
   })
 }
 
-function exitHandler(callExit, exitCode) {
+function exitHandler(exitCode) {
   if (cleanUps.length > 0) {
     console.log('Running cleanups:', cleanUps.length)
     cleanUps.forEach(f => {
@@ -176,16 +176,10 @@ function exitHandler(callExit, exitCode) {
     })
     cleanUps = []
   }
-  if (callExit) {
-    if (exitCode !== 0) {
-      console.log('Exiting with code:', exitCode)
-    }
-    process.exit(exitCode)
-  }
 }
 
-process.on('exit', exitHandler.bind(null, false))
-process.on('SIGINT', exitHandler.bind(null, true))
+process.on('exit', exitHandler)
+process.on('SIGINT', exitHandler)
 
 const scripts = {
   launchSauceConnect,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "run-p --silent lint:*",
     "lint:js": "eslint . --ext .js,.jsx,.ts",
     "lint:license": "node scripts/license-checker",
-    "test": "npm run build && lerna run test --scope=$SCOPE --no-prefix",
+    "test": "npm run build && lerna run test --scope=$SCOPE --no-prefix  --concurrency=1",
     "build": "lerna run build",
     "bundlesize": "lerna run build:module && lerna run bundlesize",
     "serve": "node ./dev-utils/run-script.js startTestServers",


### PR DESCRIPTION
When running locally `concurrency=1` is required since each of individual packages run their own servers and they conflict with each other if run in parallel. 

This doesn't effect the speed of tests running on CI since we always pass a single scope to each runner.