### PR TITLE
ci: use dockerLogs step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -389,16 +389,22 @@ def runScript(Map args = [:]){
         sleep randomNumber(min: 5, max: 10)
         sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
       }
-      // Another retry in case there are any environmental issues
-      retry(3) {
-        sleep randomNumber(min: 5, max: 10)
-        if(env.MODE == 'saucelabs'){
-          withSaucelabsEnv(){
+      try {
+        // Another retry in case there are any environmental issues
+        retry(3) {
+          sleep randomNumber(min: 5, max: 10)
+          if(env.MODE == 'saucelabs'){
+            withSaucelabsEnv(){
+              sh(label: "Start Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
+            }
+          } else {
             sh(label: "Start Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
           }
-        } else {
-          sh(label: "Start Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
         }
+      } catch(e) {
+        throw e
+      } finally {
+        dockerLogs(step: label, failNever: true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/docker-logs') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/docker-logs') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,7 +404,7 @@ def runScript(Map args = [:]){
       } catch(e) {
         throw e
       } finally {
-        dockerLogs(step: label, failNever: true)
+        dockerLogs(step: "${label}-${stack}", failNever: true)
       }
     }
   }


### PR DESCRIPTION
### What

It archives the docker container details for every stage that runs docker.


### How to use it

- Go to the `artifact/docker-info` folder
- Look for the stage that you'd like to go deeper with
- Open the file `docker-containers.txt`
- Look for the container ID
- `<id>.log` is the logs for the container with `id`
- `<id>-cmd.txt` is the docker container run parameters
- `<id>-inspect.json` is the output of the docker inspect <id> command


### Tests

![image](https://user-images.githubusercontent.com/2871786/83546338-66b1e280-a4f8-11ea-9dbf-e8460fe4edde.png)


![image](https://user-images.githubusercontent.com/2871786/83546396-7c270c80-a4f8-11ea-82ac-f935fcb6389d.png)

(BO view)

![image](https://user-images.githubusercontent.com/2871786/83547040-8a295d00-a4f9-11ea-9fd9-c028bddbd27b.png)


### Issues

Closes https://github.com/elastic/apm-agent-rum-js/issues/806
