### PR TITLE
docs: add link to dot net repo 

### DIFF
--- a/docs/distributed-tracing-guide.asciidoc
+++ b/docs/distributed-tracing-guide.asciidoc
@@ -100,6 +100,7 @@ var apm = initApm({
 Most Elastic APM back-end agents provide methods to extract this information.
 Please refer to the relevant Agent's API for more information:
 
+* {apm-dotnet-ref}/public-api.html[.NET Agent: `EnsureParentId()`]
 * {apm-java-ref}/public-api.html[Java Agent: `ensureParentId()`]
 * {apm-ruby-ref}/api.html[Ruby Agent: `EnsureParent()`]
 * {apm-go-ref}/api.html[Go Agent: `EnsureParent()`]


### PR DESCRIPTION
Please wait to merge until after https://github.com/elastic/apm-agent-dotnet/pull/771 has been merged.

The doc build will need to be retried with `@elasticmachine, run elasticsearch-ci/docs`.