### PR TITLE
fix: env var invalid type

### DIFF
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - "127.0.0.1:${APM_SERVER_PORT:-8200}:8200"
     environment:
-      BEAT_STRICT_PERMS: false
+      BEAT_STRICT_PERMS: "false"
     command: >
       apm-server -e
         -E apm-server.rum.enabled=true


### PR DESCRIPTION
Env vars cannot be boolean in docker-compose files

```
[2020-06-01T09:56:29.359Z] services.apm-server.environment.BEAT_STRICT_PERMS contains false, which is an invalid type, it should be a string, number, or a null
```