### PR TITLE
feat(rum-core): monitor longtasks by default during active transaction

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -307,7 +307,7 @@ NOTE: Spans that are captured as part of the ignored transactions would also be 
 ==== `monitorLongtasks`
 
 * *Type:* Boolean
-* *Default:* `false`
+* *Default:* `true`
 
 Instructs the agent to start monitoring for browser tasks that block the UI
 thread and might delay other user inputs by affecting the overall page

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -97,7 +97,7 @@ class Config {
       transactionSampleRate: 1.0,
       centralConfig: false,
 
-      monitorLongtasks: false,
+      monitorLongtasks: true,
 
       context: {}
     }

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -661,6 +661,7 @@ describe('TransactionService', function() {
   describe('performance entry recorder', () => {
     const logger = new LoggingService()
     const config = new Config()
+    config.init()
     const trService = new TransactionService(logger, config)
     const startSpy = jasmine.createSpy()
     const stopSpy = jasmine.createSpy()
@@ -674,7 +675,6 @@ describe('TransactionService', function() {
       stopSpy.calls.reset()
     }
 
-    beforeAll(() => config.setConfig({ monitorLongtasks: true }))
     afterEach(() => resetSpies())
 
     it('should start/stop performance recorder for managed transaction', async () => {


### PR DESCRIPTION
+ fixes #601 