### PR TITLE
fix(rum-core): add subtype span info without camelCasing

### DIFF
--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -112,10 +112,10 @@ function groupSpans(transaction) {
     if (duration === 0 || duration == null) {
       continue
     }
-    const { type, subType } = span
+    const { type, subtype } = span
     let key = type
-    if (subType) {
-      key += '.' + subType
+    if (subtype) {
+      key += '.' + subtype
     }
     if (!spanMap[key]) {
       spanMap[key] = {

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -205,7 +205,7 @@ function getApiSpanNames({ spans }) {
 
   for (let i = 0; i < spans.length; i++) {
     const span = spans[i]
-    if (span.type === 'external' && span.subType === 'http') {
+    if (span.type === 'external' && span.subtype === 'http') {
       apiCalls.push(span.name.split(' ')[1])
     }
   }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -81,7 +81,7 @@ export function groupSmallContinuouslySimilarSpans(
 
       var isContinuouslySimilar =
         lastSpan.type === span.type &&
-        lastSpan.subType === span.subType &&
+        lastSpan.subtype === span.subtype &&
         lastSpan.action === span.action &&
         lastSpan.name === span.name &&
         span.duration() / transDuration < threshold &&
@@ -417,7 +417,7 @@ export default class PerformanceMonitoring {
         trace_id: transaction.traceId,
         name: span.name,
         type: span.type,
-        subType: span.subType,
+        subtype: span.subtype,
         action: span.action,
         sync: span.sync,
         start: span._start - transactionStart,

--- a/packages/rum-core/src/performance-monitoring/span.js
+++ b/packages/rum-core/src/performance-monitoring/span.js
@@ -30,12 +30,12 @@ class Span extends SpanBase {
   constructor(name, type, options) {
     super(name, type, options)
     this.parentId = this.options.parentId
-    this.subType = undefined
+    this.subtype = undefined
     this.action = undefined
     if (this.type.indexOf('.') !== -1) {
       var fields = this.type.split('.', 3)
       this.type = fields[0]
-      this.subType = fields[1]
+      this.subtype = fields[1]
       this.action = fields[2]
     }
     this.sync = this.options.sync

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -43,7 +43,7 @@ function generateTransaction(count, breakdown = false) {
     var tr = new Transaction('transaction #' + i, 'transaction', {})
     tr.id = 'transaction-id-' + i
     tr.traceId = 'trace-id-' + i
-    var span1 = tr.startSpan('name', 'type', { sync: false })
+    var span1 = tr.startSpan('name', 'type.subtype', { sync: false })
     span1.end()
     span1.id = 'span-id-' + i + '-1'
     tr.end()
@@ -356,9 +356,9 @@ describe('ApmServer', function() {
       '{"error":{"name":"Error","message":"error #0"}}',
       '{"error":{"name":"Error","message":"error #1"}}',
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
-      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}',
+      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}',
       '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
-      '{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}'
+      '{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}'
     ]
 
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
@@ -373,9 +373,9 @@ describe('ApmServer', function() {
     var result = apmServer.ndjsonTransactions(payload)
     /* eslint-disable max-len */
     var expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
-      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n'
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n',
+      '{"transaction":{"id":"transaction-id-2","trace_id":"trace-id-2","name":"transaction #2","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}\n{"span":{"id":"span-id-2-1","transaction_id":"transaction-id-2","parent_id":"transaction-id-2","trace_id":"trace-id-2","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n'
     ]
     expect(result).toEqual(expected)
   })
@@ -389,10 +389,10 @@ describe('ApmServer', function() {
     /* eslint-disable max-len */
     const expected = [
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true}}\n',
-      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","sync":false,"start":10,"duration":10}}\n',
+      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',
-      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type","subtype":"subtype"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'
     ].join('')
     expect(result).toEqual([expected])
   })

--- a/packages/rum-core/test/common/truncate.spec.js
+++ b/packages/rum-core/test/common/truncate.spec.js
@@ -249,7 +249,7 @@ describe('Truncate', () => {
       name: generateStr('d', keywordLen),
       type: generateStr('e', keywordLen),
       sync: false,
-      subType: undefined,
+      subtype: undefined,
       action: undefined,
       start: 500,
       duration: 700.02,

--- a/packages/rum-core/test/performance-monitoring/breakdown.spec.js
+++ b/packages/rum-core/test/performance-monitoring/breakdown.spec.js
@@ -127,7 +127,7 @@ describe('Breakdown metrics', () => {
 
   it('transaction with single span', () => {
     const tr = createTransaction('custom')
-    const span = tr.startSpan('foo', 'bar', { startTime: 20 })
+    const span = tr.startSpan('foo', 'bar.baz', { startTime: 20 })
     span.end(40)
     tr.end(40)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
@@ -143,7 +143,7 @@ describe('Breakdown metrics', () => {
       'span.self_time.sum.us': { value: 20 }
     })
 
-    expect(breakdown.bar).toEqual({
+    expect(breakdown['bar.baz']).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 20 }
     })

--- a/packages/rum-core/test/performance-monitoring/span.spec.js
+++ b/packages/rum-core/test/performance-monitoring/span.spec.js
@@ -34,12 +34,12 @@ describe('Span', function() {
   it('should support dot delimiter in span types', function() {
     var s1 = new Span('test1', 'db.mysql.query')
     expect(s1.type).toBe('db')
-    expect(s1.subType).toBe('mysql')
+    expect(s1.subtype).toBe('mysql')
     expect(s1.action).toBe('query')
 
     var s2 = new Span('test2', 'db-query')
     expect(s2.type).toBe('db-query')
-    expect(s2.subType).toBe(undefined)
+    expect(s2.subtype).toBe(undefined)
     expect(s2.action).toBe(undefined)
   })
 })


### PR DESCRIPTION
+ Unfortunately this bug has been around for sometime and I just found out when doing the RUM payload test for v3. 
+ I have added some tests to ensure we dont miss them in both payload and breakdown metricsets. 

Kibana APM UI can show the info correctly now

<img width="930" alt="Screenshot 2020-04-17 at 10 27 06" src="https://user-images.githubusercontent.com/3902525/79549599-7d5ec000-8097-11ea-8bd6-92d9c5145aba.png">
