### PR TITLE
ci: comment PRs with the build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/tests-reporting') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/tests-reporting') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,7 +363,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(prComment: true)
     }
   }
 }


### PR DESCRIPTION
Enhance the build reporting with a message in the PR that contains the build status for the last commit. It does reuse the message.