### PR TITLE
feat(rum-core): add network info for all transactions

### DIFF
--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -200,11 +200,29 @@ function getTimeOrigin() {
   return PERF.timing.fetchStart
 }
 
-function getPageMetadata() {
+function getNetworkInformation(captureNetInfo) {
+  const connection = window.navigator && window.navigator.connection
+  if (!captureNetInfo || typeof connection !== 'object') {
+    return undefined
+  }
+  /**
+   * Ignoring `type` and `downlinkMax` as they are only
+   * supported on Chrome OS
+   */
+  return {
+    downlink: connection.downlink,
+    effective_type: connection.effectiveType,
+    rtt: connection.rtt,
+    save_data: !!connection.saveData
+  }
+}
+
+function getPageMetadata(captureNetInfo = true) {
   return {
     page: {
       referer: document.referrer,
-      url: window.location.href
+      url: window.location.href,
+      netinfo: getNetworkInformation(captureNetInfo)
     }
   }
 }

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -118,7 +118,7 @@ class ErrorLogging {
       : {}
     // eslint-disable-next-line no-unused-vars
     const { tags, ...configContext } = this._configService.get('context')
-    const pageMetadata = getPageMetadata()
+    const pageMetadata = getPageMetadata(false)
 
     const context = merge(
       {},

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -182,12 +182,25 @@ describe('Context', () => {
         message: 'test'
       }
     }
-    addTransactionContext(transaction, configContext)
-    expect(transaction.context).toEqual({
+
+    const pageContext = {
       page: {
         referer: jasmine.any(String),
-        url: jasmine.any(String)
-      },
+        url: jasmine.any(String),
+        netinfo:
+          {
+            downlink: jasmine.any(Number),
+            effective_type: jasmine.any(String),
+            rtt: jasmine.any(Number),
+            save_data: jasmine.any(Boolean)
+          } || undefined
+      }
+    }
+
+    addTransactionContext(transaction, configContext)
+
+    expect(transaction.context).toEqual({
+      ...pageContext,
       ...userContext,
       ...trContext
     })
@@ -197,10 +210,7 @@ describe('Context', () => {
     pageloadTr.end()
     addTransactionContext(pageloadTr, configContext)
     expect(pageloadTr.context).toEqual({
-      page: {
-        referer: jasmine.any(String),
-        url: jasmine.any(String)
-      },
+      ...pageContext,
       response: {
         transfer_size: 26941,
         encoded_body_size: 105297,

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -171,7 +171,8 @@ describe('ErrorLogging', function() {
       jasmine.objectContaining({
         page: {
           referer: jasmine.any(String),
-          url: jasmine.any(String)
+          url: jasmine.any(String),
+          netinfo: undefined
         },
         managed: true,
         dummy: {


### PR DESCRIPTION
+ fix #479 
+ All transactions like `page-load`, `route-change` and other auto instrumented transactions would include this information by default under transaction page metadata. 
+ Errors only include the previous page info and does not include the network info as its not super useful. 