### PR TITLE
[docs] Add upgrading to 5.x guide

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -142,8 +142,8 @@ To understand the different types, see <<breakdown-metrics-docs>>
 * *Type:* Number
 * *Default:* `500`
 
-The agent maintains two in-memory queues to record transactions and errors when they are added.
-This option sets the flush interval in *milliseconds* for these queues.
+The agent maintains a single queue to record transaction and error events when they are added.
+This option sets the flush interval in *milliseconds* for the queue.
 
 NOTE: After each flush of the queue, the next flush isn't scheduled until an item is added to the queue.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -212,48 +212,19 @@ var options = {
 ----
 
 [float]
-[[error-throttling]]
-=== Error throttling
+[[event-throttling]]
+=== Event throttling
 
-To throttle the number of errors send to the APM Server, you can use the following options:
+Throttle the number of events sent to APM Server.
 
 [float]
-[[error-throttle-limit]]
-==== `errorThrottleLimit`
+[[event-limit]]
+==== `eventLimit`
+
+By default, the agent can only send up to `80` events every `60000` milliseconds (one minute).
 
 * *Type:* Number
-* *Default:* `20`
-
-[float]
-[[error-throttle-interval]]
-==== `errorThrottleInterval`
-
-* *Type:* Number
-* *Default:* `30000`
-
-By default the agent can only send (up to) `20` errors every `30000` milliseconds.
-
-
-[float]
-[[transaction-throttling]]
-=== Transaction throttling
-
-[float]
-[[transaction-throttle-limit]]
-==== `transactionThrottleLimit`
-
-* *Type:* Number
-* *Default:* `20`
-
-[float]
-[[transaction-throttle-interval]]
-==== `transactionThrottleInterval`
-
-* *Type:* Number
-* *Default:* `30000`
-
-By default the agent can only send (up to) `20` transactions every `30000` milliseconds.
-
+* *Default:* `80`
 
 [float]
 [[transaction-sample-rate]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -218,8 +218,8 @@ var options = {
 Throttle the number of events sent to APM Server.
 
 [float]
-[[event-limit]]
-==== `eventLimit`
+[[events-limit]]
+==== `eventsLimit`
 
 By default, the agent can only send up to `80` events every `60000` milliseconds (one minute).
 

--- a/docs/distributed-tracing-guide.asciidoc
+++ b/docs/distributed-tracing-guide.asciidoc
@@ -77,17 +77,7 @@ Use the table below to determine which versions of our backend agents also suppo
 tracecontext headers. Compatible agents use the official tracecontext spec to propagate traces and can
 therefor be used with the RUM Agent version >=5.0 for distributed tracing.
 
-[options="header"]
-|====
-|Agent |Agent Version
-|**Go Agent**|>= `1.6`
-|**Java Agent**|>= `1.14`
-|**.NET Agent**|>= `1.3`
-|**Node.js Agent**|>= `3.4`
-|**Python Agent**|>= `5.4`
-|**Ruby Agent**|>= `3.5`
-|====
-
+include::./upgrading.asciidoc[tag=backend-compat-chart]
 
 [float]
 [[dynamic-html-doc]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -89,7 +89,7 @@ Removed options:
 
 Added option:
 
-* <<event-limit>> -- Configure the number of events sent to APM Server per minute. Defaults to `80`.
+* <<events-limit>> -- Configure the number of events sent to APM Server per minute. Defaults to `80`.
 
 [float]
 [[v5-upgrade-steps]]
@@ -136,11 +136,14 @@ Update or download the latest version of the RUM Agent using your
 <<install-the-agent,preferred installation method>>.
 
 If your old configuration used one of the removed config options (listed below),
-update your configuration to use the new <<event-limit>> config option instead.
+update your configuration to use the new config options instead.
 
 Removed configurations:
 
-* `errorThrottleLimit`
-* `errorThrottleInterval`
-* `transactionThrottleLimit`
-* `transactionThrottleInterval`
+* `errorThrottleLimit` removed in favor of <<events-limit>>.
+* `errorThrottleInterval` removed in favor of <<events-limit>>.
+* `transactionThrottleLimit` removed in favor of <<events-limit>>.
+* `transactionThrottleInterval` removed in favor of <<events-limit>>.
+* `apm.addTags()` removed in favor of <<apm-add-labels>>.
+* `span.addTags()` removed in favor of <<span-add-labels>>.
+* `transaction.addTags()` removed in favor of <<transaction-add-labels>>.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -80,7 +80,7 @@ Removed options:
 
 Added option:
 
-* <<event-limit>> -- Configure the number of events sent sent to APM Server per minute. Defaults to `80`.
+* <<event-limit>> -- Configure the number of events sent to APM Server per minute. Defaults to `80`.
 
 [float]
 [[v5-upgrade-steps]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -56,8 +56,8 @@ This guide outlines the changes and the steps required to upgrade.
 *Agent name changed to `rum-js`*
 
 The Agent name has been changed to `rum-js`.
-Because of this change, you may need to upgrade your APM Server instance,
-and therefor your Elasticsearch and Kibana instance.
+Because older versions of the APM app in Kibana don't recognize this new name,
+you may need to upgrade your Elastic stack version.
 
 *Official W3C tracecontext support*
 
@@ -102,6 +102,9 @@ NOTE: APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= 
 All Elastic APM agents have been upgraded to support the changes in the RUM Agent.
 You must upgrade your backend agents to the minimum versions listed below for all features to work:
 
+// This content is reused elsewhere in the documentation. Take care when updating.
+// tag::backend-compat-chart[]
+
 [options="header"]
 |====
 |Agent name |Agent Version
@@ -112,6 +115,9 @@ You must upgrade your backend agents to the minimum versions listed below for al
 |**Python Agent**|>= `5.4`
 |**Ruby Agent**|>= `3.5`
 |====
+
+// End shared content
+// end::backend-compat-chart[]
 
 [float]
 [[v5-update-rum-agent]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -8,6 +8,11 @@ Before upgrading the agent, be sure to review the:
 * <<release-notes,Agent release notes>>
 * {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
+The following upgrade guides are also available:
+
+* <<upgrade-to-v5>> - Follow this guide to upgrade from version `4.x` to version `5.x` of the
+Elastic APM RUM JS Agent.
+
 [float]
 [[end-of-life-dates]]
 === End of life dates
@@ -37,3 +42,75 @@ The table below is a simplified description of this policy.
 |2.0.x |2020-05-14 |2.1.0
 |1.0.x |2020-02-23 |3.0.0
 |====
+
+[[upgrade-to-v5]]
+=== Upgrade to version 5.x
+
+Upgrading from version `4.x` to `5.x` of the RUM Agent introduces some breaking changes.
+This guide outlines the changes and the steps required to upgrade.
+
+[float]
+[[v5-breaking-changes]]
+=== 5.x Breaking changes
+
+Agent name changed to `rum-js`::
+The Agent name has been changed to `rum-js`.
+Because of this change, you may need to upgrade your APM Server version,
+and therefor your Elasticsearch and Kibana version.
+
+Official W3C tracecontext support::
+The RUM Agent supports the official W3C tracecontext `traceparent` header,
+instead of the previously used `elastic-apm-traceparent` header.
+If you're using Elastic backend agents,
+you must upgrade them to a version that also supports the official W3C tracecontext headers.
+
+// https://github.com/elastic/apm-agent-rum-js/pull/664
+// WIP! I still need to clean this up
+Consolidated configurations::
+A single queue is now used to process all events (transactions, errors, etc.).
+This change consolidates two configuration options:
++
+* `throttleInterval` - details to come
+* `throttleLimit` - details to come
++
+Adding:
++
+* Introduces `eventsPerMin` which is set to 80 by default including errors and transactions for throttling instead of `throttleLimit` and `throttleInterval` for errors and transactions.
+
+[float]
+[[v5-upgrade-steps]]
+=== 5.x Upgrade steps
+
+[float]
+[[v5-upgrade-server]]
+==== Upgrade APM Server
+
+Version `5.x` of the RUM Agent requires APM Server version >= `7.0`.
+The {apm-server-ref-v}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
+Note that APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
+
+[float]
+[[v5-upgrade-agents]]
+==== Upgrade backend agents
+
+All Elastic APM agents have been upgraded to support the changes in the RUM Agent.
+You must upgrade your backend agents to the minimum versions listed below for all features to work:
+
+[options="header"]
+|====
+|Agent name |Agent Version
+|**Go Agent**|>= `1.6`
+|**Java Agent**|>= `1.14`
+|**.NET Agent**|>= `1.3`
+|**Node.js Agent**|>= `3.4`
+|**Python Agent**|>= `5.4`
+|**Ruby Agent**|>= `3.5`
+|====
+
+[float]
+[[v5-upgrade-rum-agent]]
+==== Upgrade the RUM Agent
+
+// Update your configuration
+
+// Upgrade the Agent

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -51,35 +51,40 @@ This guide outlines the changes and the steps required to upgrade.
 
 [float]
 [[v5-breaking-changes]]
-=== 5.x Breaking changes
+=== 5.0 Breaking changes
 
-Agent name changed to `rum-js`::
+*Agent name changed to `rum-js`*
+
 The Agent name has been changed to `rum-js`.
-Because of this change, you may need to upgrade your APM Server version,
-and therefor your Elasticsearch and Kibana version.
+Because of this change, you may need to upgrade your APM Server instance,
+and therefor your Elasticsearch and Kibana instance.
 
-Official W3C tracecontext support::
+*Official W3C tracecontext support*
+
 The RUM Agent supports the official W3C tracecontext `traceparent` header,
 instead of the previously used `elastic-apm-traceparent` header.
 If you're using Elastic backend agents,
 you must upgrade them to a version that also supports the official W3C tracecontext headers.
 
-// https://github.com/elastic/apm-agent-rum-js/pull/664
-// WIP! I still need to clean this up
-Consolidated configurations::
+*Consolidated configurations*
+
 A single queue is now used to process all events (transactions, errors, etc.).
-This change consolidates two configuration options:
-+
-* `throttleInterval` - details to come
-* `throttleLimit` - details to come
-+
-Adding:
-+
-* Introduces `eventsPerMin` which is set to 80 by default including errors and transactions for throttling instead of `throttleLimit` and `throttleInterval` for errors and transactions.
+This change allows the consolidation of four configuration options into one:
+
+Removed options:
+
+* `errorThrottleLimit`
+* `errorThrottleInterval`
+* `transactionThrottleLimit`
+* `transactionThrottleInterval`
+
+Added option:
+
+* <<event-limit>> -- Configure the number of events sent sent to APM Server per minute. Defaults to `80`.
 
 [float]
 [[v5-upgrade-steps]]
-=== 5.x Upgrade steps
+=== Upgrade steps
 
 [float]
 [[v5-upgrade-server]]
@@ -87,7 +92,8 @@ Adding:
 
 Version `5.x` of the RUM Agent requires APM Server version >= `7.0`.
 The {apm-server-ref-v}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
-Note that APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
+
+NOTE: APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
 
 [float]
 [[v5-upgrade-agents]]
@@ -108,9 +114,18 @@ You must upgrade your backend agents to the minimum versions listed below for al
 |====
 
 [float]
-[[v5-upgrade-rum-agent]]
-==== Upgrade the RUM Agent
+[[v5-update-rum-agent]]
+==== Upgrade the RUM agent
 
-// Update your configuration
+Update or download the latest version of the RUM Agent using your
+<<install-the-agent,preferred installation method>>.
 
-// Upgrade the Agent
+If your old configuration used one of the removed config options (listed below),
+update your configuration to use the new <<event-limit>> config option instead.
+
+Removed configurations:
+
+* `errorThrottleLimit`
+* `errorThrottleInterval`
+* `transactionThrottleLimit`
+* `transactionThrottleInterval`

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -66,7 +66,16 @@ instead of the previously used `elastic-apm-traceparent` header.
 If you're using Elastic backend agents,
 you must upgrade them to a version that also supports the official W3C tracecontext headers.
 
-*Consolidated configurations*
+*`addTags` replaced with `addLabels*
+
+`addTags`, which was deprecated in version `4.1`, has been removed and replaced with `addLabels`,
+which supports strings, booleans, and numbers:
+
+* `apm.addTags()` removed in favor of <<apm-add-labels>>.
+* `span.addTags()` removed in favor of <<span-add-labels>>.
+* `transaction.addTags()` removed in favor of <<transaction-add-labels>>.
+
+*Single queue processing*
 
 A single queue is now used to process all events (transactions, errors, etc.).
 This change allows the consolidation of four configuration options into one:


### PR DESCRIPTION
**What does this PR do?**

* Adds an upgrading guide for the APM RUM Agent version `5.x`.
* Removes documentation for the four removed config options
* Adds documentation for `eventsLimit`

**Related PRs**
* Closes https://github.com/elastic/apm-agent-rum-js/issues/671
* Related to https://github.com/elastic/apm-agent-rum-js/issues/501

**Screenshot of changes**
<details>
  <summary>Click to expand!</summary>

![RUM-upgrade](https://user-images.githubusercontent.com/5618806/76375553-575d3780-6303-11ea-95cf-5944e41e0504.png)
</details>
