### PR TITLE
fix(rum-react): avoid rerendering on query param changes

### DIFF
--- a/packages/rum-react/src/get-apm-route.js
+++ b/packages/rum-react/src/get-apm-route.js
@@ -33,15 +33,26 @@ function getApmRoute(apm) {
   return class ApmRoute extends React.Component {
     constructor(props) {
       super(props)
-      const { path, component } = props
+      this.state = {}
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+      const initial = prevState.apmComponent == null
+      const { path, component } = nextProps
+      const pathChanged = path != prevState.path
+
       /**
-       * Having the ApmComponent on state ensures that we capture the SPA
-       * navigation only when route changes/mount and not on re-renders
-       * Ex: updating query params from child components
+       * Should update the apmComponent state and re-render the component only on
+       * initial mount and on route change.
+       * Ex: Query param changes should not result in new apmComponent
        */
-      this.state = {
-        apmComponent: withTransaction(path, 'route-change')(component)
+      if (initial || pathChanged) {
+        return {
+          apmComponent: withTransaction(path, 'route-change')(component),
+          path
+        }
       }
+      return null
     }
 
     render() {

--- a/packages/rum-react/src/get-apm-route.js
+++ b/packages/rum-react/src/get-apm-route.js
@@ -30,10 +30,23 @@ import { getWithTransaction } from './get-with-transaction'
 function getApmRoute(apm) {
   const withTransaction = getWithTransaction(apm)
 
-  return function ApmRoute(props) {
-    const { path, component } = props
-    const apmComponent = withTransaction(path, 'route-change')(component)
-    return <Route {...props} component={apmComponent} />
+  return class ApmRoute extends React.Component {
+    constructor(props) {
+      super(props)
+      const { path, component } = props
+      /**
+       * Having the ApmComponent on state ensures that we capture the SPA
+       * navigation only when route changes/mount and not on re-renders
+       * Ex: updating query params from child components
+       */
+      this.state = {
+        apmComponent: withTransaction(path, 'route-change')(component)
+      }
+    }
+
+    render() {
+      return <Route {...this.props} component={this.state.apmComponent} />
+    }
   }
 }
 


### PR DESCRIPTION
+ Alternative solution to the #747 
+ This avoids the problem that would trigger full page reload when the query param is changed by any of the child components of `<ApmRoute>`
