### PR TITLE
ci(dependabot): configuration file

### DIFF
--- a/.ci/dependabot.yml
+++ b/.ci/dependabot.yml
@@ -1,0 +1,5 @@
+### The list of GitHub accounts that will be used to assign the PRs to (no space and comma separated)
+assign: ''
+
+### The package manager to be used (no space and comma separated if more than one package)
+manager: npm_and_yarn


### PR DESCRIPTION
If we would like to enable the dependabot automation process to bump the version of the packages automatically, then it's required this particular file.

### How does it work?

There is a weekly pipeline that will care for all the projects with this particular file `ci/dependabot.yml` and if so it will run the validation and PR creations.

### For instance

https://github.com/v1v/apm-agent-rum-js/pulls?q=is%3Apr+is%3Alabel%3Adependencies

### Actions

- [ ] Verify if this particular dependabot is a good candidate to be enabled in this project.
- [ ] Assign?

### Issues

Closes https://github.com/elastic/apm-agent-rum-js/issues/656