### PR TITLE
feat(rum-angular): support differential loading with CLI

### DIFF
--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -36,7 +36,8 @@ const BUNDLE_TYPES = {
   NODE_ESM_PROD: 'NODE_ESM_PROD',
   BROWSER_DEV: 'BROWSER_DEV',
   BROWSER_PROD: 'BROWSER_PROD',
-  BROWSER_ESM_PROD: 'BROWSER_ESM_PROD'
+  BROWSER_ESM_PROD: 'BROWSER_ESM_PROD',
+  BROWSER_ESM_ES2015: 'BROWSER_ESM_ES2015'
 }
 
 const {
@@ -44,7 +45,8 @@ const {
   NODE_ESM_PROD,
   BROWSER_DEV,
   BROWSER_PROD,
-  BROWSER_ESM_PROD
+  BROWSER_ESM_PROD,
+  BROWSER_ESM_ES2015
 } = BUNDLE_TYPES
 
 const PACKAGE_TYPES = {
@@ -55,19 +57,45 @@ const PACKAGE_TYPES = {
 }
 
 function getBabelPresetEnv(bundleType) {
-  const isBrowser = [BROWSER_DEV, BROWSER_PROD, BROWSER_ESM_PROD].includes(
-    bundleType
-  )
+  const isBrowser = [
+    BROWSER_DEV,
+    BROWSER_PROD,
+    BROWSER_ESM_PROD,
+    BROWSER_ESM_ES2015
+  ].includes(bundleType)
   /**
    * Decides transformation of ES6 module syntax to another module type.
    */
-  const shipESModule = [NODE_ESM_PROD, BROWSER_ESM_PROD].includes(bundleType)
+  const shipESModule = [
+    NODE_ESM_PROD,
+    BROWSER_ESM_PROD,
+    BROWSER_ESM_ES2015
+  ].includes(bundleType)
+
+  /**
+   * By default RUM agent targets IE 11 as we would like to support all of our
+   * users.
+   */
+  let targets = { ie: '11' }
+  /**
+   * Angular Packaging format uses the target `es2015` for differential
+   * loading (module/nomodule)
+   * Info - https://angular.io/guide/deployment#configuring-differential-loading
+   *
+   * Babel already supports browsers targetting ES Modules via `esmodules` flag
+   * https://babeljs.io/docs/en/babel-preset-env#targetsesmodules
+   */
+  if (isBrowser && bundleType === BROWSER_ESM_ES2015) {
+    targets = { esmodules: true }
+  } else if (!isBrowser) {
+    targets = { node: true }
+  }
 
   return [
     [
       '@babel/preset-env',
       {
-        targets: isBrowser ? { ie: '11' } : { node: true },
+        targets,
         modules: shipESModule ? false : 'auto',
         loose: true
       }

--- a/dev-utils/build.js
+++ b/dev-utils/build.js
@@ -73,12 +73,15 @@ function getBabelPresetEnv(bundleType) {
   ].includes(bundleType)
 
   /**
-   * By default RUM agent targets IE 11 as we would like to support all of our
-   * users.
+   * By default RUM agent support starts from IE 11 and we do not want every users to run
+   * babel on thier dependencies to support older browser versions. However,
+   * advanced users can always use webpack resolve.mainFields set to `source`
+   * and target their audience.
    */
   let targets = { ie: '11' }
   /**
-   * Angular Packaging format uses the target `es2015` for differential
+   * Angular CLI uses the target `es2015` by default which is based on the
+   * Angular Packaging Format specification and uses it for differential
    * loading (module/nomodule)
    * Info - https://angular.io/guide/deployment#configuring-differential-loading
    *

--- a/packages/rum-angular/package.json
+++ b/packages/rum-angular/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",
+  "es2015": "dist/es2015/index.js",
   "source": "src/index.ts",
   "files": [
     "dist",
@@ -27,6 +28,7 @@
     "build": "run-p build:main build:module",
     "build:main": "BABEL_ENV=BROWSER_PROD npx babel -x '.ts' src -d dist/lib ",
     "build:module": "BABEL_ENV=BROWSER_ESM_PROD npx babel -x '.ts' src -d dist/es",
+    "build:es2015": "BABEL_ENV=BROWSER_ESM_ES2015 npx babel -x '.ts' src -d dist/es2015",
     "build:e2e": "npm run script buildE2eBundles packages/rum-angular/test/e2e",
     "test:unit": "npm run script runUnitTests packages/rum-angular",
     "test:e2e": "npm run script runE2eTests packages/rum-angular/wdio.conf.js",


### PR DESCRIPTION
+ fixes #607 

+ Angular CLI builds the application using the target `es2015` as described in here https://angular.io/guide/deployment#differential-builds, which means our builds with `module` target wont work since we always transpile using the lowest version `IE 11`

+ There is a strong reason why we use `IE 11` as the least target since we do not want our users to transpile the dependencies code(If users are looking for more size wins, its better to follow this path as well) and instead make it work out of the box.  

+ With this PR, All webpack users would still be unaffected as it uses `module` target and can perform Tree shaking and rest like before. Angular CLI users would make use of the newly specified target `es2015` and can utilize the differential loading technique (module/nomodule) as explained here -  https://angular.io/guide/deployment#configuring-differential-loading

```
Webpack (module) - ESM + ES5 
Angular CLI (es2015) - ESM + ES2015
```

If webpack users wants to utilize the differential loading and do not want transpiled ES5 version. They can configure `resolve.mainFields` to points to 
+ `source` - No transpilation done
+ `es2015` - Target browsers that supports ES Modules 

```js
...  resolve: {
        mainFields: ['source', 'es2015', 'module', 'main'],
      }
```


Since we don't have tests with Angular CLI, Manual tests are performed with Angular CLI and it works as expected with both `ApmService` and `ApmErrorHandler`. 