### PR TITLE
chore(dev): fix span duration in tests

### DIFF
--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -320,7 +320,8 @@ describe('ApmServer', function() {
     const tr = new Transaction('test-meta-tr', 'test-type', {
       startTime: 10
     })
-    tr.startSpan('test-meta-span', 'test-type')
+    const sp = tr.startSpan('test-meta-span', 'test-type', { startTime: 0 })
+    sp.end(50)
     tr.end(100)
     const payload = performanceMonitoring.createTransactionDataModel(tr)
     await apmServer.sendEvents([


### PR DESCRIPTION
+ Our unit tests for the latest server snapshot started breaking because of the new changes in Server which disallows spans with negative duration https://github.com/elastic/apm-server/pull/3721. This PR fixes the span with correct duration. 