### PR TITLE
chore: add deps to run integration tests

### DIFF
--- a/.ci/docker/node-puppeteer/Dockerfile
+++ b/.ci/docker/node-puppeteer/Dockerfile
@@ -9,6 +9,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     && apt-get update \
     && apt-get install -y \
       google-chrome-unstable \
+      libxss1 \
       fonts-ipafont-gothic \
       fonts-wqy-zenhei \
       fonts-thai-tlwg \


### PR DESCRIPTION
+ Integration tests are not able to run properly due to the same issue reported here for puppeteer images https://github.com/elastic/apm-integration-testing/issues/870
+ Did the same workaround as https://github.com/elastic/apm-integration-testing/issues/872