### PR TITLE
feat(rum-core): end transaction after scheduled browser frames

### DIFF
--- a/packages/rum-core/src/common/after-frame.js
+++ b/packages/rum-core/src/common/after-frame.js
@@ -23,38 +23,26 @@
  *
  */
 
-export function routeHooks(router, apm) {
-  let transaction
+export default class AfterFrame {
+  constructor() {
+    this.current = null
+  }
 
-  router.beforeEach((to, from, next) => {
-    const matched = to.matched || []
-    let path = to.path
-    /**
-     * Get the last matched route record which acts as stack when
-     * route changes are pushed and popped out of the stack
-     *
-     * Also account for the slug pattern on the routes, to.path always
-     * resolves the current slug param, but we need need to
-     * use the slug pattern for the transaction name
-     */
-    if (matched.length > 0) {
-      path = matched[matched.length - 1].path || path
-    }
-    transaction = apm.startTransaction(path, 'route-change', {
-      managed: true,
-      canReuse: true
+  next(times, callback) {
+    this.current = requestAnimationFrame(() => {
+      console.log('RAF', performance.now())
+      if (times <= 0) {
+        callback()
+      } else {
+        times--
+        this.next(times, callback)
+      }
     })
-    next()
-  })
+  }
 
-  router.afterEach(() => {
-    transaction && transaction.detectFinish(3)
-  })
-  /**
-   * handle when the navigation is cancelled in `beforeEach` hook of components
-   * where `next(error)` is called
-   */
-  router.onError(() => {
-    transaction && transaction.end()
-  })
+  cancel() {
+    if (this.current) {
+      cancelAnimationFrame(this.current)
+    }
+  }
 }


### PR DESCRIPTION
+ fix #404 #636 
+ Schedules `n` number of frames for every navigation and then ends the transaction once the browser has finished rendering the relevant changes inside the frame. 

### Pros
+ Configurable, We can easy tune it for different kinds of transaction and schedule different frames

### Cons
+ Will not work as expected when page is not visible as it depends on `rAF` and browser does not fire requestAnimationFrame unless the page is foregrounded again. Having a hard timeout would fix it. 
+ Might Introduce state inside transaction as we have to clear previous scheduled frames when we want to schedule few more again.  We might end up doing in another way, But that would mean we wont be able to use have two transactions running at same time. 

TODO
+ [ ] Add tests
+ [ ] Add code documentation