### PR TITLE
docs: add link to 5.x release notes (#711)

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -7,6 +7,7 @@
 
 All notable changes to this project will be documented here.
 
+* <<release-notes-5.x>>
 * <<release-notes-4.x>>
 * <<release-notes-3.x>>
 * <<release-notes-2.x>>


### PR DESCRIPTION
I know we don't typically backport, but this seems like an important enough link to make an exception.