### PR TITLE
feat: add CLS, FID and TBT to experience field

### DIFF
--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -210,7 +210,8 @@ export function compressTransaction(transaction) {
     yc: {
       sd: spans.length
     },
-    sm: transaction.sampled
+    sm: transaction.sampled,
+    exp: transaction.experience
   }
 }
 

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -128,6 +128,7 @@ const RESOURCE = 'resource'
 const FIRST_CONTENTFUL_PAINT = 'first-contentful-paint'
 const LARGEST_CONTENTFUL_PAINT = 'largest-contentful-paint'
 const FIRST_INPUT = 'first-input'
+const LAYOUT_SHIFT = 'layout-shift'
 
 /**
  * Event types sent to APM Server on the queue
@@ -195,5 +196,6 @@ export {
   LOGGING_SERVICE,
   APM_SERVER,
   TRUNCATED_TYPE,
-  FIRST_INPUT
+  FIRST_INPUT,
+  LAYOUT_SHIFT
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -355,6 +355,13 @@ function isPerfTimelineSupported() {
   return typeof PERF.getEntriesByType === 'function'
 }
 
+function isPerfTypeSupported(type) {
+  let po = PerformanceObserver
+  return (
+    po && po.supportedEntryTypes && po.supportedEntryTypes.indexOf(type) >= 0
+  )
+}
+
 export {
   extend,
   merge,
@@ -389,5 +396,6 @@ export {
   removeInvalidChars,
   PERF,
   isPerfTimelineSupported,
-  isBrowser
+  isBrowser,
+  isPerfTypeSupported
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -356,9 +356,10 @@ function isPerfTimelineSupported() {
 }
 
 function isPerfTypeSupported(type) {
-  let po = PerformanceObserver
   return (
-    po && po.supportedEntryTypes && po.supportedEntryTypes.indexOf(type) >= 0
+    typeof PerformanceObserver !== 'undefined' &&
+    PerformanceObserver.supportedEntryTypes &&
+    PerformanceObserver.supportedEntryTypes.indexOf(type) >= 0
   )
 }
 

--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -164,6 +164,12 @@ export function calculateTotalBlockingTime(longtaskEntries) {
   })
 }
 
+/**
+ * Calculates Cumulative Layout Shift using
+ * 'layout-shift' entries captured through PerformanceObserver.
+ * https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift
+ * https://web.dev/cls/
+ */
 export function calculateCumulativeLayoutShift(clsEntries) {
   clsEntries.forEach(entry => {
     if (!entry.hadRecentInput) {
@@ -243,6 +249,7 @@ export function captureObserverEntries(list, { capturePaint }) {
   const fidEntries = list.getEntriesByType(FIRST_INPUT)
   const fidSpan = createFirstInputDelaySpan(fidEntries)
   if (fidSpan) {
+    metrics.fid = fidSpan._start
     result.spans.push(fidSpan)
   }
 

--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -27,7 +27,8 @@ import {
   LONG_TASK,
   LARGEST_CONTENTFUL_PAINT,
   FIRST_CONTENTFUL_PAINT,
-  FIRST_INPUT
+  FIRST_INPUT,
+  LAYOUT_SHIFT
 } from '../common/constants'
 import { noop, PERF } from '../common/utils'
 import Span from './span'
@@ -37,7 +38,8 @@ export const metrics = {
   tbt: {
     start: Infinity,
     duration: 0
-  }
+  },
+  cls: 0
 }
 
 const LONG_TASK_THRESHOLD = 50
@@ -162,6 +164,14 @@ export function calculateTotalBlockingTime(longtaskEntries) {
   })
 }
 
+export function calculateCumulativeLayoutShift(clsEntries) {
+  clsEntries.forEach(entry => {
+    if (!entry.hadRecentInput) {
+      metrics.cls += entry.value
+    }
+  })
+}
+
 /**
  * Captures all the observed entries as Spans and Marks depending on the
  * observed entry types and returns in the format
@@ -237,6 +247,8 @@ export function captureObserverEntries(list, { capturePaint }) {
   }
 
   calculateTotalBlockingTime(longtaskEntries)
+  const clsEntries = list.getEntriesByType(LAYOUT_SHIFT)
+  calculateCumulativeLayoutShift(clsEntries)
 
   return result
 }

--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -34,6 +34,7 @@ import { noop, PERF } from '../common/utils'
 import Span from './span'
 
 export const metrics = {
+  fid: 0,
   fcp: 0,
   tbt: {
     start: Infinity,

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -405,7 +405,8 @@ export default class PerformanceMonitoring {
       span_count: {
         started: spans.length
       },
-      sampled: transaction.sampled
+      sampled: transaction.sampled,
+      experience: transaction.experience
     }
     return truncateModel(TRANSACTION_MODEL, transactionData)
   }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -44,7 +44,8 @@ import {
   LONG_TASK,
   PAINT,
   TRUNCATED_TYPE,
-  FIRST_INPUT
+  FIRST_INPUT,
+  LAYOUT_SHIFT
 } from '../common/constants'
 import { addTransactionContext } from '../common/context'
 import { __DEV__, state } from '../state'
@@ -159,6 +160,7 @@ class TransactionService {
         this.recorder.start(LARGEST_CONTENTFUL_PAINT)
         this.recorder.start(PAINT)
         this.recorder.start(FIRST_INPUT)
+        this.recorder.start(LAYOUT_SHIFT)
       }
       if (perfOptions.pageLoadTraceId) {
         tr.traceId = perfOptions.pageLoadTraceId
@@ -277,8 +279,14 @@ class TransactionService {
            * Capture the TBT as span after observing for all long task entries
            * and once performance observer is disconnected
            */
-          if (tr.captureTimings && metrics.tbt.duration > 0) {
-            tr.spans.push(createTotalBlockingTimeSpan(metrics.tbt))
+          if (tr.captureTimings) {
+            if (metrics.tbt.duration > 0) {
+              tr.spans.push(createTotalBlockingTimeSpan(metrics.tbt))
+            }
+            /**
+             * TODO: define the proper place to store cls.
+             */
+            tr.addContext({ cls: metrics.cls })
           }
         }
         /**

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -35,7 +35,6 @@ import {
   extend,
   getEarliestSpan,
   getLatestNonXHRSpan,
-  isUndefined,
   isPerfTypeSupported
 } from '../common/utils'
 import { captureNavigation } from './capture-navigation'
@@ -300,7 +299,7 @@ class TransactionService {
               tr.experience.cls = cls
             }
 
-            if (!isUndefined(fid)) {
+            if (fid > 0) {
               tr.experience.fid = fid
             }
           }

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -28,7 +28,8 @@ import {
   createFirstInputDelaySpan,
   createTotalBlockingTimeSpan,
   PerfEntryRecorder,
-  metrics
+  metrics,
+  calculateCumulativeLayoutShift
 } from '../../src/performance-monitoring/metrics'
 import { LARGEST_CONTENTFUL_PAINT, LONG_TASK } from '../../src/common/constants'
 import {
@@ -244,6 +245,49 @@ describe('Metrics', () => {
           _start: 5482.669999997597
         })
       )
+    })
+
+    it('should calculate Cumulative Layout Shift', () => {
+      metrics.cls = 0
+      calculateCumulativeLayoutShift([
+        {
+          duration: 0,
+          entryType: 'layout-shift',
+          hadRecentInput: true,
+          lastInputTime: 28846.710000012536,
+          name: '',
+          startTime: 28932.589999982156,
+          value: 0.04
+        },
+        {
+          duration: 0,
+          entryType: 'layout-shift',
+          hadRecentInput: false,
+          lastInputTime: 28846.710000012536,
+          name: '',
+          startTime: 28932.589999982156,
+          value: 0.02
+        },
+        {
+          duration: 0,
+          entryType: 'layout-shift',
+          hadRecentInput: false,
+          lastInputTime: 28846.710000012536,
+          name: '',
+          startTime: 28932.589999982156,
+          value: 0.03
+        },
+        {
+          duration: 0,
+          entryType: 'layout-shift',
+          hadRecentInput: false,
+          lastInputTime: 28846.710000012536,
+          name: '',
+          startTime: 28932.589999982156,
+          value: 0.01
+        }
+      ])
+      expect(metrics.cls.toFixed(5)).toEqual('0.06000')
     })
   })
 })

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -49,6 +49,7 @@ describe('Metrics', () => {
       list.getEntriesByType.and.returnValue([])
       list.getEntriesByName.and.returnValue([])
       metrics.tbt = { start: Infinity, duration: 0 }
+      metrics.cls = 0
     })
 
     it('should not create long tasks spans if entries are not present', () => {
@@ -248,7 +249,6 @@ describe('Metrics', () => {
     })
 
     it('should calculate Cumulative Layout Shift', () => {
-      metrics.cls = 0
       calculateCumulativeLayoutShift([
         {
           duration: 0,

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -37,7 +37,8 @@ import {
   LARGEST_CONTENTFUL_PAINT,
   PAINT,
   TRUNCATED_TYPE,
-  FIRST_INPUT
+  FIRST_INPUT,
+  LAYOUT_SHIFT
 } from '../../src/common/constants'
 import { state } from '../../src/state'
 
@@ -652,11 +653,12 @@ describe('TransactionService', function() {
       const pageLoadTr = trService.startTransaction('test', PAGE_LOAD, {
         managed: true
       })
-      expect(startSpy).toHaveBeenCalledTimes(4)
+      expect(startSpy).toHaveBeenCalledTimes(5)
       expect(startSpy.calls.allArgs()).toEqual([
         [LARGEST_CONTENTFUL_PAINT],
         [PAINT],
         [FIRST_INPUT],
+        [LAYOUT_SHIFT],
         [LONG_TASK]
       ])
       await pageLoadTr.end()
@@ -712,11 +714,12 @@ describe('TransactionService', function() {
       const pageLoadTr = trService.startTransaction('test', PAGE_LOAD, {
         managed: true
       })
-      expect(startSpy).toHaveBeenCalledTimes(3)
+      expect(startSpy).toHaveBeenCalledTimes(4)
       expect(startSpy.calls.allArgs()).toEqual([
         [LARGEST_CONTENTFUL_PAINT],
         [PAINT],
-        [FIRST_INPUT]
+        [FIRST_INPUT],
+        [LAYOUT_SHIFT]
       ])
       await pageLoadTr.end()
       expect(stopSpy).toHaveBeenCalled()

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -41,6 +41,7 @@ import {
   LAYOUT_SHIFT
 } from '../../src/common/constants'
 import { state } from '../../src/state'
+import { isPerfTypeSupported } from '../../src/common/utils'
 
 describe('TransactionService', function() {
   var transactionService
@@ -731,6 +732,21 @@ describe('TransactionService', function() {
       expect(startSpy).not.toHaveBeenCalled()
       await routeChangeTr.end()
       expect(stopSpy).toHaveBeenCalled()
+    })
+
+    it('should set experience on Transaction', async () => {
+      const tr = trService.startTransaction('test', PAGE_LOAD, {
+        managed: true
+      })
+      expect(tr.captureTimings).toBe(true)
+      await tr.end()
+      expect(tr.experience).toBeDefined()
+      if (isPerfTypeSupported(LONG_TASK)) {
+        expect(tr.experience.tbt).toBeGreaterThanOrEqual(0)
+      }
+      if (isPerfTypeSupported(LAYOUT_SHIFT)) {
+        expect(tr.experience.cls).toBeGreaterThanOrEqual(0)
+      }
     })
   })
 })


### PR DESCRIPTION
This PR adds CLS, FID and TBT to the ['experience' field](https://github.com/elastic/apm-server/issues/3972)

+ fix #795 

I think we should find a better place for storing metrics such as TBT and CLS.
Furthermore, we have too many places to store RUM specific data (page, marks, etc.) and I think we can take this opportunity to merge these together. I'm going to make a proposal for this on apm-server.