### PR TITLE
fix(rum): allow setting labels before initializing

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -64,8 +64,7 @@ function getDataAttributesFromNode(node) {
 
 class Config {
   constructor() {
-    this.config = {}
-    this.defaults = {
+    this.config = {
       serviceName: '',
       serviceVersion: '',
       environment: '',
@@ -180,7 +179,7 @@ class Config {
       properties.serverUrl = properties.serverUrl.replace(/\/+$/, '')
     }
 
-    this.config = merge({}, this.defaults, this.config, properties)
+    this.config = merge({}, this.config, properties)
     this.events.send(CONFIG_CHANGE, [this.config])
   }
 

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -179,7 +179,7 @@ class Config {
       properties.serverUrl = properties.serverUrl.replace(/\/+$/, '')
     }
 
-    this.config = merge({}, this.config, properties)
+    merge(this.config, properties)
     this.events.send(CONFIG_CHANGE, [this.config])
   }
 

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -30,7 +30,6 @@ describe('ConfigService', function() {
   var configService
   beforeEach(function() {
     configService = new ConfigService()
-    configService.init()
   })
   it('should merge configs with already set configs', function() {
     expect(configService.get('instrument')).toBe(true)

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -57,7 +57,6 @@ describe('TransactionService', function() {
     spyOn(logger, 'debug')
 
     config = new Config()
-    config.init()
     transactionService = new TransactionService(logger, config)
   })
 
@@ -662,7 +661,6 @@ describe('TransactionService', function() {
   describe('performance entry recorder', () => {
     const logger = new LoggingService()
     const config = new Config()
-    config.init()
     const trService = new TransactionService(logger, config)
     const startSpy = jasmine.createSpy()
     const stopSpy = jasmine.createSpy()

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -308,6 +308,21 @@ describe('ApmBase', function() {
     expect(tr.spans[0].name).toBe('GET /')
   })
 
+  it('should allow setting labels before calling init', () => {
+    const labels = {
+      foo: '1',
+      bar: 2
+    }
+    apmBase.addLabels(labels)
+    apmBase.init({
+      serviceName,
+      serverUrl,
+      disableInstrumentations: [PAGE_LOAD]
+    })
+    const configService = serviceFactory.getService('ConfigService')
+    expect(configService.get('context.tags')).toEqual(labels)
+  })
+
   it('should fetch central config', done => {
     const apmServer = serviceFactory.getService('ApmServer')
     const configService = serviceFactory.getService('ConfigService')


### PR DESCRIPTION
+ fix #780 
+ User configs would be merged with the actual config instead of having `defaults`. 
+ Added a test case and removed the `config.init` from places where unnecessary. 