### PR TITLE
feat(rum-core): populate destination info for NT spans

### DIFF
--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -31,6 +31,7 @@ const LEFT_SQUARE_BRACKET = 91 // [
 const RIGHT_SQUARE_BRACKET = 93 // ]
 const EXTERNAL = 'external'
 const RESOURCE = 'resource'
+const HARD_NAVIGATION = 'hard-navigation'
 
 /**
  * Get the port number including the default ports
@@ -141,11 +142,19 @@ function getExternalContext(data) {
   return context
 }
 
+function getNavigationContext(data) {
+  const { url } = data
+  const parsedUrl = new Url(url)
+
+  const destination = getDestination(parsedUrl, HARD_NAVIGATION)
+  return { destination }
+}
+
 export function getPageContext() {
   return {
     page: {
       referer: document.referrer,
-      url: window.location.href
+      url: location.href
     }
   }
 }
@@ -162,6 +171,9 @@ export function addSpanContext(span, data) {
       break
     case RESOURCE:
       context = getResourceContext(data)
+      break
+    case HARD_NAVIGATION:
+      context = getNavigationContext(data)
       break
   }
   span.addContext(context)

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -96,11 +96,20 @@ function createNavigationTimingSpans(timings, baseTime, trStart, trEnd) {
       continue
     }
     const span = new Span(eventPairs[i][2], 'hard-navigation.browser-timing')
+    let data = null
+    /**
+     * - pageResponse flag is used to set the id of the span to
+     *  `pageLoadSpanId` if set in config to make the distributed tracing work
+     *   when HTML is genrated dynamically from backend agents
+     *
+     * - Populate the context.destination fields only for the Request Span
+     */
     if (eventPairs[i][0] === 'requestStart') {
       span.pageResponse = true
+      data = { url: location.origin }
     }
     span._start = start - baseTime
-    span.end(end - baseTime)
+    span.end(end - baseTime, data)
     spans.push(span)
   }
   return spans

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -165,6 +165,25 @@ describe('Context', () => {
     })
   })
 
+  it('should add navigation timing span context', () => {
+    const url = 'https://example.com'
+    const span = new Span(url, 'hard-navigation')
+    span.end()
+    addSpanContext(span, { url })
+
+    expect(span.context).toEqual({
+      destination: {
+        service: {
+          name: 'https://example.com',
+          resource: 'example.com:443',
+          type: 'hard-navigation'
+        },
+        address: 'example.com',
+        port: 443
+      }
+    })
+  })
+
   it('should enrich transaction with context info based on type', () => {
     const transaction = new Transaction('test', 'custom')
     const trContext = { tags: { tag1: 'tag1' } }

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -151,6 +151,40 @@ describe('Capture hard navigation', function() {
     ])
   })
 
+  it('should populate desination context only for requestStart span', () => {
+    const spans = createNavigationTimingSpans(
+      timings,
+      timings.fetchStart,
+      transactionStart,
+      transactionEnd
+    )
+
+    expect(spans.map(({ name, context }) => ({ name, context }))).toEqual([
+      { name: 'Domain lookup', context: undefined },
+      { name: 'Making a connection to the server', context: undefined },
+      {
+        name: 'Requesting and receiving the document',
+        context: {
+          destination: {
+            service: {
+              name: 'http://localhost:9876',
+              resource: 'localhost:9876',
+              type: 'hard-navigation'
+            },
+            address: 'localhost',
+            port: 9876
+          }
+        }
+      },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        context: undefined
+      },
+      { name: 'Fire "DOMContentLoaded" event', context: undefined },
+      { name: 'Fire "load" event', context: undefined }
+    ])
+  })
+
   it('should createResourceTimingSpans', function() {
     const spans = createResourceTimingSpans(
       resourceEntries,


### PR DESCRIPTION
+ fix #829 
+ This PR populates the destination information for span that is responsible for Initial HTML generation which comes under page-load transaction. So an example service request page from `www.example.com` would have a service map linked to `www.example.com` since the HTML fro the service is provided from that origin. This is in addition to other static resources like `JS, CSS, Images etc`. This would solve for both static and dynamically generated HTML's. 