### PR TITLE
chore(rum-core): use startTime for LCP marks

### DIFF
--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -190,10 +190,11 @@ export function captureObserverEntries(list, { capturePaint }) {
 
   if (lastLcpEntry) {
     /**
+     * `startTime` -  equals to renderTime if it's nonzero, otherwise equal to loadTime.
      * `renderTime` will not be available for Image element and for the element
      * that is loaded cross-origin without the `Timing-Allow-Origin` header.
      */
-    const lcp = parseInt(lastLcpEntry.renderTime || lastLcpEntry.loadTime)
+    const lcp = parseInt(lastLcpEntry.startTime)
     metrics.lcp = lcp
     result.marks.largestContentfulPaint = lcp
   }


### PR DESCRIPTION
+ shorter to use `startTime` as it fallbacks automatically to `renderTime` if its available or `loadTime`. 
+ More details - https://wicg.github.io/element-timing/#sec-performance-element-timing. LCP is part of element timing. 