### PR TITLE
ci(jenkins): pull request title linting validation

### DIFF
--- a/scripts/lint-commits.sh
+++ b/scripts/lint-commits.sh
@@ -14,7 +14,14 @@ if [[ -n "${JENKINS_URL}" ]]; then
 
     # Lint PR title
     if [[ -n ${CHANGE_TITLE} ]]; then
+      titleLength=$(echo -n "${CHANGE_TITLE}" | wc -c)
+      titleResult=0
+      if [ "${titleLength}" -ge 75 ] ; then
+        echo "PR title got a long comment. This will fail when squashing and merging the Pull Request"
+        titleResult=1
+      fi
       echo "${CHANGE_TITLE}" | commitlint
+      exit ${titleResult}
     fi
   fi
 # Run if we're not on Travis

--- a/scripts/lint-commits.sh
+++ b/scripts/lint-commits.sh
@@ -16,7 +16,7 @@ if [[ -n "${JENKINS_URL}" ]]; then
     if [[ -n ${CHANGE_TITLE} ]]; then
       titleLength=$(echo -n "${CHANGE_TITLE}" | wc -c)
       titleResult=0
-      if [ "${titleLength}" -ge 75 ] ; then
+      if [ "${titleLength}" -ge 65 ] ; then
         echo "PR title has a long comment. This will fail when squashing and merging the Pull Request"
         titleResult=1
       fi

--- a/scripts/lint-commits.sh
+++ b/scripts/lint-commits.sh
@@ -17,7 +17,7 @@ if [[ -n "${JENKINS_URL}" ]]; then
       titleLength=$(echo -n "${CHANGE_TITLE}" | wc -c)
       titleResult=0
       if [ "${titleLength}" -ge 75 ] ; then
-        echo "PR title got a long comment. This will fail when squashing and merging the Pull Request"
+        echo "PR title has a long comment. This will fail when squashing and merging the Pull Request"
         titleResult=1
       fi
       echo "${CHANGE_TITLE}" | commitlint


### PR DESCRIPTION
Solves

```
[2020-03-20T14:26:06.736Z] + commitlint --from=ce0db92d1ba057def0c81595340de4e9e59c4872~1
[2020-03-20T14:26:06.736Z] ⧗   input: perf(rum-core): random number generator using crypto.getRandomValues (#705)
[2020-03-20T14:26:06.736Z] 
[2020-03-20T14:26:06.736Z] * perf(rum-core): random number generator using crypto.getRandomValues
[2020-03-20T14:26:06.736Z] 
[2020-03-20T14:26:06.736Z] * chore: address review add tests
[2020-03-20T14:26:06.736Z] 
[2020-03-20T14:26:06.736Z] * chore: fix deps in package-lock
[2020-03-20T14:26:06.736Z] ✖   header must not be longer than 72 characters, current length is 75 [header-max-length]
```

See [master build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/master/218/pipeline)

## Questions

- Should the validation happen on the master branch?
- Should the validation happen on each tag/branch?

If not then this particular fix should be done in the Pipeline to be skipped unless it's a change request (PRs)

## Tests

With a long PR title then

![image](https://user-images.githubusercontent.com/2871786/77226985-3ce15480-6b74-11ea-9051-b485c89788ba.png)
