### PR TITLE
ci: run linting always

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,10 +75,6 @@ pipeline {
         Lint the code.
         */
         stage('Lint') {
-          when {
-            beforeAgent true
-            expression { return env.ONLY_DOCS == "false" }
-          }
           steps {
             withGithubNotify(context: 'Lint') {
               deleteDir()


### PR DESCRIPTION
### What

The linting stage generates the bundlesize report that it will be used to compare on a PR basis. 

### Why

Otherwise, if using the docs filtering in the stage then the bundlesize report won't be generated and the PRs that got built when the latest build in the mastet branch got built with docs then they won't have anything to compare with.

This will avoid this particular corner case and apply bundlesize reports for every single commit with a build.

### Further details:

- https://github.com/elastic/apm-agent-rum-js/pull/838#issuecomment-655022184