### PR TITLE
ci(jenkins): speed up builds with only docs changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,14 +54,13 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
               dir("${BASE_DIR}"){
-
                 // Look for changes related to the benchmark, if so then set the env variable.
-                def regexps =[
+                def patternList =[
                   '^packages/.*/test/benchmarks/.*',
                   '^scripts/benchmarks.js',
                   '^packages/rum-core/karma.bench.conf.js'
                 ]
-                env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: regexps)
+                env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: patternList)
 
                 // Skip all the stages except docs for PR's with asciidoc changes only
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,15 +52,19 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            // Look for changes related to the benchmark, if so then set the env variable.
             script {
               dir("${BASE_DIR}"){
+
+                // Look for changes related to the benchmark, if so then set the env variable.
                 def regexps =[
                   '^packages/.*/test/benchmarks/.*',
                   '^scripts/benchmarks.js',
                   '^packages/rum-core/karma.bench.conf.js'
                 ]
                 env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: regexps)
+
+                // Skip all the stages except docs for PR's with asciidoc changes only
+                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
               }
             }
           }
@@ -69,6 +73,10 @@ pipeline {
         Lint the code.
         */
         stage('Lint') {
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
+          }
           steps {
             withGithubNotify(context: 'Lint') {
               deleteDir()
@@ -86,6 +94,10 @@ pipeline {
           }
         }
         stage('Test Pupperteer') {
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
+          }
           matrix {
             agent { label 'linux && immutable' }
             axes {
@@ -133,6 +145,7 @@ pipeline {
             allOf {
               branch 'master'
               expression { return params.saucelab_test }
+              expression { return env.ONLY_DOCS == "false" }
             }
           }
           steps {
@@ -155,6 +168,7 @@ pipeline {
             allOf {
               changeRequest()
               expression { return params.saucelab_test }
+              expression { return env.ONLY_DOCS == "false" }
             }
           }
           steps {
@@ -173,6 +187,7 @@ pipeline {
             anyOf {
               changeRequest()
               expression { return !params.Run_As_Master_Branch }
+              expression { return env.ONLY_DOCS == "false" }
             }
           }
           steps {
@@ -203,6 +218,7 @@ pipeline {
                 expression { return env.BENCHMARK_UPDATED != "false" }
               }
               expression { return params.bench_ci }
+              expression { return env.ONLY_DOCS == "false" }
             }
           }
           steps {
@@ -236,6 +252,10 @@ pipeline {
         */
         stage('Coverage') {
           options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
+          }
           steps {
             withGithubNotify(context: 'Coverage') {
               // No scope is required as the coverage should run for all of them

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -9,7 +9,7 @@
 [[longtasks]]
 === How to interpret long task spans in the UI
 
-Long tasks is a new performance metric that can be used for measuring the
+Foo Long tasks is a new performance metric that can be used for measuring the
 responsiveness of an application and helps developers to understand the bad user
 experience. It enables detecting tasks that monopolize the UI thread for
 extended periods (greater than 50 milliseconds) and block other

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -9,7 +9,7 @@
 [[longtasks]]
 === How to interpret long task spans in the UI
 
-Foo Long tasks is a new performance metric that can be used for measuring the
+Long tasks is a new performance metric that can be used for measuring the
 responsiveness of an application and helps developers to understand the bad user
 experience. It enables detecting tasks that monopolize the UI thread for
 extended periods (greater than 50 milliseconds) and block other


### PR DESCRIPTION
### What

- Any builds for any branch or PR that only contains changes related to the asciidoc then it will skip all the stages but the `checkout`

### Why

Docs validation happens with the `elasticsearch-ci/docs` therefore there is no need to validate anything in our end.

### Issues

Closes https://github.com/elastic/apm-agent-rum-js/issues/715
