### PR TITLE
ci(jenkins): release automation followups

### DIFF
--- a/.ci/scripts/prepare-git-context.sh
+++ b/.ci/scripts/prepare-git-context.sh
@@ -38,3 +38,6 @@ git reset --hard "${GIT_BASE_COMMIT}"
 # Enable upstream with git+https.
 git remote add upstream "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ORG_NAME}/${REPO_NAME}.git"
 git fetch upstream
+
+# Pull the git history when repo was cloned with shallow/depth.
+git pull --unshallow

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -325,7 +325,7 @@ pipeline {
               }
               post {
                 success {
-                  emailext subject: "[${env.REPO}] Release published", to: "${env.NOTIFY_TO}"
+                  emailext subject: "[${env.REPO}] Release published", to: "${env.NOTIFY_TO}", body: "Great news, the release has been done successfully."
                 }
                 always {
                   script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -324,6 +324,9 @@ pipeline {
                 }
               }
               post {
+                success {
+                  emailext subject: "[${env.REPO}] Release published", to: "${env.NOTIFY_TO}"
+                }
                 always {
                   script {
                     currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,8 +44,14 @@ The release process is also automated in the way any specific commit from the ma
 
 1. Login to apm-ci.elastic.co
 1. Go to the [master](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/master/) pipeline.
-1. Click on `Build with parameters` and choose the `release` checkbox.
+1. Click on `Build with parameters` with the below checkboxes:
+  * `release` to be selected.
+  * `bench_ci` to be unselected.
+  * `saucelab_test` to be unselected.
+  * other checkboxes should be left as default.
+1. Click on `Build`.
 1. Wait for an email to confirm the release is ready to be approved, it might take roughly 30 minutes.
 1. Confirm if the list of changes are the ones that are expected.
-1. Approve or abort.
-1. Then you can go to the https://registry.npmjs.org and GitHub repo to validate that the bundles and release notes have been published.
+1. Click on the URL from the email.
+1. Click on approve or abort.
+1. Then you can go to the `https://www.npmjs.com/package/@elastic/apm-rum` and [GitHub releases](https://github.com/elastic/apm-agent-rum-js/releases) to validate that the bundles and release notes have been published.

--- a/lerna.json
+++ b/lerna.json
@@ -9,10 +9,14 @@
       "allowBranch": ["master", "4.x"],
       "conventionalCommits": true,
       "message": "chore(release): publish",
-      "gitRemote": "upstream"
+      "gitRemote": "upstream",
+      "loglevel": "verbose"
     },
     "run": {
       "stream": true
+    },
+    "publish": {
+      "loglevel": "verbose"
     }
   },
   "ignoreChanges": [


### PR DESCRIPTION
- Workspace is not anymore a shallow cloned but contains the whole history. Otherwise, the changelogs will not contain all the changes.
- Send email notification when the release has been published.
- Update RELEASE.md docs with more details.
- Enable verbose output when to publish and version. See [here](https://github.com/lerna/lerna/blob/5e790e5d661ee95e0dbc2160e6509e6691b8b9e3/core/project/README.md#command-specific-configuration)