### PR TITLE
fix(rum-core): treat truncated spans as actual in breakdown

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -140,18 +140,23 @@ const ERRORS = 'errors'
 const TRANSACTIONS = 'transactions'
 
 /**
- * Default configs used on top of extensible configs from ConfigService
- */
-const KEYWORD_LIMIT = 1024
-const SERVER_URL_PREFIX = '/intake/v2/rum/events'
-
-/**
  * Services
  */
 
 const CONFIG_SERVICE = 'ConfigService'
 const LOGGING_SERVICE = 'LoggingService'
 const APM_SERVER = 'ApmServer'
+
+/**
+ * Truncated spans are associated with this type information
+ */
+const TRUNCATED_TYPE = '.truncated'
+
+/**
+ * Default configs used on top of extensible configs from ConfigService
+ */
+const KEYWORD_LIMIT = 1024
+const SERVER_URL_PREFIX = '/intake/v2/rum/events'
 
 export {
   SCHEDULE,
@@ -196,5 +201,6 @@ export {
   TRANSACTIONS,
   CONFIG_SERVICE,
   LOGGING_SERVICE,
-  APM_SERVER
+  APM_SERVER,
+  TRUNCATED_TYPE
 }

--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -116,7 +116,7 @@ function groupSpans(transaction) {
     /**
      * Ignore calculating truncated spans as separate types in breakdown
      */
-    let key = type.replace(`${TRUNCATED_TYPE}`, '')
+    let key = type.replace(TRUNCATED_TYPE, '')
     if (subtype) {
       key += '.' + subtype
     }

--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -24,7 +24,7 @@
  */
 
 import { getDuration, PERF } from '../common/utils'
-import { PAGE_LOAD } from '../common/constants'
+import { PAGE_LOAD, TRUNCATED_TYPE } from '../common/constants'
 
 /**
  * Page load transaction breakdown timings
@@ -113,7 +113,10 @@ function groupSpans(transaction) {
       continue
     }
     const { type, subtype } = span
-    let key = type
+    /**
+     * Ignore calculating truncated spans as separate types in breakdown
+     */
+    let key = type.replace(`${TRUNCATED_TYPE}`, '')
     if (subtype) {
       key += '.' + subtype
     }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -41,7 +41,8 @@ import {
   TRANSACTION_TYPE_ORDER,
   LARGEST_CONTENTFUL_PAINT,
   LONG_TASK,
-  PAINT
+  PAINT,
+  TRUNCATED_TYPE
 } from '../common/constants'
 import { addTransactionContext } from '../common/context'
 import { __DEV__ } from '../env'
@@ -342,7 +343,7 @@ class TransactionService {
       const span = spans[i]
       if (span._end > transactionEnd) {
         span._end = transactionEnd
-        span.type += '.truncated'
+        span.type += TRUNCATED_TYPE
       }
       if (span._start > transactionEnd) {
         span._start = transactionEnd

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -33,7 +33,7 @@ import {
   extend,
   removeInvalidChars
 } from '../common/utils'
-import { REUSABILITY_THRESHOLD } from '../common/constants'
+import { REUSABILITY_THRESHOLD, TRUNCATED_TYPE } from '../common/constants'
 import { captureBreakdown } from './breakdown'
 
 class Transaction extends SpanBase {
@@ -128,7 +128,7 @@ class Transaction extends SpanBase {
     // truncate active spans
     for (let sid in this._activeSpans) {
       const span = this._activeSpans[sid]
-      span.type = span.type + '.truncated'
+      span.type = span.type + TRUNCATED_TYPE
       span.end(endTime)
     }
     this.callOnEnd()

--- a/packages/rum-core/test/performance-monitoring/breakdown.spec.js
+++ b/packages/rum-core/test/performance-monitoring/breakdown.spec.js
@@ -306,9 +306,32 @@ describe('Breakdown metrics', () => {
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 20 }
     })
-    expect(breakdown['ext.truncated']).toEqual({
+    expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 10 }
+    })
+  })
+
+  it('transaction with similar active and truncated span', () => {
+    const tr = createTransaction('custom')
+    const sp1 = tr.startSpan('foo', 'ext.http', { startTime: 10 })
+    const sp2 = tr.startSpan('foo', 'ext.http', { startTime: 15 })
+    sp2.end(20)
+    tr.end(30)
+    sp1.end(35)
+    const breakdown = getBreakdownObj(captureBreakdown(tr))
+    expect(breakdown.transaction).toEqual({
+      'transaction.duration.count': { value: 1 },
+      'transaction.duration.sum.us': { value: 30 },
+      'transaction.breakdown.count': { value: 1 }
+    })
+    expect(breakdown.app).toEqual({
+      'span.self_time.count': { value: 1 },
+      'span.self_time.sum.us': { value: 10 }
+    })
+    expect(breakdown['ext.http']).toEqual({
+      'span.self_time.count': { value: 2 },
+      'span.self_time.sum.us': { value: 25 }
     })
   })
 

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -35,7 +35,8 @@ import {
   ROUTE_CHANGE,
   LONG_TASK,
   LARGEST_CONTENTFUL_PAINT,
-  PAINT
+  PAINT,
+  TRUNCATED_TYPE
 } from '../../src/common/constants'
 
 describe('TransactionService', function() {
@@ -513,7 +514,7 @@ describe('TransactionService', function() {
     transactionService.adjustTransactionTime(transaction)
     expect(transaction.spans.length).toBe(1)
     expect(Object.keys(transaction._activeSpans).length).toBe(0)
-    expect(span.type).toContain('.truncated')
+    expect(span.type).toContain(TRUNCATED_TYPE)
   })
 
   it('should account for spans start > transaction start during breakdown', done => {


### PR DESCRIPTION
+ fix #776 
+ Truncated spans are merged with the regular spans if it exists or they are treated as actual spans. 