### PR TITLE
fix(rum-core): capture tbt after all task entries are observed

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -288,7 +288,7 @@ class TransactionService {
            * and once performance observer is disconnected
            */
           if (tr.captureTimings && metrics.tbt.duration > 0) {
-            tr.push(createTotalBlockingTimeSpan(metrics.tbt))
+            tr.spans.push(createTotalBlockingTimeSpan(metrics.tbt))
           }
         }
         captureNavigation(tr)

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -25,7 +25,12 @@
 
 import { Promise } from '../common/polyfills'
 import Transaction from './transaction'
-import { PerfEntryRecorder, captureObserverEntries } from './metrics'
+import {
+  PerfEntryRecorder,
+  captureObserverEntries,
+  metrics,
+  createTotalBlockingTimeSpan
+} from './metrics'
 import { extend, getEarliestSpan, getLatestNonXHRSpan } from '../common/utils'
 import { captureNavigation } from './capture-navigation'
 import {
@@ -277,6 +282,13 @@ class TransactionService {
           )
           if (name === NAME_UNKNOWN && pageLoadTransactionName) {
             tr.name = pageLoadTransactionName
+          }
+          /**
+           * Capture the TBT as span after observing for all long task entries
+           * and once performance observer is disconnected
+           */
+          if (tr.captureTimings && metrics.tbt.duration > 0) {
+            tr.push(createTotalBlockingTimeSpan(metrics.tbt))
           }
         }
         captureNavigation(tr)

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -176,6 +176,26 @@ describe('Metrics', () => {
         })
       })
 
+      it('should update tbt when longtasks are dispatched at different times', () => {
+        list.getEntriesByType.and.callFake(mockObserverEntryTypes)
+        captureObserverEntries(list, {
+          capturePaint: true
+        })
+        expect(metrics.tbt).toEqual({
+          start: 745.4100000031758,
+          duration: 249.92999995592982
+        })
+
+        // simulating second longtask entry list
+        captureObserverEntries(list, {
+          capturePaint: true
+        })
+        expect(metrics.tbt).toEqual({
+          start: 745.4100000031758,
+          duration: 499.85999991185963
+        })
+      })
+
       it('should calculate total blocking time based on FCP', () => {
         metrics.fcp = 1000
         calculateTotalBlockingTime(longtaskEntries)

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -26,6 +26,7 @@ import {
   captureObserverEntries,
   calculateTotalBlockingTime,
   createFirstInputDelaySpan,
+  createTotalBlockingTimeSpan,
   PerfEntryRecorder,
   metrics
 } from '../../src/performance-monitoring/metrics'
@@ -46,6 +47,7 @@ describe('Metrics', () => {
     beforeEach(() => {
       list.getEntriesByType.and.returnValue([])
       list.getEntriesByName.and.returnValue([])
+      metrics.tbt = { start: Infinity, duration: 0 }
     })
 
     it('should not create long tasks spans if entries are not present', () => {
@@ -154,24 +156,21 @@ describe('Metrics', () => {
 
     describe('Total Blocking Time', () => {
       it('should create total blocking time as span', () => {
-        list.getEntriesByType.and.callFake(mockObserverEntryTypes)
-        const { spans } = captureObserverEntries(list, {
-          capturePaint: true
-        })
-        const tbtSpans = spans.filter(
-          span => span.name === 'Total Blocking Time'
-        )
-        expect(tbtSpans[0]).toEqual(
+        calculateTotalBlockingTime(longtaskEntries)
+        const tbtSpan = createTotalBlockingTimeSpan(metrics.tbt)
+        expect(tbtSpan).toEqual(
           jasmine.objectContaining({
             name: 'Total Blocking Time',
-            type: LONG_TASK
+            type: LONG_TASK,
+            _start: 745.4100000031758,
+            _end: 995.3399999591056
           })
         )
       })
 
       it('should calculate total blocking time from long tasks', () => {
-        const tbt = calculateTotalBlockingTime(longtaskEntries)
-        expect(tbt).toEqual({
+        calculateTotalBlockingTime(longtaskEntries)
+        expect(metrics.tbt).toEqual({
           start: 745.4100000031758,
           duration: 249.92999995592982
         })
@@ -179,15 +178,15 @@ describe('Metrics', () => {
 
       it('should calculate total blocking time based on FCP', () => {
         metrics.fcp = 1000
-        const tbt = calculateTotalBlockingTime(longtaskEntries)
-        expect(tbt).toEqual({
+        calculateTotalBlockingTime(longtaskEntries)
+        expect(metrics.tbt).toEqual({
           start: 1023.40999995591,
           duration: 245.35999997751787
         })
       })
 
       it('should return tbt as 0 when entries are not self/same-origin', () => {
-        const tbt = calculateTotalBlockingTime([
+        calculateTotalBlockingTime([
           {
             name: 'unknown',
             startTime: 10
@@ -197,7 +196,7 @@ describe('Metrics', () => {
             startTime: 20
           }
         ])
-        expect(tbt).toEqual({
+        expect(metrics.tbt).toEqual({
           start: Infinity,
           duration: 0
         })


### PR DESCRIPTION
+ fix #802 
+ On very long task entry, we populate the `module level metrics` constant and update the duration and use it once the page load is done to capture the TBT as spans. 
+ We have to do something similar for `CLS` as well. 