### PR TITLE
Fix(rum-core): Check if first-contentful-paint exists before setting the agent marks

### DIFF
--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -268,7 +268,7 @@ function getFirstContentfulPaint() {
     }, null)
     return fcp
   }
-  return null
+  return undefined
 }
 
 function getPageLoadMarks() {

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -254,24 +254,21 @@ function getNavigationTimingMarks() {
  * SPEC - https://www.w3.org/TR/paint-timing/
  */
 function getFirstContentfulPaint() {
-  let fcp
   if (isPerfTimelineSupported()) {
-    const entries = PERF.getEntriesByType(PAINT)
-    if (entries.length > 0) {
-      const timing = PERF.timing
-      /**
-       * To avoid capturing the unload event handler effect
-       * as part of the transaction duration
-       */
-      const unloadDiff = timing.fetchStart - timing.navigationStart
-      const fcpEntry = entries.filter(
-        entry => entry.name === FIRST_CONTENTFUL_PAINT
-      )
-      const { startTime } = fcpEntry[0]
-      fcp = unloadDiff >= 0 ? startTime - unloadDiff : startTime
-    }
+    const timing = PERF.timing
+    /**
+     * To avoid capturing the unload event handler effect
+     * as part of the transaction duration
+     */
+    const unloadDiff = timing.fetchStart - timing.navigationStart
+    const fcp = PERF.getEntriesByType(PAINT).reduce((_fcp, entry) => {
+      if (entry.name === FIRST_CONTENTFUL_PAINT) {
+        return unloadDiff >= 0 ? entry.startTime - unloadDiff : entry.startTime
+      }
+    })
+    return fcp
   }
-  return fcp
+  return null
 }
 
 function getPageLoadMarks() {

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -265,7 +265,7 @@ function getFirstContentfulPaint() {
       if (entry.name === FIRST_CONTENTFUL_PAINT) {
         return unloadDiff >= 0 ? entry.startTime - unloadDiff : entry.startTime
       }
-    })
+    }, null)
     return fcp
   }
   return null

--- a/packages/rum-core/test/fixtures/paint-entries.js
+++ b/packages/rum-core/test/fixtures/paint-entries.js
@@ -23,6 +23,15 @@
  *
  */
 
+export const paintWithMissingFcp = [
+  {
+    name: 'first-paint',
+    entryType: 'paint',
+    startTime: 127.5000000023283,
+    duration: 0
+  }
+]
+
 export default [
   {
     name: 'first-paint',

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -34,7 +34,10 @@ import resourceEntries from '../fixtures/resource-entries'
 import userTimingEntries from '../fixtures/user-timing-entries'
 import navTimingSpans from '../fixtures/navigation-timing-span-snapshot'
 import { TIMING_LEVEL1_ENTRY as timings } from '../fixtures/navigation-entries'
-import { mockGetEntriesByType } from '../utils/globals-mock'
+import {
+  mockGetEntriesByType,
+  mockPaintEntryWithMissingFCP
+} from '../utils/globals-mock'
 import { PAGE_LOAD, ROUTE_CHANGE } from '../../src/common/constants'
 
 const spanSnapshot = navTimingSpans.map(mapSpan)
@@ -291,4 +294,25 @@ describe('Capture hard navigation', function() {
     captureNavigation(tr)
     expect(tr.marks.custom.testMark).toEqual(start + markValue)
   })
+
+  it('should set firstContentfulPaint', function() {
+    const unMock = mockGetEntriesByType()
+    const tr = new Transaction('test', PAGE_LOAD)
+    tr.captureTimings = true
+    captureNavigation(tr)
+    tr.end()
+
+    expect(tr.marks.agent.firstContentfulPaint).toBeGreaterThan(0)
+    unMock()
+  }),
+    it('should handle missing first-contentful-paint on page load', function() {
+      const unMock = mockPaintEntryWithMissingFCP()
+      const tr = new Transaction('test', PAGE_LOAD)
+      tr.captureTimings = true
+      captureNavigation(tr)
+      tr.end()
+
+      expect(tr.marks.agent.firstContentfulPaint).toBeUndefined()
+      unMock()
+    })
 })

--- a/packages/rum-core/test/utils/globals-mock.js
+++ b/packages/rum-core/test/utils/globals-mock.js
@@ -23,8 +23,8 @@
  *
  */
 
+import paintEntries, { paintWithMissingFcp } from '../fixtures/paint-entries'
 import resourceEntries from '../fixtures/resource-entries'
-import paintEntries from '../fixtures/paint-entries'
 import userTimingEntries from '../fixtures/user-timing-entries'
 import { TIMING_LEVEL2_ENTRIES } from '../fixtures/navigation-entries'
 import longtaskEntries from '../fixtures/longtask-entries'
@@ -46,6 +46,29 @@ export function mockObserverEntryTypes(type) {
   }
 
   return []
+}
+
+export function mockPaintEntryWithMissingFCP() {
+  const _getEntriesByType = window.performance.getEntriesByType
+
+  window.performance.getEntriesByType = function(type) {
+    expect([RESOURCE, PAINT, MEASURE, NAVIGATION]).toContain(type)
+    if (type === RESOURCE) {
+      return resourceEntries
+    } else if (type === PAINT) {
+      return paintWithMissingFcp
+    } else if (type === MEASURE) {
+      return userTimingEntries
+    } else if (type === NAVIGATION) {
+      return TIMING_LEVEL2_ENTRIES
+    } else {
+      return []
+    }
+  }
+
+  return function unMock() {
+    window.performance.getEntriesByType = _getEntriesByType
+  }
 }
 
 export function mockGetEntriesByType() {


### PR DESCRIPTION
https://github.com/elastic/apm-agent-rum-js/issues/680