### PR TITLE
fix(rum): use logLevel config when agent is inactive

### DIFF
--- a/packages/rum-core/src/common/logging-service.js
+++ b/packages/rum-core/src/common/logging-service.js
@@ -28,7 +28,7 @@ import { noop } from './utils'
 class LoggingService {
   constructor(spec = {}) {
     this.levels = ['trace', 'debug', 'info', 'warn', 'error']
-    this.level = spec.level || 'info'
+    this.level = spec.level || 'warn'
     this.prefix = spec.prefix || ''
 
     this.resetLogMethods()
@@ -39,6 +39,9 @@ class LoggingService {
   }
 
   setLevel(level) {
+    if (level === this.level) {
+      return
+    }
     this.level = level
     this.resetLogMethods()
   }

--- a/packages/rum-core/src/common/logging-service.js
+++ b/packages/rum-core/src/common/logging-service.js
@@ -44,30 +44,18 @@ class LoggingService {
   }
 
   resetLogMethods() {
-    var loggingService = this
-    this.levels.forEach(function(level) {
-      loggingService[level] = loggingService.shouldLog(level) ? log : noop
+    this.levels.forEach(level => {
+      this[level] = this.shouldLog(level) ? log : noop
 
       function log() {
-        var prefix = loggingService.prefix
-        var normalizedLevel
-
-        switch (level) {
-          case 'trace':
-            normalizedLevel = 'info'
-            break
-          case 'debug':
-            normalizedLevel = 'info'
-            break
-          default:
-            normalizedLevel = level
+        let normalizedLevel = level
+        if (level === 'trace' || level === 'debug') {
+          normalizedLevel = 'info'
         }
-        var args = arguments
-        if (prefix) {
-          args[0] = prefix + args[0]
-        }
+        let args = arguments
+        args[0] = this.prefix + args[0]
         if (console) {
-          var realMethod = console[normalizedLevel] || console.log
+          const realMethod = console[normalizedLevel] || console.log
           if (typeof realMethod === 'function') {
             realMethod.apply(console, args)
           }

--- a/packages/rum-core/src/common/service-factory.js
+++ b/packages/rum-core/src/common/service-factory.js
@@ -39,19 +39,10 @@ const serviceCreators = {
   [LOGGING_SERVICE]: factory => {
     const configService = factory.getService(CONFIG_SERVICE)
     const logLevel = configService.get('logLevel')
-    const loggingService = new LoggingService({
+    return new LoggingService({
       prefix: '[Elastic APM] ',
       level: logLevel
     })
-    /**
-     * Reset logLevel whenever config update happens
-     */
-    configService.events.observe(CONFIG_CHANGE, () => {
-      const logLevel = configService.get('logLevel')
-      loggingService.setLevel(logLevel)
-    })
-
-    return loggingService
   },
   [APM_SERVER]: factory => {
     const [configService, loggingService] = factory.getService([
@@ -77,7 +68,17 @@ class ServiceFactory {
     const configService = this.getService(CONFIG_SERVICE)
     configService.init()
 
-    const apmServer = this.getService(APM_SERVER)
+    const [loggingService, apmServer] = this.getService([
+      LOGGING_SERVICE,
+      APM_SERVER
+    ])
+    /**
+     * Reset logLevel whenever config update happens
+     */
+    configService.events.observe(CONFIG_CHANGE, () => {
+      const logLevel = configService.get('logLevel')
+      loggingService.setLevel(logLevel)
+    })
     apmServer.init()
   }
 

--- a/packages/rum-core/src/common/service-factory.js
+++ b/packages/rum-core/src/common/service-factory.js
@@ -36,14 +36,10 @@ import { __DEV__ } from '../state'
 
 const serviceCreators = {
   [CONFIG_SERVICE]: () => new ConfigService(),
-  [LOGGING_SERVICE]: factory => {
-    const configService = factory.getService(CONFIG_SERVICE)
-    const logLevel = configService.get('logLevel')
-    return new LoggingService({
-      prefix: '[Elastic APM] ',
-      level: logLevel
-    })
-  },
+  [LOGGING_SERVICE]: () =>
+    new LoggingService({
+      prefix: '[Elastic APM] '
+    }),
   [APM_SERVER]: factory => {
     const [configService, loggingService] = factory.getService([
       CONFIG_SERVICE,
@@ -64,7 +60,6 @@ class ServiceFactory {
       return
     }
     this.initialized = true
-
     const configService = this.getService(CONFIG_SERVICE)
     configService.init()
 

--- a/packages/rum-core/test/common/logging-service.spec.js
+++ b/packages/rum-core/test/common/logging-service.spec.js
@@ -28,7 +28,7 @@ import LoggingService from '../../src/common/logging-service'
 describe('LoggingService', function() {
   var loggingService
   beforeEach(function() {
-    loggingService = new LoggingService({})
+    loggingService = new LoggingService({ level: 'info' })
   })
   it('should log', function() {
     expect(loggingService.level).toBe('info')
@@ -98,7 +98,8 @@ describe('LoggingService', function() {
   it('should set prefix for logs', function() {
     spyOn(console, 'info')
     loggingService = new LoggingService({
-      prefix: 'APM: '
+      prefix: 'APM: ',
+      level: 'info'
     })
     loggingService.info('info')
     expect(console.info).toHaveBeenCalledWith('APM: info')

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -42,10 +42,7 @@ export default class ApmBase {
   init(config) {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
-      const [configService, loggingService] = this.serviceFactory.getService([
-        CONFIG_SERVICE,
-        LOGGING_SERVICE
-      ])
+      const configService = this.serviceFactory.getService(CONFIG_SERVICE)
       /**
        * Set Agent version to be sent as part of metadata to the APM Server
        */
@@ -85,7 +82,12 @@ export default class ApmBase {
         }
       } else {
         this._disable = true
-        loggingService.info('RUM agent is inactive')
+        /**
+         * Creation of LoggingService should happen only after config update.
+         * This order gurantees that we use the proper logLevel
+         */
+        const loggingService = this.serviceFactory.getService(LOGGING_SERVICE)
+        loggingService.warn('RUM agent is inactive')
       }
     }
     return this

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -42,12 +42,20 @@ export default class ApmBase {
   init(config) {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
-      const configService = this.serviceFactory.getService(CONFIG_SERVICE)
+      const [configService, loggingService] = this.serviceFactory.getService([
+        CONFIG_SERVICE,
+        LOGGING_SERVICE
+      ])
       /**
        * Set Agent version to be sent as part of metadata to the APM Server
        */
       configService.setVersion('5.4.0')
       this.config(config)
+      /**
+       * Set level here to account for both active and inactive cases
+       */
+      const logLevel = configService.get('logLevel')
+      loggingService.setLevel(logLevel)
       /**
        * Deactive agent when the active config flag is set to false
        */
@@ -82,11 +90,6 @@ export default class ApmBase {
         }
       } else {
         this._disable = true
-        /**
-         * Creation of LoggingService should happen only after config update.
-         * This order gurantees that we use the proper logLevel
-         */
-        const loggingService = this.serviceFactory.getService(LOGGING_SERVICE)
         loggingService.warn('RUM agent is inactive')
       }
     }

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -158,16 +158,12 @@ describe('ApmBase', function() {
   })
 
   it('should use user provided logLevel when agent is inactive', () => {
-    const apmInstance = new ApmBase(serviceFactory, !enabled)
-    apmInstance.init({
+    const loggingService = serviceFactory.getService('LoggingService')
+    apmBase.init({
       active: false,
       logLevel: 'error'
     })
-    const loggingService = apmInstance.serviceFactory.getService(
-      'LoggingService'
-    )
-    spyOn(loggingService, 'warn')
-    expect(loggingService.warn).not.toHaveBeenCalled()
+    expect(loggingService.warn.toString()).toBe('function noop() {}')
   })
 
   it('should provide the public api', function() {

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -161,6 +161,26 @@ describe('ApmBase', function() {
     expect(apmBase.getCurrentTransaction()).toBeUndefined()
   })
 
+  it('should use user provided logLevel when agent is inactive', () => {
+    const infoSpy = spyOn(console, 'info')
+    apmBase.init({
+      active: false,
+      logLevel: 'warn'
+    })
+    expect(console.info).not.toHaveBeenCalled()
+    infoSpy.calls.reset()
+
+    const apmInstance = new ApmBase(serviceFactory, !enabled)
+    apmInstance.init({
+      active: false,
+      logLevel: 'debug'
+    })
+    expect(console.info).toHaveBeenCalledWith(
+      '[Elastic APM] RUM agent is inactive'
+    )
+    infoSpy.calls.reset()
+  })
+
   it('should provide the public api', function() {
     apmBase.init({ serviceName, serverUrl })
     apmBase.setInitialPageLoadName('test')

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -121,11 +121,9 @@ describe('ApmBase', function() {
 
   it('should be noop for auto instrumentaion when agent is not active', done => {
     const loggingService = serviceFactory.getService('LoggingService')
-    spyOn(loggingService, 'info')
+    spyOn(loggingService, 'warn')
 
-    apmBase.init({
-      active: false
-    })
+    apmBase.init({ active: false })
     /**
      * Start a XHR which shouldn't be captured as transaction
      */
@@ -135,7 +133,7 @@ describe('ApmBase', function() {
       setTimeout(() => {
         const tr = apmBase.getCurrentTransaction()
         expect(tr).toBeUndefined()
-        expect(loggingService.info).toHaveBeenCalledWith(
+        expect(loggingService.warn).toHaveBeenCalledWith(
           'RUM agent is inactive'
         )
         done()
@@ -147,12 +145,10 @@ describe('ApmBase', function() {
 
   it('should be noop when API methods are used and agent is not active', () => {
     const loggingService = serviceFactory.getService('LoggingService')
-    spyOn(loggingService, 'info')
+    spyOn(loggingService, 'warn')
 
-    apmBase.init({
-      active: false
-    })
-    expect(loggingService.info).toHaveBeenCalledWith('RUM agent is inactive')
+    apmBase.init({ active: false })
+    expect(loggingService.warn).toHaveBeenCalledWith('RUM agent is inactive')
     const tr = apmBase.startTransaction('test')
     const span = apmBase.startSpan('span1')
 
@@ -162,23 +158,16 @@ describe('ApmBase', function() {
   })
 
   it('should use user provided logLevel when agent is inactive', () => {
-    const infoSpy = spyOn(console, 'info')
-    apmBase.init({
-      active: false,
-      logLevel: 'warn'
-    })
-    expect(console.info).not.toHaveBeenCalled()
-    infoSpy.calls.reset()
-
     const apmInstance = new ApmBase(serviceFactory, !enabled)
     apmInstance.init({
       active: false,
-      logLevel: 'debug'
+      logLevel: 'error'
     })
-    expect(console.info).toHaveBeenCalledWith(
-      '[Elastic APM] RUM agent is inactive'
+    const loggingService = apmInstance.serviceFactory.getService(
+      'LoggingService'
     )
-    infoSpy.calls.reset()
+    spyOn(loggingService, 'warn')
+    expect(loggingService.warn).not.toHaveBeenCalled()
   })
 
   it('should provide the public api', function() {
@@ -260,7 +249,7 @@ describe('ApmBase', function() {
 
   it('should patch xhr when not active', function(done) {
     const loggingService = serviceFactory.getService('LoggingService')
-    spyOn(loggingService, 'info')
+    spyOn(loggingService, 'warn')
 
     apmBase.init({ active: false })
 
@@ -279,12 +268,12 @@ describe('ApmBase', function() {
     req.send()
     const tr = apmBase.getCurrentTransaction()
     expect(tr).toBeUndefined()
-    expect(loggingService.info).toHaveBeenCalledWith('RUM agent is inactive')
+    expect(loggingService.warn).toHaveBeenCalledWith('RUM agent is inactive')
   })
 
   it('should log errors when config is invalid', () => {
     const loggingService = serviceFactory.getService('LoggingService')
-    spyOn(loggingService, 'info')
+    spyOn(loggingService, 'warn')
     const logErrorSpy = spyOn(loggingService, 'error')
     apmBase.init({
       serverUrl: undefined,


### PR DESCRIPTION
+ fix #861 
+ The first logLevel update happens during the LoggingService creation phase in both active and also inactive phase.
+ The second logLevel update happens if users call `apm.config({})` or config is updated from remote config for the active phase. 