### PR TITLE
docs: add user centric metrics to supported list

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -18,8 +18,8 @@ captures the following information:
 * <<page-load-metrics,Page load metrics>>
 * Load time of Static Assets (JS, CSS, images, fonts, etc.)
 * API requests (XMLHttpRequest and Fetch)
-* Single page application interactions and navigation
-* <<user-interactions, User interactions>> (click events that trigger navigation changes)
+* Single page application navigations
+* <<user-interactions, User interactions>> (click events that trigger network activity)
 * <<user-centric-metrics, User-centric metrics>> (Long tasks, FCP, LCP, FID, etc.)
 * Page information (URLs visited and referrer)
 * Network connection information

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -11,21 +11,21 @@ This enables you to analyze performance throughout your microservice architectur
 [[features]]
 === Features
 
-The agent uses browser timing API's such as https://w3c.github.io/navigation-timing/[Navigation Timing]
-https://w3c.github.io/resource-timing/[Resource Timing], https://w3c.github.io/paint-timing/[Paint Timing], https://w3c.github.io/user-timing/[User Timing] etc. and
-captures the following information
+The agent uses browser timing APIs such as https://w3c.github.io/navigation-timing/[Navigation Timing]
+https://w3c.github.io/resource-timing/[Resource Timing], https://w3c.github.io/paint-timing/[Paint Timing], https://w3c.github.io/user-timing/[User Timing], etc., and
+captures the following information:
 
 * <<page-load-metrics,Page load metrics>>
-* Load time of Static Assets (JS, CSS, Images, Fonts, etc.)
+* Load time of Static Assets (JS, CSS, images, fonts, etc.)
 * API requests (XMLHttpRequest and Fetch)
-* Single Page Application Interactions/Navigation
-* <<user-interactions, User Interactions>> (Click events that triggers Navigation changes)
-* User-Centric metrics (Long tasks, FCP, LCP, FID, etc.)
+* Single page application interactions and navigation
+* <<user-interactions, User interactions>> (click events that trigger navigation changes)
+* User-centric metrics (Long tasks, FCP, LCP, FID, etc.)
 * Page information (URL's visited and Referrer)
-* Network Connection information
-* JavaScript Errors
-* <<<<distributed-tracing-guide, Distributed Tracing>>
-* <<breakdown-metrics-docs, Breakdown Metrics>>
+* Network connection information
+* JavaScript errors
+* <<<<distributed-tracing-guide, Distributed tracing>>
+* <<breakdown-metrics-docs, Breakdown metrics>>
 
 [float]
 [[additional-components]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -8,24 +8,24 @@ The Agent also supports <<distributed-tracing-guide,distributed tracing>> for al
 This enables you to analyze performance throughout your microservice architecture -- all in one view.
 
 [float]
-[[how-it-works]]
-=== How does the Agent work?
+[[features]]
+=== Features
 
-The RUM Agent automatically instruments the following:
+The agent uses browser timing API's such as https://w3c.github.io/navigation-timing/[Navigation Timing]
+https://w3c.github.io/resource-timing/[Resource Timing], https://w3c.github.io/paint-timing/[Paint Timing], https://w3c.github.io/user-timing/[User Timing] etc. and
+captures the following information
 
 * <<page-load-metrics,Page load metrics>>
-* Load time of Static Assets
+* Load time of Static Assets (JS, CSS, Images, Fonts, etc.)
 * API requests (XMLHttpRequest and Fetch)
-
-The agent uses the https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API[Navigation Timing API]
-and https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API[Resource Timing API]
-available in the browser to instrument the page load performance and static assets load times.
-
-The agent automatically captures all outgoing http requests,
-by instrumenting both XHR and Fetch API requests from the webpage to backend servers.
-
-For all transactions, the agent automatically captures <<breakdown-metrics-docs, breakdown metrics>>.
-
+* Single Page Application Interactions/Navigation
+* <<user-interactions, User Interactions>> (Click events that triggers Navigation changes)
+* User-Centric metrics (Long tasks, FCP, LCP, FID, etc.)
+* Page information (URL's visited and Referrer)
+* Network Connection information
+* JavaScript Errors
+* <<<<distributed-tracing-guide, Distributed Tracing>>
+* <<breakdown-metrics-docs, Breakdown Metrics>>
 
 [float]
 [[additional-components]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -20,8 +20,8 @@ captures the following information:
 * API requests (XMLHttpRequest and Fetch)
 * Single page application interactions and navigation
 * <<user-interactions, User interactions>> (click events that trigger navigation changes)
-* User-centric metrics (Long tasks, FCP, LCP, FID, etc.)
-* Page information (URL's visited and Referrer)
+* <<user-centric-metrics, User-centric metrics>> (Long tasks, FCP, LCP, FID, etc.)
+* Page information (URLs visited and referrer)
 * Network connection information
 * JavaScript errors
 * <<<<distributed-tracing-guide, Distributed tracing>>

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -39,12 +39,14 @@ https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event[Load] event o
 If you are interested in accurately measuring the duration of load event, the information can be extracted by using 
 `Fire load event` Span or from the Transaction marks available as `transaction.marks.agent.domComplete` in the Elasticsearch document.
 
+NOTE: The page load transaction is measured relative to the `fetchStart` timestamp from the Navigation Timing API.
+
 
 [float]
 [[user-centric-metrics]]
 === User-centric Metrics
 
-To understand the performance characteristics of a web page beyond the page load and how the user perceives performance, the agent supports capturing these responsiveness metrics.
+To understand the performance characteristics of a web page beyond the page load and how the user perceives performance, the agent supports capturing these https://web.dev/user-centric-performance-metrics/[responsiveness metrics].
 
 `First contentful paint (FCP)`::
 Focusses on the initial rendering and measures the time from when the page starts loading to when any part of the page's content is displayed on the screen. Captured as transaction mark for `page-load` transaction.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -7,7 +7,7 @@
 
 The RUM agent tries to capture the overall user experience on how the page is loaded/rendered as part of the page load Transaction.
 It includes all of the dependent resources, like JavaScript, stylesheets, images, etc., which are included as part of the page. In addition
-to capturing the resource timing information as Spans, the transaction also includes navigation spans that are associated with the rest
+to capturing the resource timing information as Spans, the transaction also includes navigation spans, marks that are associated with the rest
 of the captured information to make the waterfall more appealing.
 
 `Domain lookup`::
@@ -29,6 +29,8 @@ is executed: `domContentLoadedEventEnd` - `domContentLoadedEventStart`.
 `Fire "load" event`::
 Trigged when the browser finishes loading its document and dependent resources: `loadEventEnd` - `loadEventStart`.
 
+`Time to first byte (TTFB)`::
+Duration from the browser making an HTTP request for the initial document to the first byte of the page being received. TTFB is avaialble from the Navigation Timing API as `reponseStart` timestamp and captured as transaction mark `transaction.marks.agent.timeToFirstByte` in the ES document.
 
 To capture the overall user experience of the page including all of the above information plus additional resource requests that might be
 triggered during the execution of dependent resources, the `page-load` transaction duration might not always reflect the 
@@ -36,6 +38,31 @@ https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event[Load] event o
 
 If you are interested in accurately measuring the duration of load event, the information can be extracted by using 
 `Fire load event` Span or from the Transaction marks available as `transaction.marks.agent.domComplete` in the Elasticsearch document.
+
+
+[float]
+[[user-centric-metrics]]
+=== User-Centric Metrics
+
+To understand the performance characteristics of a web page beyond the page load and how the user perceives performance, the agent supports capturing the responsiveness metrics.
+
+`First contentful paint (FCP)`::
+Focusses on the initial rendering and measures the time from when the page starts loading to when any part of the page's content is displayed on the screen. Captured as transaction mark for `page-load` transaction.
+
+`Largest contentful paint (LCP)`::
+A new page-load metric that denotes the time from when the page starts loading to when the critical element (largest text or image element) is displayed on the screen. Captured as transaction mark for `page-load` transaction.
+
+`First input delay (FID)`::
+The time from when a user first interacts with your site (mouse clicks, taps, select dropdowns, etc.) to the time when the browser is able to respond to that interaction. Captured as `First Input Delay` span for `page-load` transaction.
+
+`Total blocking time (TBT)`::
+The sum of the blocking time (duration above 50 ms) for each long task that occurs between the First contentful paint and the time when the transaction is ended. Captured as `Total Blocking Time` span for `page-load` transaction.
+
+`Long Tasks`::
+Any user activity or tasks that monopolize the UI thread for extended periods (greater than 50 milliseconds) and block other critical tasks (frame rate or input latency) from being executed. Captured as `Longtask<name>` span for all managed transactions. Learn more about <<longtasks, long task spans>>, and how to interpret them.
+
+`User Timing`::
+Custom metrics that are annotated by the developers in their application code which helps analyze the performance characteristics. https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure[Measure events] are captured as spans with the measure name in the waterfall for all managed transactions.
 
 
 [float]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -7,7 +7,7 @@
 
 The RUM agent tries to capture the overall user experience on how the page is loaded/rendered as part of the page load Transaction.
 It includes all of the dependent resources, like JavaScript, stylesheets, images, etc., which are included as part of the page. In addition
-to capturing the resource timing information as Spans, the transaction also includes navigation spans, marks that are associated with the rest
+to capturing the resource timing information as Spans, the transaction also includes navigation spans—marks that are associated with the rest
 of the captured information to make the waterfall more appealing.
 
 `Domain lookup`::
@@ -30,7 +30,7 @@ is executed: `domContentLoadedEventEnd` - `domContentLoadedEventStart`.
 Trigged when the browser finishes loading its document and dependent resources: `loadEventEnd` - `loadEventStart`.
 
 `Time to first byte (TTFB)`::
-Duration from the browser making an HTTP request for the initial document to the first byte of the page being received. TTFB is avaialble from the Navigation Timing API as `reponseStart` timestamp and captured as transaction mark `transaction.marks.agent.timeToFirstByte` in the ES document.
+Duration from the browser making an HTTP request for the initial document to the first byte of the page being received. TTFB is available from the Navigation Timing API as the `reponseStart` timestamp, and captured as transaction mark `transaction.marks.agent.timeToFirstByte` in the ElasticSearch document.
 
 To capture the overall user experience of the page including all of the above information plus additional resource requests that might be
 triggered during the execution of dependent resources, the `page-load` transaction duration might not always reflect the 
@@ -42,9 +42,9 @@ If you are interested in accurately measuring the duration of load event, the in
 
 [float]
 [[user-centric-metrics]]
-=== User-Centric Metrics
+=== User-centric Metrics
 
-To understand the performance characteristics of a web page beyond the page load and how the user perceives performance, the agent supports capturing the responsiveness metrics.
+To understand the performance characteristics of a web page beyond the page load and how the user perceives performance, the agent supports capturing these responsiveness metrics.
 
 `First contentful paint (FCP)`::
 Focusses on the initial rendering and measures the time from when the page starts loading to when any part of the page's content is displayed on the screen. Captured as transaction mark for `page-load` transaction.


### PR DESCRIPTION
+ fix #633 
+ part of #790 
+ Enhanced the feature section and also added user centric metrics section that has FCP, LCP, TBT, FID and longtasks that we have supported. 