### PR TITLE
add apiVersion config option to typescript

### DIFF
--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -105,7 +105,7 @@ declare class Span extends BaseSpan {
 }
 
 interface AgentConfigOptions {
-  apiVersion?: 2|3
+  apiVersion?: 2 | 3
   serviceName?: string
   serverUrl?: string
   serviceVersion?: string

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -105,7 +105,7 @@ declare class Span extends BaseSpan {
 }
 
 interface AgentConfigOptions {
-  apiVersion?: number
+  apiVersion?: 2|3
   serviceName?: string
   serverUrl?: string
   serviceVersion?: string

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -105,6 +105,7 @@ declare class Span extends BaseSpan {
 }
 
 interface AgentConfigOptions {
+  apiVersion?: number
   serviceName?: string
   serverUrl?: string
   serviceVersion?: string


### PR DESCRIPTION
The apiVersion config option was added in 5.2.0 https://www.elastic.co/guide/en/apm/agent/rum-js/current/release-notes-5.x.html as part of this issue https://github.com/elastic/apm-agent-rum-js/issues/768.

However the option was not added to index.d.ts making it inaccessible when using typescript