### PR TITLE
feat(rum-core): capture total blocking time for navigation

### DIFF
--- a/packages/rum-core/src/common/metrics.js
+++ b/packages/rum-core/src/common/metrics.js
@@ -1,0 +1,29 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+export const metrics = {
+  fcp: 0,
+  lcp: 0
+}

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -126,6 +126,11 @@ export function calculateTotalBlockingTime(longtaskEntries) {
     totalBlockingTime.start = Math.min(totalBlockingTime.start, startTime)
 
     const blockingTime = duration - threshold
+    /**
+     * Theoretically blocking time would always be greater than 0 as Long tasks are
+     * tasks that exceeds 50ms, but this would be configurable in the future so
+     * the > 0 check acts as an extra guard
+     */
     if (blockingTime > 0) {
       totalBlockingTime.duration += blockingTime
     }

--- a/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
+++ b/packages/rum-core/src/performance-monitoring/perf-entry-recorder.js
@@ -29,6 +29,7 @@ import {
   FIRST_CONTENTFUL_PAINT
 } from '../common/constants'
 import { noop, PERF } from '../common/utils'
+import { metrics } from '../common/metrics'
 import Span from './span'
 
 /**
@@ -46,8 +47,7 @@ function createLongTaskSpans(longtasks) {
      */
     const { name, startTime, duration, attribution } = longtasks[i]
     const end = startTime + duration
-    const kind = LONG_TASK
-    const span = new Span(`Longtask(${name})`, kind, { startTime })
+    const span = new Span(`Longtask(${name})`, LONG_TASK, { startTime })
 
     /**
      * use attribution data to figure out the culprits of the longtask
@@ -94,6 +94,46 @@ function createLongTaskSpans(longtasks) {
 }
 
 /**
+ * Calculate Total Blocking Time (TBT) from long tasks
+ */
+export function calculateTotalBlockingTime(longtaskEntries) {
+  const threshold = 50
+  const totalBlockingTime = {
+    start: Infinity,
+    duration: 0
+  }
+  for (let i = 0; i < longtaskEntries.length; i++) {
+    const { name, startTime, duration } = longtaskEntries[i]
+    /**
+     * FCP is picked as the lower bound because there is little risk of user input happening
+     * before FCP and it will not harm user experience.
+     */
+    if (startTime < metrics.fcp) {
+      continue
+    }
+    /**
+     * Account for long task originated only from the current browsing context
+     * or from the same origin.
+     * https://w3c.github.io/longtasks/#performancelongtasktiming
+     */
+    if (name !== 'self' && name.indexOf('same-origin') === -1) {
+      continue
+    }
+    /**
+     * Calcualte the start time of the first long task so we can add it
+     * as span start
+     */
+    totalBlockingTime.start = Math.min(totalBlockingTime.start, startTime)
+
+    const blockingTime = duration - threshold
+    if (blockingTime > 0) {
+      totalBlockingTime.duration += blockingTime
+    }
+  }
+  return totalBlockingTime
+}
+
+/**
  * Captures all the observed entries as Spans and Marks depending on the
  * observed entry types and returns in the format
  * {
@@ -132,8 +172,9 @@ export function captureObserverEntries(list, { capturePaint }) {
      * `renderTime` will not be available for Image element and for the element
      * that is loaded cross-origin without the `Timing-Allow-Origin` header.
      */
-    const lcp = lastLcpEntry.renderTime || lastLcpEntry.loadTimes
-    result.marks.largestContentfulPaint = parseInt(lcp)
+    const lcp = parseInt(lastLcpEntry.renderTime || lastLcpEntry.loadTime)
+    metrics.lcp = lcp
+    result.marks.largestContentfulPaint = lcp
   }
 
   /**
@@ -149,9 +190,24 @@ export function captureObserverEntries(list, { capturePaint }) {
   const unloadDiff = timing.fetchStart - timing.navigationStart
   const fcpEntry = list.getEntriesByName(FIRST_CONTENTFUL_PAINT)[0]
   if (fcpEntry) {
-    const fcp =
+    const fcp = parseInt(
       unloadDiff >= 0 ? fcpEntry.startTime - unloadDiff : fcpEntry.startTime
-    result.marks.firstContentfulPaint = parseInt(fcp)
+    )
+    metrics.fcp = fcp
+    result.marks.firstContentfulPaint = fcp
+  }
+
+  /**
+   * Capture TBT as Span only for page load navigation
+   */
+  const { duration, start } = calculateTotalBlockingTime(longtaskEntries)
+
+  if (duration > 0) {
+    const tbtSpan = new Span('Total Blocking Time', LONG_TASK, {
+      startTime: start
+    })
+    tbtSpan.end(start + duration)
+    result.spans.push(tbtSpan)
   }
 
   return result


### PR DESCRIPTION
+ fix #781 
+ Captures Total blocking time only for page-load navigations from long tasks.
+ Long tasks from only from same frame and same origins are added to the TBT as tasks from chrome extensions or plugins might end up influencing the TBT time and its not under the website owners/developer control. This is an extra precaution and we can also account for only `self` in future if child frames from ADS are also influencing this score. 