### PR TITLE
chore(jenkins): increase bundlesize

### DIFF
--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -51,11 +51,11 @@
   "bundlesize": [
     {
       "path": "./dist/bundles/elastic-apm-rum*.min.js",
-      "maxSize": "20 kB"
+      "maxSize": "18.5 kB"
     },
     {
       "path": "./dist/bundles/elastic-apm-opentracing*.min.js",
-      "maxSize": "22kB"
+      "maxSize": "20kB"
     }
   ]
 }

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -51,11 +51,11 @@
   "bundlesize": [
     {
       "path": "./dist/bundles/elastic-apm-rum*.min.js",
-      "maxSize": "16 kB"
+      "maxSize": "20 kB"
     },
     {
       "path": "./dist/bundles/elastic-apm-opentracing*.min.js",
-      "maxSize": "18kB"
+      "maxSize": "22kB"
     }
   ]
 }


### PR DESCRIPTION
This increases the bundle size for apm-rum and apm-opentracing. It should resolve errors seen here:

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/master/308/pipeline/78/