### PR TITLE
ci: run benchmark on a PR basis if comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:benchmark\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -220,6 +220,7 @@ pipeline {
                 tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
                 expression { return env.BENCHMARK_UPDATED != "false" }
+                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
               }
               expression { return params.bench_ci }
               expression { return env.ONLY_DOCS == "false" }


### PR DESCRIPTION
## What does this pull request do?

Enable the benchmark stage on a PR basis if using the GH comment `jenkins run the benchmark tests please` or a more minimalistic comment with `jenkins run benchmark tests` or even with `run benchmark tests`

## Why is it important?

Help to run the benchmark on a PR basis using a GitHub comment can facilitate the CI interactions.