### PR TITLE
fix(rum): use single instance of apm across all packages

### DIFF
--- a/packages/rum-core/src/bootstrap.js
+++ b/packages/rum-core/src/bootstrap.js
@@ -23,9 +23,9 @@
  *
  */
 
-import { isPlatformSupported, isBrowser } from './utils'
-import { patchAll } from './patching'
-import { bootstrapMetrics } from '../performance-monitoring/metrics'
+import { isPlatformSupported, isBrowser } from './common/utils'
+import { patchAll } from './common/patching'
+import { bootstrapMetrics } from './performance-monitoring/metrics'
 
 let enabled = false
 export function bootstrap() {

--- a/packages/rum-core/src/common/bootstrap.js
+++ b/packages/rum-core/src/common/bootstrap.js
@@ -23,24 +23,17 @@
  *
  */
 
-import { isPlatformSupported } from './common/utils'
-import { patchAll } from './common/patching'
-import { bootstrapMetrics } from './performance-monitoring/metrics'
+import { isPlatformSupported, isBrowser } from './utils'
+import { patchAll } from './patching'
+import { bootstrapMetrics } from '../performance-monitoring/metrics'
 
-let alreadyBootstrap = false
 let enabled = false
-
 export function bootstrap() {
-  if (alreadyBootstrap) {
-    return enabled
-  }
-  alreadyBootstrap = true
-
   if (isPlatformSupported()) {
     patchAll()
     bootstrapMetrics()
     enabled = true
-  } else if (typeof window !== 'undefined') {
+  } else if (isBrowser) {
     /**
      * Print this error message only on the browser console
      * on unsupported browser versions

--- a/packages/rum-core/src/common/polyfills.js
+++ b/packages/rum-core/src/common/polyfills.js
@@ -24,13 +24,14 @@
  */
 
 import PromisePollyfill from 'promise-polyfill'
+import { isBrowser } from './utils'
 
 /**
  * Use the globally available promise if it exists and
  * fallback to using the polyfilled Promise
  */
 let local = {}
-if (typeof window !== 'undefined') {
+if (isBrowser) {
   local = window
 } else if (typeof self !== 'undefined') {
   local = self

--- a/packages/rum-core/src/common/url.js
+++ b/packages/rum-core/src/common/url.js
@@ -45,6 +45,8 @@
  *
  */
 
+import { isBrowser } from './utils'
+
 /**
  * Add default ports for other protocols(ws, wss) after
  * RUM agent starts instrumenting those
@@ -197,7 +199,7 @@ class Url {
 
   getLocation() {
     var globalVar = {}
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       globalVar = window
     }
 

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -26,10 +26,8 @@
 import { Promise } from './polyfills'
 
 const slice = [].slice
-const PERF =
-  typeof window !== 'undefined' && typeof performance !== 'undefined'
-    ? performance
-    : {}
+const isBrowser = typeof window !== 'undefined'
+const PERF = isBrowser && typeof performance !== 'undefined' ? performance : {}
 
 function isCORSSupported() {
   var xhr = new window.XMLHttpRequest()
@@ -135,7 +133,7 @@ function checkSameOrigin(source, target) {
 
 function isPlatformSupported() {
   return (
-    typeof window !== 'undefined' &&
+    isBrowser &&
     typeof Array.prototype.forEach === 'function' &&
     typeof JSON.stringify === 'function' &&
     typeof Function.bind === 'function' &&
@@ -390,5 +388,6 @@ export {
   find,
   removeInvalidChars,
   PERF,
-  isPerfTimelineSupported
+  isPerfTimelineSupported,
+  isBrowser
 }

--- a/packages/rum-core/src/index.js
+++ b/packages/rum-core/src/index.js
@@ -31,7 +31,8 @@ import { ServiceFactory } from './common/service-factory'
 import {
   isPlatformSupported,
   scheduleMicroTask,
-  scheduleMacroTask
+  scheduleMacroTask,
+  isBrowser
 } from './common/utils'
 import { patchAll, patchEventHandler } from './common/patching'
 import {
@@ -43,8 +44,8 @@ import {
 } from './common/constants'
 import { getInstrumentationFlags } from './common/instrument'
 import afterFrame from './common/after-frame'
+import { bootstrap } from './common/bootstrap'
 import { createTracer } from './opentracing'
-import { bootstrap } from './bootstrap'
 
 function createServiceFactory() {
   registerPerfServices()
@@ -59,6 +60,7 @@ export {
   patchAll,
   patchEventHandler,
   isPlatformSupported,
+  isBrowser,
   getInstrumentationFlags,
   createTracer,
   scheduleMicroTask,

--- a/packages/rum-core/src/index.js
+++ b/packages/rum-core/src/index.js
@@ -44,7 +44,7 @@ import {
 } from './common/constants'
 import { getInstrumentationFlags } from './common/instrument'
 import afterFrame from './common/after-frame'
-import { bootstrap } from './common/bootstrap'
+import { bootstrap } from './bootstrap'
 import { createTracer } from './opentracing'
 
 function createServiceFactory() {

--- a/packages/rum-core/test/bootstrap.spec.js
+++ b/packages/rum-core/test/bootstrap.spec.js
@@ -23,7 +23,7 @@
  *
  */
 
-import { bootstrap } from '../../src/common/bootstrap'
+import { bootstrap } from '../src/bootstrap'
 
 describe('bootstrap', function() {
   it('should log warning on unsupported environments', () => {

--- a/packages/rum-core/test/common/bootstrap.spec.js
+++ b/packages/rum-core/test/common/bootstrap.spec.js
@@ -23,35 +23,20 @@
  *
  */
 
-import {
-  createServiceFactory,
-  bootstrap,
-  isBrowser
-} from '@elastic/apm-rum-core'
-import ApmBase from './apm-base'
+import { bootstrap } from '../../src/common/bootstrap'
 
-/**
- * Use a single instance of ApmBase across all instance of the agent
- * including the instanes used in framework specific integrations
- */
-function getApmBase() {
-  if (isBrowser && window.elasticApm) {
-    return window.elasticApm
-  }
-  const enabled = bootstrap()
-  const serviceFactory = createServiceFactory()
-  const apmBase = new ApmBase(serviceFactory, !enabled)
+describe('bootstrap', function() {
+  it('should log warning on unsupported environments', () => {
+    // Pass unsupported check
+    const nowFn = window.performance.now
+    window.performance.now = undefined
 
-  if (isBrowser) {
-    window.elasticApm = apmBase
-  }
+    spyOn(console, 'log')
+    bootstrap()
 
-  return apmBase
-}
-
-const apmBase = getApmBase()
-
-const init = apmBase.init.bind(apmBase)
-
-export default init
-export { init, apmBase, ApmBase, apmBase as apm }
+    expect(console.log).toHaveBeenCalledWith(
+      '[Elastic APM] platform is not supported!'
+    )
+    window.performance.now = nowFn
+  })
+})

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -32,7 +32,7 @@ import {
   APM_SERVER
 } from '@elastic/apm-rum-core'
 
-class ApmBase {
+export default class ApmBase {
   constructor(serviceFactory, disable) {
     this._disable = disable
     this.serviceFactory = serviceFactory
@@ -277,5 +277,3 @@ class ApmBase {
     configService.addFilter(fn)
   }
 }
-
-export default ApmBase

--- a/packages/rum/test/specs/index.spec.js
+++ b/packages/rum/test/specs/index.spec.js
@@ -46,22 +46,6 @@ describe('index', function() {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
   })
 
-  it('should log only on browser environments', () => {
-    // Pass unsupported check
-    const nowFn = window.performance.now
-    window.performance.now = undefined
-
-    spyOn(console, 'log')
-
-    require('../../src/')
-
-    expect(console.log).toHaveBeenCalledWith(
-      '[Elastic APM] platform is not supported!'
-    )
-
-    window.performance.now = nowFn
-  })
-
   it('should init ApmBase', function(done) {
     var apmServer = apmBase.serviceFactory.getService('ApmServer')
     if (globalConfig.useMocks) {

--- a/packages/rum/test/specs/index.spec.js
+++ b/packages/rum/test/specs/index.spec.js
@@ -104,6 +104,13 @@ describe('index', function() {
     }
   })
 
+  it('should return same instance when loaded multiple times', () => {
+    require('../../src/')
+    expect(window.elasticApm).toEqual(apmBase)
+    const exportsObj = require('../../src/')
+    expect(exportsObj.apmBase).toEqual(window.elasticApm)
+  })
+
   it('should not throw error on global Promise patching', () => {
     window.count = 0
     window.Promise = {


### PR DESCRIPTION
+ fixes #791 
+ Ensures the following when the agent script is loaded twice or agent script is used along with other framework integrations
  -  `apm` instance is singleton 
  - does not patch the `window.elasticApm` multiple times
  - does not patch XHR, Fetch, History multiple times. 