### PR TITLE
ci(jenkins): report bundlesize as a GitHub comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@feature/bundlesize-step-1') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    PIPELINE_LOG_LEVEL='INFO'
+    PIPELINE_LOG_LEVEL = 'DEBUG'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-rum-codecov'
     SAUCELABS_SECRET_CORE = 'secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum-core'
     SAUCELABS_SECRET = 'secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,6 +364,7 @@ pipeline {
   }
   post {
     cleanup {
+      // bundlesize id was generated previously, see the bundlesize function
       notifyBuildResult(prComment: true, newPRComment: [ 'bundlesize': 'bundlesize.md' ])
     }
   }
@@ -434,7 +435,7 @@ def bundlesize(){
       npm run bundlesize|tee bundlesize.txt
     ''')
   }
-  generateReport(id: 'bundlesize', template: true, compare: true)
+  generateReport(id: 'bundlesize', input: 'packages/rum/reports/apm-*-report.html', template: true, compare: true, templateFormat: 'md')
   catchError(buildResult: 'SUCCESS', message: 'Bundlesize report issues', stageResult: 'UNSTABLE') {
     sh(label: "Process Bundlesize out", script: '''#!/bin/bash
       grep -e "\\(FAIL\\|PASS\\)" bundlesize.txt|cut -d ":" -f 2 >bundlesize-lines.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/pr-comment-customise') _
+@Library('apm@master') _
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -448,12 +448,14 @@ def bundlesize(){
 > For more info visit https://webpack.js.org/guides/code-splitting/
 
 <details><summary>:information_source: <strong>View Stats</strong></summary>
-| Filename | Size |
-|:--- |:---:|:---:|
-| `elastic-apm-opentracing.umd.min.js` | 61515 B |
-| `elastic-apm-opentracing.umd.min.js.map` | 278318 B |
-| `elastic-apm-rum.umd.min.js` | 55470 B |
-| `elastic-apm-rum.umd.min.js.map` | 240426 B |
+
+Filename | Size
+ --- | ---
+`elastic-apm-opentracing.umd.min.js` | 61515 B
+`elastic-apm-opentracing.umd.min.js.map` | 278318 B
+`elastic-apm-rum.umd.min.js` | 55470 B
+`elastic-apm-rum.umd.min.js.map` | 240426 B
+
 </details>'''
   stash name: 'bundlesize.md', includes: 'bundlesize.md'
   catchError(buildResult: 'SUCCESS', message: 'Bundlesize report issues', stageResult: 'UNSTABLE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@master') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -437,15 +437,6 @@ def bundlesize(){
   // TODO: generate md for the given json files
   writeFile file: 'bundlesize.md', text: '''
 **Total Size:** 130221 B
-
-:warning:
-> asset size limit: The following asset(s) exceed the recommended size limit (60 KiB).
-> This can impact web performance.
-> Assets:
->   elastic-apm-opentracing.umd.min.js (60.1 KiB)
-> Webpack performance recommendations:
->   You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
-> For more info visit https://webpack.js.org/guides/code-splitting/
 
 <details><summary>:information_source: <strong>View Stats</strong></summary>
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/bundlesize-step-1') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }
@@ -9,7 +9,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    PIPELINE_LOG_LEVEL = 'DEBUG'
+    PIPELINE_LOG_LEVEL = 'INFO'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-rum-codecov'
     SAUCELABS_SECRET_CORE = 'secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum-core'
     SAUCELABS_SECRET = 'secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum'
@@ -368,7 +368,7 @@ pipeline {
   }
   post {
     cleanup {
-      // bundlesize id was generated previously, see the bundlesize function
+      // bundlesize id was generated previously with the generateReport step in the lint stage.
       notifyBuildResult(prComment: true, newPRComment: [ 'bundlesize': 'bundlesize.md' ])
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -433,8 +433,9 @@ def bundlesize(){
       set -o pipefail
       npm run bundlesize|tee bundlesize.txt
     ''')
-    // TODO: generate md for the given json files
-    writeFile file: 'bundlesize.md', text: '''
+  }
+  // TODO: generate md for the given json files
+  writeFile file: 'bundlesize.md', text: '''
 **Total Size:** 130221 B
 
 :warning:
@@ -454,8 +455,7 @@ def bundlesize(){
 | `elastic-apm-rum.umd.min.js` | 55470 B |
 | `elastic-apm-rum.umd.min.js.map` | 240426 B |
 </details>'''
-    stash name: 'bundlesize.md', includes: 'bundlesize.md'
-  }
+  stash name: 'bundlesize.md', includes: 'bundlesize.md'
   catchError(buildResult: 'SUCCESS', message: 'Bundlesize report issues', stageResult: 'UNSTABLE') {
     sh(label: "Process Bundlesize out", script: '''#!/bin/bash
       grep -e "\\(FAIL\\|PASS\\)" bundlesize.txt|cut -d ":" -f 2 >bundlesize-lines.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,8 @@ pipeline {
                     bundlesize()
                   }
                   stash allowEmpty: true, name: 'cache', includes: "${BASE_DIR}/.npm/**", useDefaultExcludes: false
+                  // To run in the worker otherwise some tools won't be in place when using the above docker container
+                  generateReport(id: 'bundlesize', input: 'packages/rum/reports/apm-*-report.html', template: true, compare: true, templateFormat: 'md')
                 }
               }
             }
@@ -435,7 +437,6 @@ def bundlesize(){
       npm run bundlesize|tee bundlesize.txt
     ''')
   }
-  generateReport(id: 'bundlesize', input: 'packages/rum/reports/apm-*-report.html', template: true, compare: true, templateFormat: 'md')
   catchError(buildResult: 'SUCCESS', message: 'Bundlesize report issues', stageResult: 'UNSTABLE') {
     sh(label: "Process Bundlesize out", script: '''#!/bin/bash
       grep -e "\\(FAIL\\|PASS\\)" bundlesize.txt|cut -d ":" -f 2 >bundlesize-lines.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,7 +364,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true, newPRComment: [ 'bundlesize.md': 'bundlesize.md' ])
+      notifyBuildResult(prComment: true, newPRComment: [ 'bundlesize': 'bundlesize.md' ])
     }
   }
 }
@@ -434,21 +434,7 @@ def bundlesize(){
       npm run bundlesize|tee bundlesize.txt
     ''')
   }
-  // TODO: generate md for the given json files
-  writeFile file: 'bundlesize.md', text: '''
-**Total Size:** 130221 B
-
-<details><summary>:information_source: <strong>View Stats</strong></summary>
-
-Filename | Size
- --- | ---
-`elastic-apm-opentracing.umd.min.js` | 61515 B
-`elastic-apm-opentracing.umd.min.js.map` | 278318 B
-`elastic-apm-rum.umd.min.js` | 55470 B
-`elastic-apm-rum.umd.min.js.map` | 240426 B
-
-</details>'''
-  stash name: 'bundlesize.md', includes: 'bundlesize.md'
+  generateReport(id: 'bundlesize', template: true, compare: true)
   catchError(buildResult: 'SUCCESS', message: 'Bundlesize report issues', stageResult: 'UNSTABLE') {
     sh(label: "Process Bundlesize out", script: '''#!/bin/bash
       grep -e "\\(FAIL\\|PASS\\)" bundlesize.txt|cut -d ":" -f 2 >bundlesize-lines.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,8 @@ pipeline {
                     bundlesize()
                   }
                   stash allowEmpty: true, name: 'cache', includes: "${BASE_DIR}/.npm/**", useDefaultExcludes: false
+                }
+                dir("${BASE_DIR}"){
                   // To run in the worker otherwise some tools won't be in place when using the above docker container
                   generateReport(id: 'bundlesize', input: 'packages/rum/reports/apm-*-report.html', template: true, compare: true, templateFormat: 'md')
                 }


### PR DESCRIPTION
Create markdown file on the fly and populate the content as a GitHub comment. See https://github.com/elastic/apm-agent-rum-js/pull/826#issuecomment-650255846

## Issues

Closes https://github.com/elastic/apm-agent-rum-js/issues/667