### PR TITLE
fix(rum-core): consider user defined type of high precedence

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -143,29 +143,20 @@ class TransactionService {
       const currentTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(tr.type)
       const redefineTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(type)
 
-      if (currentTypeOrder >= 0) {
-        /**
-         * If the redefined type is not present in the predefined order, that implies
-         * it's a user defined type and it is of higher precedence
-         */
-        if (redefineTypeOrder === -1) {
-          redefineType = type
-        } else if (
-          /**
-           * Update type based on precedence defined in TRANSACTION_TYPE_ORDER.
-           * If either orders don't exist we also don't redefine the type.
-           */
-          redefineTypeOrder >= 0 &&
-          redefineTypeOrder < currentTypeOrder
-        ) {
-          redefineType = type
-        }
+      /**
+       * Update type based on precedence defined in TRANSACTION_TYPE_ORDER.
+       * 1. If both orders doesn't exist, we don't redefine the type.
+       * 2. If only the redefined type is not present in predefined order, that implies
+       * it's a user defined type and it is of higher precedence
+       */
+      if (currentTypeOrder >= 0 && redefineTypeOrder < currentTypeOrder) {
+        redefineType = type
       }
       if (__DEV__) {
         this._logger.debug(
           `redefining transaction(${tr.id}, ${tr.name}, ${tr.type})`,
           'to',
-          `(${name}, ${redefineType})`,
+          `(${name || tr.name}, ${redefineType})`,
           tr
         )
       }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -139,27 +139,35 @@ class TransactionService {
        * allow a redefinition until there's a call that doesn't have that
        * or the threshold is exceeded.
        */
+      let redefineType = tr.type
+      const currentTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(tr.type)
+      const redefineTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(type)
+
+      if (currentTypeOrder >= 0) {
+        /**
+         * If the redefined type is not present in the predefined order, that implies
+         * it's a user defined type and it is of higher precedence
+         */
+        if (redefineTypeOrder === -1) {
+          redefineType = type
+        } else if (
+          /**
+           * Update type based on precedence defined in TRANSACTION_TYPE_ORDER.
+           * If either orders don't exist we also don't redefine the type.
+           */
+          redefineTypeOrder >= 0 &&
+          redefineTypeOrder < currentTypeOrder
+        ) {
+          redefineType = type
+        }
+      }
       if (__DEV__) {
         this._logger.debug(
           `redefining transaction(${tr.id}, ${tr.name}, ${tr.type})`,
           'to',
-          `(${name}, ${type})`,
+          `(${name}, ${redefineType})`,
           tr
         )
-      }
-      /**
-       * We only update based precedence defined in TRANSACTION_TYPE_ORDER.
-       * If either orders don't exist we also don't redefine the type.
-       */
-      let redefineType
-      let currentTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(tr.type)
-      let redefineTypeOrder = TRANSACTION_TYPE_ORDER.indexOf(type)
-      if (
-        currentTypeOrder !== -1 &&
-        redefineTypeOrder !== -1 &&
-        redefineTypeOrder < currentTypeOrder
-      ) {
-        redefineType = type
       }
       tr.redefine(name, redefineType, perfOptions)
       isRedefined = true

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -84,7 +84,7 @@ class Transaction extends SpanBase {
     }
 
     if (options) {
-      this.options = extend(this.options, options)
+      extend(this.options, options)
     }
   }
 

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -621,14 +621,6 @@ describe('TransactionService', function() {
     let tr = transactionService.getCurrentTransaction()
     expect(tr.type).toBe('temporary')
 
-    transactionService.startTransaction('test 1', 'random-type', {
-      managed: true,
-      canReuse: true
-    })
-
-    tr = transactionService.getCurrentTransaction()
-    expect(tr.type).toBe('temporary')
-
     transactionService.startTransaction('test 1', 'route-change', {
       managed: true,
       canReuse: true
@@ -650,13 +642,24 @@ describe('TransactionService', function() {
       canReuse: true
     })
 
-    transactionService.startTransaction('test 1', 'random-type', {
+    tr = transactionService.getCurrentTransaction()
+    expect(tr.type).toBe('page-load')
+
+    transactionService.startTransaction('test 1', 'custom-type', {
       managed: true,
       canReuse: true
     })
 
     tr = transactionService.getCurrentTransaction()
-    expect(tr.type).toBe('page-load')
+    expect(tr.type).toBe('custom-type')
+
+    transactionService.startTransaction('test 1', 'page-load', {
+      managed: true,
+      canReuse: true
+    })
+
+    tr = transactionService.getCurrentTransaction()
+    expect(tr.type).toBe('custom-type')
   })
 
   describe('performance entry recorder', () => {

--- a/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
@@ -88,7 +88,7 @@ describe('General usecase with react-router', function() {
 
     const routeTransaction = transactions[1]
     expect(routeTransaction.name).toBe('ManualComponent')
-    expect(routeTransaction.type).toBe('route-change')
+    expect(routeTransaction.type).toBe('component')
 
     const spanTypes = ['app', 'resource', 'external']
     const foundSpans = routeTransaction.spans.filter(

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -171,7 +171,7 @@ describe('ApmBase', function() {
     })
     expect(tr).toBeDefined()
     expect(tr.name).toBe('test-transaction')
-    expect(tr.type).toBe('page-load')
+    expect(tr.type).toBe('test-type')
 
     spyOn(tr, 'startSpan').and.callThrough()
     apmBase.startSpan('test-span', 'test-type')


### PR DESCRIPTION
+ fix #758 
+ User defined type for managed transaction should be considered a high priority as it would let users to filter these transactions in the UI in a better way. This applies only to managed transaction and custom transactions is not touched in this PR. 
+ Also moved and improved the logging after the redefining as it gives false information as mentioned in the linked issue. 