### PR TITLE
chore(benchmark): run only on chromium and exit process

### DIFF
--- a/.ci/docker/node-puppeteer/Dockerfile
+++ b/.ci/docker/node-puppeteer/Dockerfile
@@ -1,5 +1,5 @@
-#Dockerfile for docker.elastic.co/observability-ci/node-puppeteer:8
-FROM node:8
+#Dockerfile for docker.elastic.co/observability-ci/node-puppeteer:12
+FROM node:12
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   node-puppeteer:
     build: ../.ci/docker/node-puppeteer
     container_name: node-puppeteer
-    image: docker.elastic.co/observability-ci/node-puppeteer:8
+    image: docker.elastic.co/observability-ci/node-puppeteer:12
     environment:
       - HOME=/app
       - SCOPE=${SCOPE}
@@ -156,8 +156,8 @@ services:
 
   node-benchmark:
     build: ../.ci/docker/node-puppeteer
-    container_name: node-puppeteer
-    image: docker.elastic.co/observability-ci/node-puppeteer:8
+    container_name: node-playwright
+    image: docker.elastic.co/observability-ci/node-playwright:12
     environment:
       - HOME=/app
       - BUILD_NUMBER=${BUILD_NUMBER}
@@ -173,7 +173,7 @@ services:
         cd /app
         export
         npm install
-        npm install puppeteer --unsafe-perm=true --allow-root
+        npm install playwright --unsafe-perm=true --allow-root
         set -eo pipefail
         npx lerna run build:module
         node ./scripts/benchmarks.js ${REPORT_FILE}"

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -28,7 +28,7 @@ module.exports = {
   scenarios: ['basic', 'heavy'],
   runs: 3,
   noOfImages: 30,
-  browserTypes: ['chromium', 'firefox', 'webkit'],
+  browserTypes: ['chromium'],
   port,
   chrome: {
     /**
@@ -42,6 +42,7 @@ module.exports = {
     memorySamplingInterval: 10,
     launchOptions: {
       headless: true,
+      dumpio: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox']
     }
   }

--- a/packages/rum/test/benchmarks/run.js
+++ b/packages/rum/test/benchmarks/run.js
@@ -39,6 +39,7 @@ const startServer = require('./server')
 const REPORTS_DIR = join(__dirname, '../../reports')
 
 !(async function run() {
+  let exitCode = 0
   try {
     /**
      * Generate custom apm build
@@ -95,5 +96,8 @@ const REPORTS_DIR = join(__dirname, '../../reports')
     console.log('RUM benchmark results written to disk', filePath)
   } catch (e) {
     console.error('Error running RUM benchmark script', e)
+    exitCode = 1
+  } finally {
+    process.exit(exitCode)
   }
 })()


### PR DESCRIPTION
+ extracting some commits from this #https://github.com/elastic/apm-agent-rum-js/pull/650
+ Playwright requires Node >8 otherwise we will see this error - https://github.com/microsoft/playwright/blob/master/docs/troubleshooting.md#referenceerror-url-is-not-defined
+ Firefox and Webkit require more packages to work correctly inside docker. Will be addressed in separate PR