### PR TITLE
perf(rum-core): compress server payload for all events

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -28,15 +28,23 @@ import throttle from './throttle'
 import NDJSON from './ndjson'
 import { XHR_IGNORE } from './patching/patch-utils'
 import { truncateModel, METADATA_MODEL } from './truncate'
-import { SERVER_URL_PREFIX, ERRORS, TRANSACTIONS } from './constants'
+import { ERRORS, TRANSACTIONS } from './constants'
 import { noop } from './utils'
 import { Promise } from './polyfills'
+import {
+  compressMetadata,
+  compressTransaction,
+  compressError
+} from './compress'
 import { __DEV__ } from '../env'
 
 /**
  * Throttling interval deafults to 60 seconds
  */
 const THROTTLE_INTERVAL = 60000
+
+const V2_PREFIX = '/intake/v2/rum/events'
+const V3_PREFIX = '/intake/v3/rum/events'
 
 class ApmServer {
   constructor(configService, loggingService) {
@@ -210,28 +218,42 @@ class ApmServer {
     this.throttleEvents({ [TRANSACTIONS]: transaction })
   }
 
-  ndjsonErrors(errors) {
-    return errors.map(error => NDJSON.stringify({ error }))
+  ndjsonErrors(errors, compress) {
+    const key = compress ? 'e' : 'error'
+    return errors.map(error =>
+      NDJSON.stringify({
+        [key]: compress ? compressError(error) : error
+      })
+    )
   }
 
   ndjsonMetricsets(metricsets) {
     return metricsets.map(metricset => NDJSON.stringify({ metricset })).join('')
   }
 
-  ndjsonTransactions(transactions) {
+  ndjsonTransactions(transactions, compress) {
+    const key = compress ? 'x' : 'transaction'
+
     return transactions.map(tr => {
-      let spans = ''
-      if (tr.spans) {
-        spans = tr.spans.map(span => NDJSON.stringify({ span })).join('')
-        delete tr.spans
-      }
-      let breakdowns = ''
-      if (tr.breakdown) {
-        breakdowns = this.ndjsonMetricsets(tr.breakdown)
-        delete tr.breakdown
+      let spans = '',
+        breakdowns = ''
+
+      if (!compress) {
+        if (tr.spans) {
+          spans = tr.spans.map(span => NDJSON.stringify({ span })).join('')
+          delete tr.spans
+        }
+        if (tr.breakdown) {
+          breakdowns = this.ndjsonMetricsets(tr.breakdown)
+          delete tr.breakdown
+        }
       }
 
-      return NDJSON.stringify({ transaction: tr }) + spans + breakdowns
+      return (
+        NDJSON.stringify({ [key]: compress ? compressTransaction(tr) : tr }) +
+        spans +
+        breakdowns
+      )
     })
   }
 
@@ -253,26 +275,34 @@ class ApmServer {
       return
     }
 
+    const cfg = this._configService
     const payload = {
       [TRANSACTIONS]: transactions,
       [ERRORS]: errors
     }
-    const filteredPayload = this._configService.applyFilters(payload)
+    const filteredPayload = cfg.applyFilters(payload)
     if (!filteredPayload) {
       this._loggingService.warn('Dropped payload due to filtering!')
       return
     }
 
+    const compress = cfg.get('compressPayload')
     let ndjson = []
     const metadata = this.createMetaData()
-    ndjson.push(NDJSON.stringify({ metadata }))
+    const metadataKey = compress ? 'm' : 'metadata'
+
+    ndjson.push(
+      NDJSON.stringify({
+        [metadataKey]: compress ? compressMetadata(metadata) : metadata
+      })
+    )
 
     ndjson = ndjson.concat(
-      this.ndjsonErrors(filteredPayload[ERRORS]),
-      this.ndjsonTransactions(filteredPayload[TRANSACTIONS])
+      this.ndjsonErrors(filteredPayload[ERRORS], compress),
+      this.ndjsonTransactions(filteredPayload[TRANSACTIONS], compress)
     )
     const ndjsonPayload = ndjson.join('')
-    const endPoint = this._configService.get('serverUrl') + SERVER_URL_PREFIX
+    const endPoint = cfg.get('serverUrl') + compress ? V3_PREFIX : V2_PREFIX
     return this._postJson(endPoint, ndjsonPayload)
   }
 }

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -287,9 +287,9 @@ class ApmServer {
 
     const apiVersion = cfg.get('apiVersion')
     /**
-     * when API version is >2, we can enable compression of the payload
+     * Enable payload compression only when API version is > 2
      */
-    const compress = apiVersion > 2 ? true : false
+    const compress = apiVersion > 2
 
     let ndjson = []
     const metadata = this.createMetaData()

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -302,7 +302,7 @@ class ApmServer {
       this.ndjsonTransactions(filteredPayload[TRANSACTIONS], compress)
     )
     const ndjsonPayload = ndjson.join('')
-    const endPoint = cfg.get('serverUrl') + compress ? V3_PREFIX : V2_PREFIX
+    const endPoint = cfg.get('serverUrl') + (compress ? V3_PREFIX : V2_PREFIX)
     return this._postJson(endPoint, ndjsonPayload)
   }
 }

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -39,7 +39,7 @@ import {
 import { __DEV__ } from '../env'
 
 /**
- * Throttling interval deafults to 60 seconds
+ * Throttling interval defaults to 60 seconds
  */
 const THROTTLE_INTERVAL = 60000
 

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -25,6 +25,12 @@
 
 import { NAVIGATION_TIMING_MARKS } from '../performance-monitoring/capture-navigation'
 
+/**
+ * Compression of all the below schema is based on the v3 RUM Specification
+ * Mapping of existing fields can  be found here
+ * https://github.com/elastic/apm-server/blob/master/model/modeldecoder/field/rum_v3_mapping.go
+ */
+
 const COMPRESSED_NAV_TIMING_MARKS = [
   'fs',
   'ls',

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -84,6 +84,9 @@ function compressHTTP(http) {
 }
 
 function compressContext(context) {
+  if (!context) {
+    return null
+  }
   const compressed = {}
   for (const key of Object.keys(context)) {
     const value = context[key]
@@ -128,6 +131,9 @@ function compressContext(context) {
 }
 
 function compressMarks(marks) {
+  if (!marks) {
+    return null
+  }
   const { navigationTiming, agent } = marks
   const compressed = { nt: {}, a: {} }
 
@@ -180,10 +186,8 @@ export function compressTransaction(transaction) {
       n: span.name,
       t: span.type,
       s: span.start,
-      d: span.duration
-    }
-    if (span.context) {
-      spanData.c = compressContext(span.context)
+      d: span.duration,
+      c: compressContext(span.context)
     }
     /**
      * Set parentId only for spans that are child of other spans

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -1,0 +1,284 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { NAVIGATION_TIMING_MARKS } from '../performance-monitoring/capture-navigation'
+
+const COMPRESSED_NAV_TIMING_MARKS = [
+  'fs',
+  'ls',
+  'le',
+  'cs',
+  'ce',
+  'qs',
+  'rs',
+  're',
+  'dl',
+  'di',
+  'ds',
+  'de',
+  'dc',
+  'es',
+  'ee'
+]
+
+function compressStackFrames(frames) {
+  return frames.map(frame => ({
+    ap: frame.abs_path,
+    f: frame.filename,
+    fn: frame.function,
+    li: frame.lineno,
+    co: frame.colno
+  }))
+}
+
+function compressResponse(response) {
+  return {
+    ts: response.transfer_size,
+    ebs: response.encoded_body_size,
+    dbs: response.decoded_body_size
+  }
+}
+
+function compressHTTP(http) {
+  const compressed = {}
+  for (const key of Object.keys(http)) {
+    const value = http[key]
+    switch (key) {
+      case 'method':
+        compressed.mt = value
+        break
+      case 'status_code':
+        compressed.sc = value
+        break
+      case 'url':
+        compressed.url = value
+        break
+      case 'response':
+        compressed.r = compressResponse(value)
+        break
+    }
+  }
+  return compressed
+}
+
+function compressContext(context) {
+  const compressed = {}
+  for (const key of Object.keys(context)) {
+    const value = context[key]
+    switch (key) {
+      case 'page':
+        compressed.p = {
+          rf: value.referer,
+          url: value.url
+        }
+        break
+      case 'http':
+        compressed.h = compressHTTP(value)
+        break
+      case 'response':
+        compressed.r = compressResponse(value)
+        break
+      case 'user':
+        compressed.u = {
+          id: value.id,
+          un: value.username,
+          em: value.email
+        }
+        break
+      case 'destination':
+        const { service } = value
+        compressed.dt = {
+          se: {
+            n: service.name,
+            t: service.type,
+            rc: service.resource
+          },
+          ad: value.address,
+          po: value.port
+        }
+        break
+      case 'custom':
+        compressed.cu = value
+        break
+    }
+  }
+  return compressed
+}
+
+function compressMarks(marks) {
+  const { navigationTiming, agent } = marks
+  const compressed = { nt: {}, a: {} }
+
+  COMPRESSED_NAV_TIMING_MARKS.forEach((mark, index) => {
+    const mapping = NAVIGATION_TIMING_MARKS[index]
+    compressed.nt[mark] = navigationTiming[mapping]
+  })
+
+  compressed.a = {
+    fb: compressed.nt.rs,
+    di: compressed.nt.di,
+    dc: compressed.nt.dc
+  }
+  const fp = agent.firstContentfulPaint
+  const lp = agent.largestContentfulPaint
+  if (fp) {
+    compressed.a.fp = fp
+  }
+  if (lp) {
+    compressed.a.lp = lp
+  }
+
+  return compressed
+}
+
+export function compressMetadata(metadata) {
+  const { service, labels } = metadata
+  const { agent, language } = service
+  return {
+    se: {
+      n: service.name,
+      ve: service.version,
+      a: {
+        n: agent.name,
+        ve: agent.version
+      },
+      la: {
+        n: language.name
+      },
+      en: service.environment
+    },
+    l: labels
+  }
+}
+
+export function compressTransaction(transaction) {
+  const spans = transaction.spans.map(span => {
+    const spanData = {
+      id: span.id,
+      n: span.name,
+      t: span.type,
+      s: span.start,
+      d: span.duration
+    }
+    if (span.context) {
+      spanData.c = compressContext(span.context)
+    }
+    /**
+     * Set parentId only for spans that are child of other spans
+     * and not transaction as it will be inferred
+     */
+    if (span.parent_id !== transaction.id) {
+      spanData.pid = span.parent_id
+    }
+    /**
+     * Set the below fields only when they are truthy or exists
+     */
+    if (span.sync === true) {
+      spanData.sy = true
+    }
+    if (span.subtype) {
+      spanData.su = span.subtype
+    }
+    if (span.action) {
+      spanData.ac = span.action
+    }
+    return spanData
+  })
+
+  return {
+    id: transaction.id,
+    tid: transaction.trace_id,
+    n: transaction.name,
+    t: transaction.type,
+    d: transaction.duration,
+    c: compressContext(transaction.context),
+    m: compressMarks(transaction.marks),
+    b: compressMetricsets(transaction.breakdown),
+    y: spans,
+    yc: {
+      sd: spans.length
+    },
+    sm: transaction.sampled
+  }
+}
+
+export function compressError(error) {
+  const { exception } = error
+  const compressed = {
+    id: error.id,
+    cl: error.culprit,
+    ex: {
+      mg: exception.message,
+      st: compressStackFrames(exception.stacktrace),
+      t: error.type
+    },
+    c: compressContext(error.context)
+  }
+
+  const { transaction } = error
+  if (transaction) {
+    compressed.tid = error.trace_id
+    compressed.pid = error.parent_id
+    compressed.xid = error.transaction_id
+    compressed.x = {
+      t: transaction.type,
+      sm: transaction.sampled
+    }
+  }
+
+  return compressed
+}
+
+export function compressMetricsets(breakdowns) {
+  return breakdowns.map(({ span, samples }) => {
+    const isSpan = span != null
+    if (isSpan) {
+      return {
+        y: { t: span.type },
+        sa: {
+          ysc: {
+            v: samples['span.self_time.count'].value
+          },
+          yss: {
+            v: samples['span.self_time.sum.us'].value
+          }
+        }
+      }
+    }
+    return {
+      sa: {
+        xdc: {
+          v: samples['transaction.duration.count'].value
+        },
+        xds: {
+          v: samples['transaction.duration.sum.us'].value
+        },
+        xbc: {
+          v: samples['transaction.breakdown.count'].value
+        }
+      }
+    }
+  })
+}

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -89,6 +89,7 @@ class Config {
       transactionSampleRate: 1.0,
       centralConfig: false,
       monitorLongtasks: true,
+      compressPayload: false,
       context: {}
     }
 

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -89,7 +89,7 @@ class Config {
       transactionSampleRate: 1.0,
       centralConfig: false,
       monitorLongtasks: true,
-      compressPayload: false,
+      apiVersion: 2,
       context: {}
     }
 

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -142,7 +142,6 @@ const TRANSACTIONS = 'transactions'
 /**
  * Services
  */
-
 const CONFIG_SERVICE = 'ConfigService'
 const LOGGING_SERVICE = 'LoggingService'
 const APM_SERVER = 'ApmServer'
@@ -156,7 +155,6 @@ const TRUNCATED_TYPE = '.truncated'
  * Default configs used on top of extensible configs from ConfigService
  */
 const KEYWORD_LIMIT = 1024
-const SERVER_URL_PREFIX = '/intake/v2/rum/events'
 
 export {
   SCHEDULE,
@@ -192,7 +190,6 @@ export {
   FIRST_CONTENTFUL_PAINT,
   LARGEST_CONTENTFUL_PAINT,
   KEYWORD_LIMIT,
-  SERVER_URL_PREFIX,
   TEMPORARY_TYPE,
   USER_INTERACTION,
   TRANSACTION_TYPE_ORDER,

--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -25,12 +25,7 @@
 
 import Url from './url'
 import { PAGE_LOAD, NAVIGATION } from './constants'
-import {
-  getPageMetadata,
-  getServerTimingInfo,
-  PERF,
-  isPerfTimelineSupported
-} from './utils'
+import { getServerTimingInfo, PERF, isPerfTimelineSupported } from './utils'
 
 const LEFT_SQUARE_BRACKET = 91 // [
 const RIGHT_SQUARE_BRACKET = 93 // ]
@@ -146,6 +141,15 @@ function getExternalContext(data) {
   return context
 }
 
+export function getPageContext() {
+  return {
+    page: {
+      referer: document.referrer,
+      url: window.location.href
+    }
+  }
+}
+
 export function addSpanContext(span, data) {
   if (!data) {
     return
@@ -168,7 +172,7 @@ export function addTransactionContext(
   // eslint-disable-next-line no-unused-vars
   { tags, ...configContext } = {}
 ) {
-  const pageContext = getPageMetadata()
+  const pageContext = getPageContext()
   let responseContext = {}
   if (transaction.type === PAGE_LOAD && isPerfTimelineSupported()) {
     let entries = PERF.getEntriesByType(NAVIGATION)

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -200,15 +200,6 @@ function getTimeOrigin() {
   return PERF.timing.fetchStart
 }
 
-function getPageMetadata() {
-  return {
-    page: {
-      referer: document.referrer,
-      url: window.location.href
-    }
-  }
-}
-
 function stripQueryStringFromUrl(url) {
   return url && url.split('?')[0]
 }
@@ -347,7 +338,7 @@ function getDuration(start, end) {
   if (isUndefined(end) || isUndefined(start)) {
     return null
   }
-  return parseFloat(end - start)
+  return parseInt(end - start)
 }
 
 function scheduleMacroTask(callback) {
@@ -381,7 +372,6 @@ export {
   parseDtHeaderValue,
   getServerTimingInfo,
   getDtHeaderValue,
-  getPageMetadata,
   getCurrentScript,
   getElasticScript,
   getTimeOrigin,

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -24,12 +24,8 @@
  */
 
 import { createStackTraces, filterInvalidFrames } from './stack-trace'
-import {
-  getPageMetadata,
-  generateRandomId,
-  merge,
-  extend
-} from '../common/utils'
+import { generateRandomId, merge, extend } from '../common/utils'
+import { getPageContext } from '../common/context'
 import { truncateModel, ERROR_MODEL } from '../common/truncate'
 
 /**
@@ -118,11 +114,11 @@ class ErrorLogging {
       : {}
     // eslint-disable-next-line no-unused-vars
     const { tags, ...configContext } = this._configService.get('context')
-    const pageMetadata = getPageMetadata()
+    const pageContext = getPageContext()
 
     const context = merge(
       {},
-      pageMetadata,
+      pageContext,
       transactionContext,
       configContext,
       errorContext

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -212,6 +212,13 @@ function getApiSpanNames({ spans }) {
   return apiCalls
 }
 
+/**
+ * Navigation timing marks are reported only for page-load transactions
+ *
+ * Do not change the order of both NAVIGATION_TIMING_MARKS and
+ * COMPRESSED_NAV_TIMING_MARKS since compression of the fields are based on the
+ * order they are placed in the array
+ */
 const NAVIGATION_TIMING_MARKS = [
   'fetchStart',
   'domainLookupStart',
@@ -228,6 +235,24 @@ const NAVIGATION_TIMING_MARKS = [
   'domComplete',
   'loadEventStart',
   'loadEventEnd'
+]
+
+const COMPRESSED_NAV_TIMING_MARKS = [
+  'fs',
+  'ls',
+  'le',
+  'cs',
+  'ce',
+  'qs',
+  'rs',
+  're',
+  'dl',
+  'di',
+  'ds',
+  'de',
+  'dc',
+  'es',
+  'ee'
 ]
 
 function getNavigationTimingMarks() {
@@ -344,5 +369,6 @@ export {
   createNavigationTimingSpans,
   createResourceTimingSpans,
   createUserTimingSpans,
-  NAVIGATION_TIMING_MARKS
+  NAVIGATION_TIMING_MARKS,
+  COMPRESSED_NAV_TIMING_MARKS
 }

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -212,13 +212,12 @@ function getApiSpanNames({ spans }) {
   return apiCalls
 }
 
-const navigationTimingKeys = [
+const NAVIGATION_TIMING_MARKS = [
   'fetchStart',
   'domainLookupStart',
   'domainLookupEnd',
   'connectStart',
   'connectEnd',
-  'secureConnectionStart',
   'requestStart',
   'responseStart',
   'responseEnd',
@@ -235,10 +234,10 @@ function getNavigationTimingMarks() {
   const timing = PERF.timing
   const fetchStart = timing.fetchStart
   const marks = {}
-  navigationTimingKeys.forEach(function(timingKey) {
+  NAVIGATION_TIMING_MARKS.forEach(function(timingKey) {
     const m = timing[timingKey]
     if (m && m >= fetchStart) {
-      marks[timingKey] = m - fetchStart
+      marks[timingKey] = parseInt(m - fetchStart)
     }
   })
   return marks
@@ -344,5 +343,6 @@ export {
   captureNavigation,
   createNavigationTimingSpans,
   createResourceTimingSpans,
-  createUserTimingSpans
+  createUserTimingSpans,
+  NAVIGATION_TIMING_MARKS
 }

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -133,7 +133,7 @@ export function captureObserverEntries(list, { capturePaint }) {
      * that is loaded cross-origin without the `Timing-Allow-Origin` header.
      */
     const lcp = lastLcpEntry.renderTime || lastLcpEntry.loadTimes
-    result.marks.largestContentfulPaint = lcp
+    result.marks.largestContentfulPaint = parseInt(lcp)
   }
 
   /**
@@ -151,7 +151,7 @@ export function captureObserverEntries(list, { capturePaint }) {
   if (fcpEntry) {
     const fcp =
       unloadDiff >= 0 ? fcpEntry.startTime - unloadDiff : fcpEntry.startTime
-    result.marks.firstContentfulPaint = fcp
+    result.marks.firstContentfulPaint = parseInt(fcp)
   }
 
   return result

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -420,7 +420,7 @@ export default class PerformanceMonitoring {
         subtype: span.subtype,
         action: span.action,
         sync: span.sync,
-        start: span._start - transactionStart,
+        start: parseInt(span._start - transactionStart),
         duration: span.duration(),
         context: span.context
       }

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -360,7 +360,7 @@ describe('ApmServer', function() {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"b":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true}}'
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -334,10 +334,10 @@ describe('ApmServer', function() {
     clock.uninstall()
   })
 
-  it('should compress all events when compress flag is true', () => {
+  it('should compress all events when apiVersion is >2', () => {
     const clock = jasmine.clock()
     clock.install()
-    configService.setConfig({ compressPayload: true })
+    configService.setConfig({ apiVersion: 3 })
     apmServer.init()
     spyOn(apmServer, '_postJson')
     const trs = generateTransaction(1, true).map(tr =>
@@ -485,7 +485,7 @@ describe('ApmServer', function() {
     '7.8+',
     () => {
       it('should post compressed payload without errors', async () => {
-        configService.setConfig({ compressPayload: true })
+        configService.setConfig({ apiVersion: 3 })
         const transactions = generateTransaction(1, true).map(tr =>
           performanceMonitoring.createTransactionDataModel(tr)
         )

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -25,51 +25,16 @@
 
 import compareVersions from 'compare-versions'
 import Transaction from '../../src/performance-monitoring/transaction'
-import { getGlobalConfig } from '../../../../dev-utils/test-config'
-import { describeIf } from '../../../../dev-utils/jasmine'
-import { captureBreakdown } from '../../src/performance-monitoring/breakdown'
 import {
   LOCAL_CONFIG_KEY,
   ERRORS,
   TRANSACTIONS
 } from '../../src/common/constants'
-import { createServiceFactory } from '../'
+import { getGlobalConfig } from '../../../../dev-utils/test-config'
+import { describeIf } from '../../../../dev-utils/jasmine'
+import { createServiceFactory, generateTransaction, generateErrors } from '../'
 
 const { agentConfig, testConfig } = getGlobalConfig('rum-core')
-
-function generateTransaction(count, breakdown = false) {
-  var result = []
-  for (var i = 0; i < count; i++) {
-    var tr = new Transaction('transaction #' + i, 'transaction', {
-      startTime: 10
-    })
-    tr.id = 'transaction-id-' + i
-    tr.traceId = 'trace-id-' + i
-    var span = tr.startSpan('name', 'type.subtype', {
-      sync: false,
-      startTime: 20
-    })
-    span.end(30)
-    span.id = 'span-id-' + i + '-1'
-    tr.end(1000)
-    if (breakdown) {
-      tr.sampled = true
-      tr.selfTime = tr.duration() - span.duration()
-      tr.breakdownTimings = captureBreakdown(tr)
-    }
-
-    result.push(tr)
-  }
-  return result
-}
-
-function generateErrors(count) {
-  var result = []
-  for (var i = 0; i < count; i++) {
-    result.push(new Error('error #' + i))
-  }
-  return result
-}
 
 describe('ApmServer', function() {
   var serviceFactory

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -40,20 +40,21 @@ const { agentConfig, testConfig } = getGlobalConfig('rum-core')
 function generateTransaction(count, breakdown = false) {
   var result = []
   for (var i = 0; i < count; i++) {
-    var tr = new Transaction('transaction #' + i, 'transaction', {})
+    var tr = new Transaction('transaction #' + i, 'transaction', {
+      startTime: 10
+    })
     tr.id = 'transaction-id-' + i
     tr.traceId = 'trace-id-' + i
-    var span1 = tr.startSpan('name', 'type.subtype', { sync: false })
-    span1.end()
-    span1.id = 'span-id-' + i + '-1'
-    tr.end()
-    tr._start = 10
-    tr._end = 1000
-    span1._start = 20
-    span1._end = 30
+    var span = tr.startSpan('name', 'type.subtype', {
+      sync: false,
+      startTime: 20
+    })
+    span.end(30)
+    span.id = 'span-id-' + i + '-1'
+    tr.end(1000)
     if (breakdown) {
       tr.sampled = true
-      tr.selfTime = tr.duration() - span1.duration()
+      tr.selfTime = tr.duration() - span.duration()
       tr.breakdownTimings = captureBreakdown(tr)
     }
 
@@ -77,6 +78,7 @@ describe('ApmServer', function() {
   var loggingService
   var originalTimeout
   var performanceMonitoring
+  var errorLogging
 
   beforeEach(function() {
     /**
@@ -91,6 +93,7 @@ describe('ApmServer', function() {
     loggingService = serviceFactory.getService('LoggingService')
     apmServer = serviceFactory.getService('ApmServer')
     performanceMonitoring = serviceFactory.getService('PerformanceMonitoring')
+    errorLogging = serviceFactory.getService('ErrorLogging')
   })
 
   afterEach(function() {
@@ -366,6 +369,38 @@ describe('ApmServer', function() {
     clock.uninstall()
   })
 
+  it('should compress all events when compress flag is true', () => {
+    const clock = jasmine.clock()
+    clock.install()
+    configService.setConfig({ compressPayload: true })
+    apmServer.init()
+    spyOn(apmServer, '_postJson')
+    const trs = generateTransaction(1, true).map(tr =>
+      performanceMonitoring.createTransactionDataModel(tr)
+    )
+    const errors = generateErrors(1).map((err, i) => {
+      let model = errorLogging.createErrorDataModel(err)
+      model.id = 'error-id-' + i
+      model.context = null
+      return model
+    })
+
+    trs.forEach(tr => apmServer.addTransaction(tr))
+    errors.forEach(err => apmServer.addError(err))
+    clock.tick(600)
+
+    expect(apmServer._postJson).toHaveBeenCalled()
+    const payload = apmServer._postJson.calls.argsFor(0)[1]
+
+    const expected = [
+      '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
+      '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"b":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true}}'
+    ]
+    expect(payload.split('\n').filter(a => a)).toEqual(expected)
+    clock.uninstall()
+  })
+
   it('should ndjson transactions', function() {
     var trs = generateTransaction(3)
     const payload = trs.map(tr =>
@@ -477,7 +512,32 @@ describe('ApmServer', function() {
         sessionStorage.removeItem(LOCAL_CONFIG_KEY)
       })
     },
-    !testConfig.stackVersion ||
+    testConfig.stackVersion &&
       compareVersions(testConfig.stackVersion, '7.5.0') >= 0
+  )
+
+  describeIf(
+    '7.8+',
+    () => {
+      it('should post compressed payload without errors', async () => {
+        configService.setConfig({ compressPayload: true })
+        const transactions = generateTransaction(1, true).map(tr =>
+          performanceMonitoring.createTransactionDataModel(tr)
+        )
+        const errors = generateErrors(1, true).map(err =>
+          errorLogging.createErrorDataModel(err)
+        )
+        await apmServer.sendEvents([
+          {
+            [TRANSACTIONS]: transactions[0]
+          },
+          {
+            [ERRORS]: errors[0]
+          }
+        ])
+      })
+    },
+    testConfig.stackVersion &&
+      compareVersions(testConfig.stackVersion, '7.8.0') >= 0
   )
 })

--- a/packages/rum-core/test/common/compess.spec.js
+++ b/packages/rum-core/test/common/compess.spec.js
@@ -1,0 +1,248 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { createServiceFactory, generateTransaction, generateErrors } from '../'
+import {
+  compressTransaction,
+  compressMetadata,
+  compressError
+} from '../../src/common/compress'
+import { addTransactionContext } from '../../src/common/context'
+
+/**
+ * Mapping of existing fields with the new v3 RUM specification
+ * https://github.com/elastic/apm-server/blob/master/model/modeldecoder/field/rum_v3_mapping.go
+ */
+const V3_MAPPING = {
+  abs_path: 'ap',
+  action: 'ac',
+  address: 'ad',
+  agent: 'a',
+  attributes: 'at',
+  breakdown: 'b',
+  cause: 'ca',
+  classname: 'cn',
+  code: 'cd',
+  colno: 'co',
+  connectEnd: 'ce',
+  connectStart: 'cs',
+  context: 'c',
+  context_line: 'cli',
+  culprit: 'cl',
+  custom: 'cu',
+  decoded_body_size: 'dbs',
+  destination: 'dt',
+  domComplete: 'dc',
+  domContentLoadedEventEnd: 'de',
+  domContentLoadedEventStart: 'ds',
+  domInteractive: 'di',
+  domLoading: 'dl',
+  domainLookupEnd: 'le',
+  domainLookupStart: 'ls',
+  dropped: 'dd',
+  duration: 'd',
+  email: 'em',
+  encoded_body_size: 'ebs',
+  env: 'en',
+  environment: 'en',
+  error: 'e',
+  exception: 'ex',
+  fetchStart: 'fs',
+  filename: 'f',
+  firstContentfulPaint: 'fp',
+  framework: 'fw',
+  function: 'fn',
+  handled: 'hd',
+  headers: 'he',
+  http: 'h',
+  http_version: 'hve',
+  labels: 'l',
+  language: 'la',
+  largestContentfulPaint: 'lp',
+  level: 'lv',
+  lineno: 'li',
+  loadEventEnd: 'ee',
+  loadEventStart: 'es',
+  log: 'log',
+  logger_name: 'ln',
+  marks: 'k',
+  message: 'mg',
+  metadata: 'm',
+  method: 'mt',
+  metricset: 'me',
+  module: 'mo',
+  name: 'n',
+  navigationTiming: 'nt',
+  page: 'p',
+  param_message: 'pmg',
+  parent_id: 'pid',
+  parent_idx: 'pi',
+  port: 'po',
+  post_context: 'poc',
+  pre_context: 'prc',
+  referer: 'rf',
+  request: 'q',
+  requestStart: 'qs',
+  resource: 'rc',
+  result: 'rt',
+  response: 'r',
+  responseEnd: 're',
+  responseStart: 'rs',
+  runtime: 'ru',
+  sampled: 'sm',
+  samples: 'sa',
+  'server-timing': 'set',
+  service: 'se',
+  span: 'y',
+  'span.self_time.count': 'ysc',
+  'span.self_time.sum.us': 'yss',
+  span_count: 'yc',
+  stacktrace: 'st',
+  start: 's',
+  started: 'sd',
+  status_code: 'sc',
+  subType: 'su',
+  sync: 'sy',
+  tags: 'g',
+  timeToFirstByte: 'fb',
+  trace_id: 'tid',
+  transaction: 'x',
+  transaction_id: 'xid',
+  'transaction.breakdown.count': 'xbc',
+  'transaction.duration.count': 'xdc',
+  'transaction.duration.sum.us': 'xds',
+  transfer_size: 'ts',
+  type: 't',
+  url: 'url',
+  user: 'u',
+  username: 'un',
+  value: 'v',
+  version: 've'
+}
+
+const SEPARATOR = '.'
+
+function flatten(obj) {
+  const result = {}
+  for (const key of Object.keys(obj)) {
+    const value = obj[key]
+    if (value != null && typeof value === 'object') {
+      const flatObj = flatten(value)
+
+      for (let flatKey of Object.keys(flatObj)) {
+        result[key + SEPARATOR + flatKey] = flatObj[flatKey]
+      }
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+describe('Compress', function() {
+  let serviceFactory
+  let apmServer
+  let configService
+  let performanceMonitoring
+  let errorLogging
+
+  beforeEach(function() {
+    serviceFactory = createServiceFactory()
+    configService = serviceFactory.getService('ConfigService')
+    apmServer = serviceFactory.getService('ApmServer')
+    performanceMonitoring = serviceFactory.getService('PerformanceMonitoring')
+    errorLogging = serviceFactory.getService('ErrorLogging')
+    configService.setConfig({
+      context: {
+        tags: {
+          foo: 'bar'
+        }
+      }
+    })
+  })
+
+  function getMappedKeys(keys) {
+    return keys.map(key => {
+      const mappedKey = V3_MAPPING[key]
+      if (mappedKey != null) {
+        return mappedKey
+      }
+      return key
+    })
+  }
+
+  function testMappedObject(original, compressed) {
+    const originalFlat = flatten(original)
+    const compressedFlat = flatten(compressed)
+
+    for (const key of Object.keys(originalFlat)) {
+      const keys = key.split(SEPARATOR)
+      const mappedKeys = getMappedKeys(keys)
+      const compressedKey = mappedKeys.join(SEPARATOR)
+      /**
+       * Some fields are made optional in the v3 spec so we check
+       * the condition only when the values are present in new scheme
+       */
+      if (compressedFlat[compressedKey] != null) {
+        expect(originalFlat[key]).toEqual(compressedFlat[compressedKey])
+      }
+    }
+  }
+
+  it('should compress metadata model', () => {
+    configService.setVersion('5.0.0')
+    configService.setConfig({
+      serviceName: 'test',
+      serviceVersion: '1.1.2',
+      environment: 'test'
+    })
+    const metadata = apmServer.createMetaData()
+    const compressed = compressMetadata(metadata)
+
+    testMappedObject(metadata, compressed)
+  })
+
+  it('should compress transaction model', () => {
+    const transaction = generateTransaction(1, true).map(tr => {
+      addTransactionContext(tr, { custom: { foo: 'bar' } })
+      const model = performanceMonitoring.createTransactionDataModel(tr)
+      return model
+    })[0]
+    const compressed = compressTransaction(transaction)
+
+    testMappedObject(transaction, compressed)
+  })
+
+  it('should compress error model', () => {
+    const error = generateErrors(1).map((err, i) => {
+      let model = errorLogging.createErrorDataModel(err)
+      model.id = 'error-id-' + i
+      return model
+    })[0]
+    const compressed = compressError(error)
+
+    testMappedObject(error, compressed)
+  })
+})

--- a/packages/rum-core/test/common/compress.spec.js
+++ b/packages/rum-core/test/common/compress.spec.js
@@ -23,7 +23,7 @@
  *
  */
 
-import { createServiceFactory, generateTransaction, generateErrors } from '../'
+import { createServiceFactory, generateTransaction, generateErrors } from '..'
 import {
   compressTransaction,
   compressMetadata,
@@ -123,7 +123,7 @@ const V3_MAPPING = {
   start: 's',
   started: 'sd',
   status_code: 'sc',
-  subType: 'su',
+  subtype: 'su',
   sync: 'sy',
   tags: 'g',
   timeToFirstByte: 'fb',

--- a/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
+++ b/packages/rum-core/test/performance-monitoring/perf-entry-recorder.spec.js
@@ -69,7 +69,7 @@ describe('PerfEntryRecorder', () => {
     })
 
     expect(paintTrue).toEqual({
-      largestContentfulPaint: 1040.0399999925867
+      largestContentfulPaint: 1040
     })
   })
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -189,8 +189,8 @@ describe('PerformanceMonitoring', function() {
     expect(payload.spans.length).toBe(1)
     expect(payload.spans[0].name).toBe('span1')
     expect(payload.spans[0].type).toBe('span1type')
-    expect(payload.spans[0].start).toBe(span._start - tr._start)
-    expect(payload.spans[0].duration).toBe(span._end - span._start)
+    expect(payload.spans[0].start).toBe(parseInt(span._start - tr._start))
+    expect(payload.spans[0].duration).toBe(parseInt(span._end - span._start))
   })
 
   it('should sendPageLoadMetrics', function(done) {
@@ -224,7 +224,10 @@ describe('PerformanceMonitoring', function() {
   })
 
   it('should filter out empty transactions', function() {
-    var tr = new Transaction('test', 'test', { transactionSampleRate: 1 })
+    var tr = new Transaction('test', 'test', {
+      transactionSampleRate: 1,
+      startTime: 0
+    })
     var result = performanceMonitoring.filterTransaction(tr)
     expect(tr.spans.length).toBe(0)
     expect(tr.duration()).toBe(null)
@@ -237,11 +240,8 @@ describe('PerformanceMonitoring', function() {
     result = performanceMonitoring.filterTransaction(tr)
     expect(result).toBe(false)
 
-    tr.end()
-    if (tr._end && tr._end === tr._start) {
-      tr._end += 100
-    }
-    expect(tr.duration()).toBeGreaterThan(0)
+    tr.end(100)
+    expect(tr.duration()).toBe(100)
     result = performanceMonitoring.filterTransaction(tr)
     expect(result).toBe(true)
   })


### PR DESCRIPTION
+ fix #768 
+ Adds a new config option `compressPayload` which is set to false by default and when enabled will use the new v3 spec for reporting the events. 
+ Compression is done after the payload to make sure we don't break the existing version and also let the user supplied filters work as expected
 + floats are converted to integers and this would be applied for all the previous apm server versions as well and would be applied even if the flag is set to false. Server schema is a JSON number so this validation is intact. 

### Test Scenario

No of Spans 
+ 50 JS files
+ 3 Custom spans (Parsing document, DOM interactive etc)
+ Metricsets/Breakdown - 4 for page-load


| Name of the test               | Payload Size (approx bytes) |
| :------------------------ | :-------------------------: |
| Current Release                |            31750            |
| After this PR                      |            17057            |


**Note: The flag would be removed and set to true by default from verison 6.x**