### PR TITLE
fix(rum-core): filter API calls from resource spans

### DIFF
--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -207,11 +207,9 @@ function getApiSpanNames({ spans }) {
 
   for (let i = 0; i < spans.length; i++) {
     const span = spans[i]
-
     if (span.type === 'external' && span.subType === 'http') {
-      continue
+      apiCalls.push(span.name.split(' ')[1])
     }
-    apiCalls.push(span.name.split(' ')[1])
   }
   return apiCalls
 }

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -316,4 +316,24 @@ describe('Capture hard navigation', function() {
     expect(tr.marks.agent.firstContentfulPaint).toBeUndefined()
     unMock()
   })
+
+  it('should not add API calls as resource timing spans', function() {
+    const unMock = mockGetEntriesByType()
+    const tr = new Transaction('test', PAGE_LOAD, {
+      startTime: transactionStart
+    })
+    const apiSpan = tr.startSpan('GET http://ajax-filter.test', 'external.http')
+    apiSpan.end()
+    tr.captureTimings = true
+    tr.end(transactionEnd)
+    captureNavigation(tr)
+
+    const filteredRTSpan = tr.spans.filter(
+      span => span.name === 'http://ajax-filter.test'
+    )
+    expect(filteredRTSpan).toEqual([])
+    expect(tr.spans.length, 23)
+
+    unMock()
+  })
 })

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -328,9 +328,9 @@ describe('Capture hard navigation', function() {
     tr.end(transactionEnd)
     captureNavigation(tr)
 
-    const filteredRTSpan = tr.spans.filter(
-      span => span.name === 'http://ajax-filter.test'
-    )
+    const filteredRTSpan = tr.spans.filter(({ name, type }) => {
+      return name.indexOf('http://ajax-filter.test') >= 0 && type === 'resource'
+    })
     expect(filteredRTSpan).toEqual([])
     expect(tr.spans.length, 23)
 


### PR DESCRIPTION
+ fix #723 