### PR TITLE
feat(rum-core): set sync field only for synchronous spans

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -65,7 +65,6 @@ export function patchFetch(callback) {
       data: {
         target: request,
         method: request.method,
-        sync: false,
         url,
         aborted: false
       }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -297,7 +297,14 @@ export default class PerformanceMonitoring {
           `Could not inject distributed tracing header to the request origin ('${requestUrl.origin}') from the current origin ('${currentUrl.origin}')`
         )
       }
-      span.sync = data.sync
+      /**
+       * set sync flag only for synchronous API calls, setting the flag to
+       * false would result in UI showing `async` label on non-synchronous spans
+       * which creates unncessary noise for the user
+       */
+      if (data.sync) {
+        span.sync = data.sync
+      }
       data.span = span
       task.id = taskId
     } else if (event === INVOKE) {


### PR DESCRIPTION
+ fix #619 