### PR TITLE
chore(rum-core): fix apm-server error msg in test

### DIFF
--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -172,7 +172,7 @@ describe('ApmServer', function() {
        * explicit characters instead of whole message
        */
       expect(error.message).toContain(
-        'validating JSON document against schema: I[#] S[#] doesn\'t validate with "transaction#'
+        ': I[#] S[#] doesn\'t validate with "transaction#'
       )
       expect(error.message).toContain('missing properties: "trace_id"')
       done()


### PR DESCRIPTION
+ This currently breaks all our PR tests. 
+ Server recently landed a PR which changed the format of message, so had to account for that 
https://github.com/elastic/apm-server/pull/3594/files

<img width="878" alt="Screenshot 2020-04-02 at 17 09 06" src="https://user-images.githubusercontent.com/3902525/78265404-afebb300-7504-11ea-9ae2-66b04141805b.png">
