### PR TITLE
fix(rum-core): handle error when `performance` is not available

### DIFF
--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -27,7 +27,10 @@ import rng from 'uuid/lib/rng-browser'
 import { Promise } from './polyfills'
 
 const slice = [].slice
-const PERF = typeof window !== 'undefined' ? performance : {}
+const PERF =
+  typeof window !== 'undefined' && typeof performance !== 'undefined'
+    ? performance
+    : {}
 
 function isCORSSupported() {
   var xhr = new window.XMLHttpRequest()


### PR DESCRIPTION
Fix for https://github.com/elastic/apm-agent-rum-js/issues/707
