### PR TITLE
chore(benchmark): run profiler benchmark in webkit

### DIFF
--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -3,15 +3,15 @@
 FROM ubuntu:bionic
 
 # 1. Install node12
-RUN apt-get update && apt-get install -y curl && \
+RUN apt-get -qq update && apt-get -qq install -y curl && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get -qq install -y nodejs
 
 # 2. Install git (used to tag commit in benchmark runner)
-RUN apt-get install -y git --no-install-recommends
+RUN apt-get -qq install -y git --no-install-recommends
 
 # 3. Install WebKit dependencies
-RUN apt-get install -y libwoff1 \
+RUN apt-get -qq install -y libwoff1 \
                        libopus0 \
                        libwebp6 \
                        libwebpdemux2 \
@@ -26,28 +26,24 @@ RUN apt-get install -y libwoff1 \
                        libevent-2.1-6 \
                        libgles2 \
                        libvpx5
-
 # 4. Install Chromium dependencies
-RUN apt-get install -y libnss3 \
+RUN apt-get -qq install -y libnss3 \
                        libxss1 \
                        libasound2
 
 # 5. Install Chrome unstable to run karma benchmark tests inside puppeteer
-RUN apt-get update \
-    && apt-get install -y wget --no-install-recommends \
+RUN apt-get -qq install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y \
+    && apt-get -qq update  \
+    && apt-get -qq install -y \
         google-chrome-unstable \
         fonts-ipafont-gothic \
         fonts-wqy-zenhei \
         fonts-thai-tlwg \
         fonts-kacst \
-        --no-install-recommends \
-        && rm -rf /var/lib/apt/lists/*
+        --no-install-recommends
 
 # 6. Install Firefox dependencies
-RUN apt-get update \
-    && apt-get install -y libdbus-glib-1-2 \
+RUN apt-get -qq install -y libdbus-glib-1-2 \
                           xvfb

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -33,8 +33,7 @@ RUN apt-get install -y libnss3 \
                        libasound2
 
 # 5. Install Chrome unstable to run karma benchmark tests inside puppeteer
-RUN apt-get update \
-    && apt-get install -y wget --no-install-recommends \
+RUN apt-get install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
@@ -48,6 +47,5 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 # 6. Install Firefox dependencies
-RUN apt-get update \
-    && apt-get install -y libdbus-glib-1-2 \
+RUN apt-get install -y libdbus-glib-1-2 \
                           xvfb

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get install -y libnss3 \
                        libasound2
 
 # 5. Install Chrome unstable to run karma benchmark tests inside puppeteer
-RUN apt-get install -y wget --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
@@ -47,5 +48,6 @@ RUN apt-get install -y wget --no-install-recommends \
         && rm -rf /var/lib/apt/lists/*
 
 # 6. Install Firefox dependencies
-RUN apt-get install -y libdbus-glib-1-2 \
+RUN apt-get update \
+    && apt-get install -y libdbus-glib-1-2 \
                           xvfb

--- a/packages/rum/test/benchmarks/config.js
+++ b/packages/rum/test/benchmarks/config.js
@@ -28,9 +28,15 @@ module.exports = {
   scenarios: ['basic', 'heavy'],
   runs: 3,
   noOfImages: 30,
-  browserTypes: ['chromium', 'firefox'],
+  browserTypes: ['chromium', 'firefox', 'webkit'],
   port,
-  chrome: {
+  default: {
+    launchOptions: {
+      headless: true,
+      dumpio: true
+    }
+  },
+  chromium: {
     /**
      * By default the CPU samples are taken at 1000 microseconds, To get
      * more samples in each run within page-load event, we have to tune it so that
@@ -42,7 +48,6 @@ module.exports = {
     memorySamplingInterval: 10,
     launchOptions: {
       headless: true,
-      dumpio: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox']
     }
   }

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -24,7 +24,7 @@
  */
 
 const playwright = require('playwright')
-const { chrome } = require('./config')
+const config = require('./config')
 const {
   filterCpuMetrics,
   capturePayloadInfo,
@@ -32,7 +32,9 @@ const {
 } = require('./analyzer')
 
 async function launchBrowser(type) {
-  return await playwright[type].launch(chrome.launchOptions)
+  const { launchOptions } =
+    type !== 'chromium' ? config.default : config.chromium
+  return await playwright[type].launch(launchOptions)
 }
 
 function gatherRawMetrics(browser, url) {

--- a/packages/rum/test/benchmarks/profiler.js
+++ b/packages/rum/test/benchmarks/profiler.js
@@ -72,7 +72,7 @@ function gatherRawMetrics(browser, url) {
        * number of samples generated
        */
       await client.send('Profiler.setSamplingInterval', {
-        interval: chrome.cpuSamplingInterval
+        interval: config.chromium.cpuSamplingInterval
       })
     }
 
@@ -146,7 +146,7 @@ function gatherRawMetrics(browser, url) {
        */
       await client.send('Profiler.start')
       await client.send('HeapProfiler.startSampling', {
-        interval: chrome.memorySamplingInterval
+        interval: config.chromium.memorySamplingInterval
       })
     }
 


### PR DESCRIPTION
+ Fixing the webkit runs - webkit cannot understand `--no-sandbox` and results in parse error. so 
we have chromium/other browser specific launch options
+ fix nitpicks from other PR https://github.com/elastic/apm-agent-rum-js/pull/683

Benchmark working - https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/PR-685/3/console