### PR TITLE
chore(dev): watch files when running karma dev

### DIFF
--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -68,7 +68,7 @@ const baseConfig = {
     'karma-sourcemap-loader'
   ],
   client: {
-    // clearContext: false, // make Jasmine Spec Runner output visible in browsers
+    clearContext: false,
     jasmine: {
       random: false,
       failFast: true,


### PR DESCRIPTION
+ Without this flag set to false, watch mode does not work correctly. 