### PR TITLE
chore(rum): add standalone async loading tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 
 *.e2e-bundle.*
+*-e2e.html
 
 dist
 tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -4543,6 +4543,12 @@
       "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
       "dev": true
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4571,6 +4577,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/html-minifier-terser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.0.0.tgz",
+      "integrity": "sha512-q95SP4FdkmF0CwO0F2q0H6ZgudsApaY/yCtAQNRn1gduef5fGpyEphzy0YCq/N0UFvDSnLg5V8jFK/YGXlDiCw==",
+      "dev": true
     },
     "@types/jasmine": {
       "version": "3.5.0",
@@ -4601,6 +4613,76 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
+      "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
+      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.10",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.10.tgz",
+      "integrity": "sha512-vIy0qaq8AjOjZLuFPqpo7nAJzcoVXMdw3mvpNN07Uvdy0p1IpJeLNBe3obdRP7FX2jIusDE7z1pZa0A6qYUgnA==",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.7.tgz",
+      "integrity": "sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.11.0",
@@ -7468,6 +7550,23 @@
       "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=",
       "dev": true
     },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9514,6 +9613,15 @@
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
+      }
+    },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "dev": true,
+      "requires": {
+        "utila": "~0.4"
       }
     },
     "dom-event-types": {
@@ -12872,6 +12980,144 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
           "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+          "dev": true
+        }
+      }
+    },
+    "html-minifier-terser": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.5.tgz",
+      "integrity": "sha512-cBSFFghQh/uHcfSiL42KxxIRMF7A144+3E44xdlctIjxEmkEfCvouxNyFH2wysXk1fCGBPwtcr3hDWlGTfkDew==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      },
+      "dependencies": {
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "dot-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+          "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "param-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+          "dev": true,
+          "requires": {
+            "dot-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+          "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.6.10",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
+          "integrity": "sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+              "dev": true
+            }
+          }
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+          "dev": true
+        }
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.4.tgz",
+      "integrity": "sha512-BREQzUbFfIQS39KqxkT2L1Ot0tuu1isako1CaCQLrgEQ43zi2ScHAe3SMTnVBWsStnIsGtl8jprDdxwZkNhrwQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.15",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         }
       }
@@ -17380,6 +17626,16 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
+    },
     "pretty-ms": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz",
@@ -18249,11 +18505,30 @@
         }
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+      "dev": true,
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
+      }
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -20983,6 +21258,12 @@
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
       }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "express-http-proxy": "^1.6.0",
     "gh-release-assets": "^1.1.2",
     "glob": "^7.1.6",
+    "html-webpack-plugin": "^4.0.4",
     "husky": "^3.1.0",
     "jasmine": "^3.5.0",
     "karma": "^4.4.1",

--- a/packages/rum/test/e2e/async-tests/app.js
+++ b/packages/rum/test/e2e/async-tests/app.js
@@ -1,0 +1,36 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { testFetch, renderTestElement } from '../utils'
+import { getGlobalConfig } from '../../../../../dev-utils/test-config'
+
+const { mockBackendUrl } = getGlobalConfig().testConfig
+
+/**
+ * Currently, Fetch call will not be captured as Spans by the agent
+ * since agent script is loaded asynchronously and we will not be able to patch
+ * XHR and FETCH calls on time
+ */
+testFetch(mockBackendUrl, renderTestElement, false)

--- a/packages/rum/test/e2e/async-tests/app.js
+++ b/packages/rum/test/e2e/async-tests/app.js
@@ -23,14 +23,14 @@
  *
  */
 
-import { testFetch, renderTestElement } from '../utils'
+import { testXHR, renderTestElement } from '../utils'
 import { getGlobalConfig } from '../../../../../dev-utils/test-config'
 
 const { mockBackendUrl } = getGlobalConfig().testConfig
 
 /**
- * Currently, Fetch call will not be captured as Spans by the agent
+ * Currently, XHR call will not be captured as Spans by the agent
  * since agent script is loaded asynchronously and we will not be able to patch
  * XHR and FETCH calls on time
  */
-testFetch(mockBackendUrl, renderTestElement, false)
+testXHR(mockBackendUrl, renderTestElement, false)

--- a/packages/rum/test/e2e/async-tests/async.e2e-spec.js
+++ b/packages/rum/test/e2e/async-tests/async.e2e-spec.js
@@ -23,13 +23,10 @@
  *
  */
 
-const {
-  waitForApmServerCalls,
-  getBrowserInfo
-} = require('../../../../../dev-utils/webdriver')
+const { getBrowserInfo } = require('../../../../../dev-utils/webdriver')
 
 describe('async-tests', function() {
-  fit('should run the usecase', function() {
+  it('should run the usecase', function() {
     browser.url('/test/e2e/async-tests/async-e2e.html')
     browser.waitUntil(
       () => {
@@ -39,14 +36,14 @@ describe('async-tests', function() {
       'expected element #test-element'
     )
 
-    const { sendEvents } = waitForApmServerCalls(0, 1)
-    const { transactions } = sendEvents
-
-    expect(transactions.length).toBe(1)
-    const transactionPayload = transactions[0]
+    /**
+     * Payload is set in the EJS template.
+     * Its not possible to inject the ApmServerMock for standalone
+     * tests as the application code is different from the APM Agent bundle code
+     */
+    const transactionPayload = browser.execute(() => window.TRANSACTION_PAYLOAD)
     expect(transactionPayload.type).toBe('page-load')
     expect(transactionPayload.name).toBe('/async')
-
     /**
      * Check for all types of spans that would be captured by
      * loading script async
@@ -56,7 +53,7 @@ describe('async-tests', function() {
      * Safari does not support Resource & User Timing API
      */
     const { name } = getBrowserInfo()
-    if (name.indexOf('safari') !== -1) {
+    if (name.indexOf('safari') === -1) {
       spanTypes.push('resource', 'app')
     }
 

--- a/packages/rum/test/e2e/async-tests/async.e2e-spec.js
+++ b/packages/rum/test/e2e/async-tests/async.e2e-spec.js
@@ -1,0 +1,69 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const {
+  waitForApmServerCalls,
+  getBrowserInfo
+} = require('../../../../../dev-utils/webdriver')
+
+describe('async-tests', function() {
+  fit('should run the usecase', function() {
+    browser.url('/test/e2e/async-tests/async-e2e.html')
+    browser.waitUntil(
+      () => {
+        return $('#test-element').getText() === 'Passed'
+      },
+      5000,
+      'expected element #test-element'
+    )
+
+    const { sendEvents } = waitForApmServerCalls(0, 1)
+    const { transactions } = sendEvents
+
+    expect(transactions.length).toBe(1)
+    const transactionPayload = transactions[0]
+    expect(transactionPayload.type).toBe('page-load')
+    expect(transactionPayload.name).toBe('/async')
+
+    /**
+     * Check for all types of spans that would be captured by
+     * loading script async
+     */
+    const spanTypes = ['hard-navigation']
+    /**
+     * Safari does not support Resource & User Timing API
+     */
+    const { name } = getBrowserInfo()
+    if (name.indexOf('safari') !== -1) {
+      spanTypes.push('resource', 'app')
+    }
+
+    const captured = transactionPayload.spans.every(({ type }) => {
+      return spanTypes.indexOf(type) !== -1
+    })
+
+    expect(captured).toBe(true)
+  })
+})

--- a/packages/rum/test/e2e/async-tests/async.e2e-spec.js
+++ b/packages/rum/test/e2e/async-tests/async.e2e-spec.js
@@ -41,7 +41,9 @@ describe('async-tests', function() {
      * Its not possible to inject the ApmServerMock for standalone
      * tests as the application code is different from the APM Agent bundle code
      */
-    const transactionPayload = browser.execute(() => window.TRANSACTION_PAYLOAD)
+    const transactionPayload = browser.execute(function() {
+      return window.TRANSACTION_PAYLOAD
+    })
     expect(transactionPayload.type).toBe('page-load')
     expect(transactionPayload.name).toBe('/async')
     /**

--- a/packages/rum/test/e2e/async-tests/async.e2e-spec.js
+++ b/packages/rum/test/e2e/async-tests/async.e2e-spec.js
@@ -50,7 +50,7 @@ describe('async-tests', function() {
      * Check for all types of spans that would be captured by
      * loading script async
      */
-    const spanTypes = ['hard-navigation']
+    const spanTypes = ['hard-navigation', 'external']
     /**
      * Safari does not support Resource & User Timing API
      */

--- a/packages/rum/test/e2e/async-tests/index.ejs
+++ b/packages/rum/test/e2e/async-tests/index.ejs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Async Test</title>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <script>
+      var script = document.createElement('script')
+      script.src = '/dist/bundles/elastic-apm-rum.umd.js'
+      script.onload = function() {
+        if (typeof performance.measure === 'function') {
+          performance.measure('loaded')
+        }
+        console.log('<%= ApmServerMock %>')
+        window.elasticApm.init({
+          serviceName: 'async-test',
+          serverUrl: '<%= serverUrl %>',
+          logLevel: 'debug',
+          distributedTracingOrigins: ['<%= mockBackendUrl %>'],
+          pageLoadTransactionName: '/async'
+        })
+      }
+      document.head.appendChild(script)
+    </script>
+  </head>
+
+  <body>
+    <div id="app">Loading RUM agent Asynchronously</div>
+    <script src="/test/e2e/async-tests/app.e2e-bundle.min.js"></script>
+  </body>
+</html>

--- a/packages/rum/test/e2e/async-tests/index.ejs
+++ b/packages/rum/test/e2e/async-tests/index.ejs
@@ -11,7 +11,6 @@
         if (typeof performance.measure === 'function') {
           performance.measure('loaded')
         }
-        console.log('<%= ApmServerMock %>')
         window.elasticApm.init({
           serviceName: 'async-test',
           serverUrl: '<%= serverUrl %>',
@@ -19,6 +18,14 @@
           distributedTracingOrigins: ['<%= mockBackendUrl %>'],
           pageLoadTransactionName: '/async'
         })
+
+        /**
+         * Make payload available globally so we can test
+         */
+        var apmServer = window.elasticApm.serviceFactory.getService('ApmServer')
+        apmServer.addTransaction = function(payload) {
+          window.TRANSACTION_PAYLOAD = payload
+        }
       }
       document.head.appendChild(script)
     </script>

--- a/packages/rum/test/e2e/async-tests/webpack.config.js
+++ b/packages/rum/test/e2e/async-tests/webpack.config.js
@@ -1,0 +1,56 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const path = require('path')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const { getGlobalConfig } = require('../../../../../dev-utils/test-config')
+const {
+  getWebpackConfig,
+  BUNDLE_TYPES
+} = require('../../../../../dev-utils/build')
+const ApmServerMock = require('../../../../rum-core/test/utils/apm-server-mock')
+
+const { serverUrl, mockBackendUrl } = getGlobalConfig().testConfig
+
+module.exports = {
+  entry: path.join(__dirname, 'app.js'),
+  output: {
+    path: path.resolve(__dirname),
+    filename: 'app.e2e-bundle.min.js'
+  },
+  ...getWebpackConfig(BUNDLE_TYPES.BROWSER_DEV),
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, 'index.ejs'),
+      filename: path.resolve(__dirname, 'async-e2e.html'),
+      templateParameters: {
+        serverUrl,
+        mockBackendUrl,
+        ApmServerMock
+      },
+      inject: false
+    })
+  ]
+}

--- a/packages/rum/test/e2e/async-tests/webpack.config.js
+++ b/packages/rum/test/e2e/async-tests/webpack.config.js
@@ -30,7 +30,6 @@ const {
   getWebpackConfig,
   BUNDLE_TYPES
 } = require('../../../../../dev-utils/build')
-const ApmServerMock = require('../../../../rum-core/test/utils/apm-server-mock')
 
 const { serverUrl, mockBackendUrl } = getGlobalConfig().testConfig
 
@@ -47,8 +46,7 @@ module.exports = {
       filename: path.resolve(__dirname, 'async-e2e.html'),
       templateParameters: {
         serverUrl,
-        mockBackendUrl,
-        ApmServerMock
+        mockBackendUrl
       },
       inject: false
     })

--- a/packages/rum/test/e2e/bundle-test/index.html
+++ b/packages/rum/test/e2e/bundle-test/index.html
@@ -1,15 +1,12 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>Bundle test</title>
+    <base href="/" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
 
-<head>
-  <title>test</title>
-  <base href="/">
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-
-<body>
-</body>
-<script src="/dist/bundles/elastic-apm-rum.umd.js"></script>
-
+  <body></body>
+  <script src="/dist/bundles/elastic-apm-rum.umd.js"></script>
 </html>

--- a/packages/rum/test/e2e/general-usecase/index.html
+++ b/packages/rum/test/e2e/general-usecase/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>test</title>
+    <title>General Usecase test</title>
     <base href="/" />
     <!-- <meta http-equiv="Content-Security-Policy" content="default-src 'self';img-src 'self' data:; connect-src http://localhost:8000 http://localhost:8200 http://localhost:8001 https://frontend-test-apm-server.elastic.co"> -->
     <meta charset="UTF-8" />

--- a/packages/rum/test/e2e/manual-timing/index.html
+++ b/packages/rum/test/e2e/manual-timing/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>test</title>
+    <title>Manual Timing test</title>
     <base href="/test/e2e/manual-timing/" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/rum/test/e2e/utils.js
+++ b/packages/rum/test/e2e/utils.js
@@ -54,24 +54,26 @@ function renderTestElement() {
   appEl.appendChild(testEl)
 }
 
-function testXHR(backendUrl, callback = () => {}) {
+function testXHR(backendUrl, callback = () => {}, validateDT = true) {
   const req = new window.XMLHttpRequest()
   req.onerror = err => console.log('[XHR Error]', err)
   req.open('POST', backendUrl + '/data', false)
   req.addEventListener('load', function() {
-    const payload = JSON.parse(req.responseText)
-    checkDtInfo(payload)
+    if (validateDT) {
+      const payload = JSON.parse(req.responseText)
+      checkDtInfo(payload)
+    }
     callback()
   })
 
   req.send()
 }
 
-function testFetch(backendUrl, callback = () => {}) {
+function testFetch(backendUrl, callback = () => {}, validateDT = true) {
   if ('fetch' in window) {
     fetch(backendUrl + '/fetch', { method: 'POST' }).then(response => {
       response.json().then(function(payload) {
-        checkDtInfo(payload)
+        validateDT && checkDtInfo(payload)
         callback()
       })
     })

--- a/packages/rum/test/e2e/utils.js
+++ b/packages/rum/test/e2e/utils.js
@@ -69,11 +69,11 @@ function testXHR(backendUrl, callback = () => {}, validateDT = true) {
   req.send()
 }
 
-function testFetch(backendUrl, callback = () => {}, validateDT = true) {
+function testFetch(backendUrl, callback = () => {}) {
   if ('fetch' in window) {
     fetch(backendUrl + '/fetch', { method: 'POST' }).then(response => {
       response.json().then(function(payload) {
-        validateDT && checkDtInfo(payload)
+        checkDtInfo(payload)
         callback()
       })
     })


### PR DESCRIPTION
+ fix #191 
+ Adds async-tests which loads our agent bundle asynchronously and also added some explanation on not able to capture XHR/Fetch since we cant patch the API's later. This is an issue and we can rely on Resource Timing API's in these cases. 