### PR TITLE
feat(rum-core): provide api to block managed transactions 

### DIFF
--- a/docs/custom-transactions.asciidoc
+++ b/docs/custom-transactions.asciidoc
@@ -1,29 +1,18 @@
 [[custom-transactions]]
 === Custom Transactions
 
-This is an example of how to use custom transactions and custom spans. 
-Please also see <<api, API documentation>>.
+Elastic APM uses the concept of transactions and spans to collect performance data. Spans are used to measure an operation and they
+are grouped into the transactions.
 
+By default Elastic APM JS agent creates transactions for all the <<supported-technologies, Supported Technologies>> and send them to the apm-server, however if the current instrumentation doesn't provide all the insights, you can create custom transactions to fill the gaps.
 
-Elastic APM uses the concept of transactions and spans to collect performance data. Spans are used to measure an operation and spans
-are grouped into what transactions.
-
-By default Elastic APM JS agent collects some transactions (`page-load` transaction for example) and send them to apm-server, however
-if the current instrumentation doesn't provide what you need, you can create custom transactions to fill the gaps.
-
-Here is an example application using custom transactions:
+Here is an example of using custom transactions and spans:
 
 [source,js]
 ----
-import { init as initApm } from '@elastic/apm-rum'
-var apm = initApm({
-  serviceName: 'service-name',
-  serverUrl: 'http://localhost:8200'
-})
-
-var transaction = apm.startTransaction('Application start', 'custom')
-var url = 'http://example.com/data.json'
-var httpSpan = transaction.startSpan('FETCH ' + url, 'http')
+const transaction = apm.startTransaction('Application start', 'custom')
+const url = 'http://example.com/data.json'
+const httpSpan = transaction.startSpan('GET ' + url, 'external.http')
 fetch(url)
   .then((resp) => {
     if (!resp.ok) {
@@ -34,8 +23,27 @@ fetch(url)
   })
 ----
 
-
 NOTE: By default custom transactions are not managed by the agent, therefore,
 the agent does not create spans based on <<supported-technologies,automatic instrumentations>>, e.g. XHR instrumentation.
- 
-NOTE: Transactions are queued and sent together automatically after `Transaction.end` is called.
+
+[float]
+[[custom-managed-transactions]]
+==== Creating a Managed transaction
+
+If you want to create a custom transaction and associate all the other timing information and spans based on the <<supported-technologies,supported technologies>>, you can set the `managed` flag to `true` and it will be controlled by the agent. However the transaction might get
+closed automatically once all the assocaited pending spans and tasks are completed. If you want to control the ending of this transaction, you can create a blocking span that will hold the transaction until `span.end` is called.
+
+[source,js]
+----
+const transaction = apm.startTransaction('custom managed', 'custom', { managed: true })
+const span = transaction.startSpan('async-task', 'app', { blocking: true })
+
+setTimeout(() => {
+  span.end()
+  // this would also end the managed transaction as all blocking tasks are completed and
+  // transaction would also contain other timing information and spans similar to page-load and route-change.
+}, 3000)
+
+----
+
+NOTE: Both custom and managed transactions are queued and sent together automatically after `transaction.end` is called.

--- a/docs/custom-transactions.asciidoc
+++ b/docs/custom-transactions.asciidoc
@@ -1,10 +1,12 @@
 [[custom-transactions]]
 === Custom Transactions
 
-Elastic APM uses the concept of transactions and spans to collect performance data. Spans are used to measure an operation and they
-are grouped into the transactions.
+Elastic APM uses the concept of transactions and spans to collect performance data. Spans are used to measure a unit of 
+operation and they are grouped into the transactions.
 
-By default Elastic APM JS agent creates transactions for all the <<supported-technologies, Supported Technologies>> and send them to the apm-server, however if the current instrumentation doesn't provide all the insights, you can create custom transactions to fill the gaps.
+By default, Elastic APM JS agent creates transactions for all the <<supported-technologies, Supported Technologies>> and
+send them to the apm-server, however if the current instrumentation doesn't provide all the insights, you can create
+custom transactions to fill the gaps.
 
 Here is an example of using custom transactions and spans:
 
@@ -23,15 +25,18 @@ fetch(url)
   })
 ----
 
-NOTE: By default custom transactions are not managed by the agent, therefore,
-the agent does not create spans based on <<supported-technologies,automatic instrumentations>>, e.g. XHR instrumentation.
+NOTE: custom transactions are not managed by the agent, therefore, the agent does not capture spans and
+other timing information based on <<supported-technologies,automatic instrumentations>>, e.g. XHR, Resource Timing etc.
 
 [float]
 [[custom-managed-transactions]]
 ==== Creating a Managed transaction
 
-If you want to create a custom transaction and associate all the other timing information and spans based on the <<supported-technologies,supported technologies>>, you can set the `managed` flag to `true` and it will be controlled by the agent. However the transaction might get
-closed automatically once all the assocaited pending spans and tasks are completed. If you want to control the ending of this transaction, you can create a blocking span that will hold the transaction until `span.end` is called.
+If the user is interested in associating all the other timing information and spans in the custom transactions based
+on the <<supported-technologies,supported technologies>>, they can pass the `managed` flag to `true` while creating the
+transaction and will be controlled by the agent. However, the transaction might get closed automatically once all the
+associated spans are completed. If the user wants to control this behavior, they can create a blocking span that will
+hold the transaction until `span.end` is called.
 
 [source,js]
 ----
@@ -40,10 +45,13 @@ const span = transaction.startSpan('async-task', 'app', { blocking: true })
 
 setTimeout(() => {
   span.end()
-  // this would also end the managed transaction as all blocking tasks are completed and
-  // transaction would also contain other timing information and spans similar to page-load and route-change.
-}, 3000)
+  /**
+   * This would also end the managed transaction once all the blocking tasks are completed and
+   * transaction would also contain other timing information and spans similar to auto
+   * instrumented transactions like `page-load` and `route-change`.
+   */
+}, 1000)
 
 ----
 
-NOTE: Both custom and managed transactions are queued and sent together automatically after `transaction.end` is called.
+NOTE: Both custom and managed transactions are queued and sent together automatically at configured intervals after `transaction.end` is called.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -64,57 +64,51 @@ Arguments:
 
 * `options` - The following options are supported:
 
-** `blocked` - Blocks the associated transaction from ending till this span is ended. Blocked spans
-    automatically creates a task. Defaults to false
+** `blocking` - Blocks the associated transaction from ending till this span is ended. Blocked spans
+    automatically internally creates a task. Defaults to false
 
 ** `parentId` - Parent id associated with the new span. Defaults to current transaction id
 
 ** `sync` - Denotes if the span is synchronous or asynchronous.
 
-When a span is started it will measure the time until <<span-end,`span.end()`>> is called.
+When a span is started it will measure the time until <<span-end,`span.end()`>> is called. Blocked
+spans allow users to control the early closing of <<custom-managed-transactions, managed transactions>> in some cases.
 
-See <<span-api,Span API>> docs for details on how to use custom spans.
+See also the <<span-api,Span API>> docs for details on how to use custom spans.
 
 [float]
-[[transaction-add-task]]
-==== `transaction.addTask([taskId])`
+[[transaction-block]]
+==== `transaction.block(flag)`
 
 [source,js]
 ----
-const taskId = transaction.addTask('async-task')
+transaction.block(true)
 ----
 
-Starts a new task for the current transaction and returns the new task id. The transaction does not end till all the tasks are
-removed from the transacion.
+Blocks the currently running auto-instrumented or custom transactions from getting automatically closed once the associated spans are ended.
 
 Arguments:
 
-* `name` - Optional. The name of the task (string). Defaults to a random id.
+* `flag` - Boolean. Defaults to false.
 
-Tasks are pretty new and its available only on the RUM agent. Most of the time, the users shouldn't need to create tasks as
-custom transactions created by the user ends only when `transaction.end` method is called. However in the case of managed transactions like page-load, route-change and other user created ones by setting `managed: true` flag, the transaction might get closed automatically prior to the user's expectation once all the associated tasks are completed. Please check the <<custom-managed-transactions, custom transactions>> guide to understand how you can control the behaviour of transaction using tasks.
-
-
-NOTE: This API will be removed in the next major version, Please use the `startSpan` method with `blocking: true`.
-
-
-[float]
-[[transaction-remove-task]]
-==== `transaction.removeTask(taskId)`
+Most of the time, users shouldn't need to block the running transaction as the agent tries to account for all of the async network activity and capture
+the required information. The block API is useful when the user feels the auto instrumented code missed some important activity and ends up prematurely
+closing the transaction and the page contains lots of asynchronous tasks that cannot be automatically instrumented (eg: web workers).
 
 [source,js]
 ----
-transaction.removeTask('async-task')
+// get the current active autoinstrumented transaction (page-load, route-change, etc.)
+const activeTransaction = apm.getCurrentTransaction()
+
+if (activeTransaction) {
+  activeTransaction.block(true)
+}
+
+// Perform some more async tasks and unblock it
+activeTransaction.block(false)
 ----
 
-Removes the task if its present from the associated transaction and also checks if the transaction can be ended when there are no pending tasks to be completed.
-
-Arguments:
-
-* `name` - Required. The name of the task (string).
-
-
-NOTE: This API will be removed in the next major version, Please use the `startSpan` method with `blocking: true`.
+One can also achieve a similar action by creating blocked spans. Check the <<custom-managed-transactions, managed transactions>> guide to learn more.
 
 
 [float]
@@ -154,8 +148,8 @@ Defining too many unique fields in an index is a condition that can lead to a
 transaction.end()
 ----
 
-Ends the transaction. If the transaction has already ended, nothing happens.
-
+Ends the transaction. Calling `transaction.end` on an active transaction would end all of the underlying spans and marks them as `truncated`.
+If the transaction has already ended, nothing happens.
 
 [float]
 [[transaction-mark]]

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -64,13 +64,57 @@ Arguments:
 
 * `options` - The following options are supported:
 
+** `blocked` - Blocks the associated transaction from ending till this span is ended. Blocked spans
+    automatically creates a task. Defaults to false
+
 ** `parentId` - Parent id associated with the new span. Defaults to current transaction id
 
-** `sync` - Denotes if the span is blocking (sync) or non-blocking(async). 
+** `sync` - Denotes if the span is synchronous or asynchronous.
 
 When a span is started it will measure the time until <<span-end,`span.end()`>> is called.
 
 See <<span-api,Span API>> docs for details on how to use custom spans.
+
+[float]
+[[transaction-add-task]]
+==== `transaction.addTask([taskId])`
+
+[source,js]
+----
+const taskId = transaction.addTask('async-task')
+----
+
+Starts a new task for the current transaction and returns the new task id. The transaction does not end till all the tasks are
+removed from the transacion.
+
+Arguments:
+
+* `name` - Optional. The name of the task (string). Defaults to a random id.
+
+Tasks are pretty new and its available only on the RUM agent. Most of the time, the users shouldn't need to create tasks as
+custom transactions created by the user ends only when `transaction.end` method is called. However in the case of managed transactions like page-load, route-change and other user created ones by setting `managed: true` flag, the transaction might get closed automatically prior to the user's expectation once all the associated tasks are completed. Please check the <<custom-managed-transactions, custom transactions>> guide to understand how you can control the behaviour of transaction using tasks.
+
+
+NOTE: This API will be removed in the next major version, Please use the `startSpan` method with `blocking: true`.
+
+
+[float]
+[[transaction-remove-task]]
+==== `transaction.removeTask(taskId)`
+
+[source,js]
+----
+transaction.removeTask('async-task')
+----
+
+Removes the task if its present from the associated transaction and also checks if the transaction can be ended when there are no pending tasks to be completed.
+
+Arguments:
+
+* `name` - Required. The name of the task (string).
+
+
+NOTE: This API will be removed in the next major version, Please use the `startSpan` method with `blocking: true`.
 
 
 [float]

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -51,7 +51,7 @@ which might not always be accurate.
 
 [source,js]
 ----
-var span = transaction.startSpan('My custom span')
+const span = transaction.startSpan('My custom span')
 ----
 
 Start and return a new custom span associated with this transaction.

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -134,9 +134,8 @@ function checkSameOrigin(source, target) {
 function isPlatformSupported() {
   return (
     isBrowser &&
-    typeof Array.prototype.forEach === 'function' &&
+    typeof Set === 'function' &&
     typeof JSON.stringify === 'function' &&
-    typeof Function.bind === 'function' &&
     PERF &&
     typeof PERF.now === 'function' &&
     isCORSSupported()

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -266,9 +266,9 @@ export default class PerformanceMonitoring {
         })
       }
 
-      const span = transactionService.startSpan(spanName, 'external.http')
-      const taskId = transactionService.addTask()
-
+      const span = transactionService.startSpan(spanName, 'external.http', {
+        blocked: true
+      })
       if (!span) {
         return
       }
@@ -295,13 +295,10 @@ export default class PerformanceMonitoring {
         span.sync = data.sync
       }
       data.span = span
-      task.id = taskId
     } else if (event === INVOKE) {
-      if (task.data && task.data.span) {
-        task.data.span.end(null, task.data)
-      }
-      if (task.id) {
-        transactionService.removeTask(task.id)
+      const data = task.data
+      if (data && data.span) {
+        transactionService.endSpan(data.span, data)
       }
     }
   }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -267,7 +267,7 @@ export default class PerformanceMonitoring {
       }
 
       const span = transactionService.startSpan(spanName, 'external.http', {
-        blocked: true
+        blocking: true
       })
       if (!span) {
         return

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -330,7 +330,10 @@ class TransactionService {
 
         this._config.events.send(TRANSACTION_END, [tr])
         if (__DEV__) {
-          this._logger.debug(`end transaction(${tr.id}, ${tr.name})`, tr)
+          this._logger.debug(
+            `end transaction(${tr.id}, ${tr.name}, ${tr.type})`,
+            tr
+          )
         }
       },
       err => {
@@ -398,7 +401,7 @@ class TransactionService {
     return false
   }
 
-  startSpan(name, type, options = {}) {
+  startSpan(name, type, options) {
     const tr = this.ensureCurrentTransaction(
       undefined,
       TEMPORARY_TYPE,
@@ -410,12 +413,9 @@ class TransactionService {
 
     if (tr) {
       const span = tr.startSpan(name, type, options)
-      if (options.blocked) {
-        tr.addTask(span.id)
-      }
       if (__DEV__) {
         this._logger.debug(
-          `startSpan(${name}, ${type})`,
+          `startSpan(${name}, ${span.type})`,
           `on transaction(${tr.id}, ${tr.name})`
         )
       }
@@ -424,20 +424,17 @@ class TransactionService {
   }
 
   endSpan(span, context) {
-    const tr = this.getCurrentTransaction()
-    if (!span || !tr) {
+    if (!span) {
       return
     }
-
-    span.end(null, context)
-    tr.removeTask(span.id)
     if (__DEV__) {
       const tr = this.getCurrentTransaction()
       this._logger.debug(
-        `endSpan(${span.name}, ${span.type}.${span.subtype})`,
+        `endSpan(${span.name}, ${span.type})`,
         `on transaction(${tr.id}, ${tr.name})`
       )
     }
+    span.end(null, context)
   }
 }
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -429,10 +429,11 @@ class TransactionService {
     }
     if (__DEV__) {
       const tr = this.getCurrentTransaction()
-      this._logger.debug(
-        `endSpan(${span.name}, ${span.type})`,
-        `on transaction(${tr.id}, ${tr.name})`
-      )
+      tr &&
+        this._logger.debug(
+          `endSpan(${span.name}, ${span.type})`,
+          `on transaction(${tr.id}, ${tr.name})`
+        )
     }
     span.end(null, context)
   }

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -45,8 +45,8 @@ class Transaction extends SpanBase {
     this.spans = []
     this._activeSpans = {}
 
-    this.nextAutoTaskId = 1
-    this._scheduledTasks = []
+    this.nextTaskId = 1
+    this._activeTasks = new Set()
 
     this.captureTimings = false
 
@@ -110,7 +110,7 @@ class Transaction extends SpanBase {
   }
 
   isFinished() {
-    return this._scheduledTasks.length === 0
+    return this._activeTasks.size === 0
   }
 
   detectFinish() {
@@ -138,20 +138,15 @@ class Transaction extends SpanBase {
   }
 
   addTask(taskId) {
-    if (typeof taskId === 'undefined') {
-      taskId = 'task' + this.nextAutoTaskId++
+    if (!taskId) {
+      taskId = 'task' + this.nextTaskId++
     }
-    if (this._scheduledTasks.indexOf(taskId) == -1) {
-      this._scheduledTasks.push(taskId)
-      return taskId
-    }
+    this._activeTasks.add(taskId)
+    return taskId
   }
 
   removeTask(taskId) {
-    let index = this._scheduledTasks.indexOf(taskId)
-    if (index > -1) {
-      this._scheduledTasks.splice(index, 1)
-    }
+    this._activeTasks.delete(taskId)
     this.detectFinish()
   }
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -485,14 +485,14 @@ describe('PerformanceMonitoring', function() {
     req.addEventListener('readystatechange', function() {
       if (req.readyState === req.DONE) {
         fn('invoke', task)
-        expect(tr._scheduledTasks).toEqual([])
+        expect(tr._activeTasks.size).toEqual(0)
         expect(tr.ended).toBeTruthy()
         done()
       }
     })
     fn('schedule', task)
     expect(task.id).toBeDefined()
-    expect(tr._scheduledTasks).toEqual(['task1'])
+    expect(tr._activeTasks).toContain('task1')
     req.send()
   })
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -353,7 +353,8 @@ describe('PerformanceMonitoring', function() {
       })
       expect(transactionService.startSpan).toHaveBeenCalledWith(
         'GET /',
-        'external.http'
+        'external.http',
+        { blocked: true }
       )
     })
 
@@ -370,9 +371,12 @@ describe('PerformanceMonitoring', function() {
       spyOn(transactionService, 'startSpan').and.callThrough()
       fn(SCHEDULE, fakeXHRTask)
 
-      expect(transactionService.startSpan).toHaveBeenCalledWith(
+      expect(
+        transactionService.startSpan
+      ).toHaveBeenCalledWith(
         'GET https://[REDACTED]:[REDACTED]@c.com/d',
-        'external.http'
+        'external.http',
+        { blocked: true }
       )
     })
 
@@ -485,14 +489,13 @@ describe('PerformanceMonitoring', function() {
     req.addEventListener('readystatechange', function() {
       if (req.readyState === req.DONE) {
         fn('invoke', task)
-        expect(tr._activeTasks.size).toEqual(0)
+        expect(tr._activeTasks.size).toBe(0)
         expect(tr.ended).toBeTruthy()
         done()
       }
     })
     fn('schedule', task)
-    expect(task.id).toBeDefined()
-    expect(tr._activeTasks).toContain('task1')
+    expect(tr._activeTasks.size).toBe(1)
     req.send()
   })
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -354,7 +354,7 @@ describe('PerformanceMonitoring', function() {
       expect(transactionService.startSpan).toHaveBeenCalledWith(
         'GET /',
         'external.http',
-        { blocked: true }
+        { blocking: true }
       )
     })
 
@@ -376,7 +376,7 @@ describe('PerformanceMonitoring', function() {
       ).toHaveBeenCalledWith(
         'GET https://[REDACTED]:[REDACTED]@c.com/d',
         'external.http',
-        { blocked: true }
+        { blocking: true }
       )
     })
 

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -101,7 +101,7 @@ describe('TransactionService', function() {
       return r
     }
     spyOn(result, 'onEnd').and.callThrough()
-    var span = transactionService.startSpan('test', 'test', { blocked: true })
+    var span = transactionService.startSpan('test', 'test', { blocking: true })
     result.detectFinish()
     expect(result.onEnd).not.toHaveBeenCalled()
     span.end()
@@ -432,7 +432,7 @@ describe('TransactionService', function() {
     spyOn(tr1, 'end')
 
     const span1 = transactionService.startSpan('blocked-span', 'custom', {
-      blocked: true
+      blocking: true
     })
     expect(tr1.addTask).toHaveBeenCalled()
     expect(tr2.addTask).not.toHaveBeenCalled()

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -101,12 +101,10 @@ describe('TransactionService', function() {
       return r
     }
     spyOn(result, 'onEnd').and.callThrough()
-    transactionService.addTask('task1')
-    var span = transactionService.startSpan('test', 'test')
-    span.end()
+    var span = transactionService.startSpan('test', 'test', { blocked: true })
     result.detectFinish()
     expect(result.onEnd).not.toHaveBeenCalled()
-    transactionService.removeTask('task1')
+    span.end()
     expect(result.onEnd).toHaveBeenCalled()
   })
 
@@ -399,10 +397,7 @@ describe('TransactionService', function() {
     const tr1 = transactionService.startTransaction('test-name', 'test-type')
     expect(tr1.name).toBe('test-name')
     expect(transactionService.currentTransaction).toBeUndefined()
-    spyOn(tr1, 'removeTask')
     spyOn(tr1, 'startSpan')
-    transactionService.removeTask('testId')
-    expect(tr1.removeTask).not.toHaveBeenCalled()
     transactionService.startSpan('test-name', 'test-type')
     expect(tr1.startSpan).not.toHaveBeenCalled()
     expect(tr1.spans.length).toBe(0)
@@ -435,12 +430,15 @@ describe('TransactionService', function() {
     spyOn(tr1, 'addTask').and.callThrough()
     spyOn(tr1, 'removeTask').and.callThrough()
     spyOn(tr1, 'end')
-    transactionService.addTask('taskId')
-    expect(tr1.addTask).toHaveBeenCalledWith('taskId')
-    expect(tr2.addTask).not.toHaveBeenCalled()
 
-    transactionService.removeTask('taskId')
-    expect(tr1.removeTask).toHaveBeenCalledWith('taskId')
+    const span1 = transactionService.startSpan('blocked-span', 'custom', {
+      blocked: true
+    })
+    expect(tr1.addTask).toHaveBeenCalled()
+    expect(tr2.addTask).not.toHaveBeenCalled()
+    span1.end()
+    expect(tr1.spans.length).toBe(2)
+    expect(tr1.removeTask).toHaveBeenCalled()
     expect(tr1.end).toHaveBeenCalled()
     expect(tr2.removeTask).not.toHaveBeenCalled()
     expect(tr2.end).not.toHaveBeenCalled()

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -26,7 +26,7 @@
 import Transaction from '../../src/performance-monitoring/transaction'
 import Span from '../../src/performance-monitoring/span'
 
-describe('transaction.Transaction', function() {
+describe('Transaction', function() {
   it('should contain correct number of spans in the end', function(done) {
     var firstSpan = new Span('first-span-name', 'first-span')
     firstSpan.end()
@@ -89,7 +89,7 @@ describe('transaction.Transaction', function() {
 
   it('should create task only for blocked spans', () => {
     const tr = new Transaction('/', 'transaction')
-    const span1 = tr.startSpan('span1', 'custom', { blocked: true })
+    const span1 = tr.startSpan('span1', 'custom', { blocking: true })
     const span2 = tr.startSpan('span2', 'custom')
 
     expect(tr._activeTasks.size).toBe(1)
@@ -97,6 +97,19 @@ describe('transaction.Transaction', function() {
     span2.end()
     expect(tr._activeTasks.size).toBe(0)
     expect(tr.spans.length).toBe(2)
+  })
+
+  it('should support blocking and unblocking transaction', () => {
+    const tr = new Transaction('/', 'transaction')
+    spyOn(tr, 'end').and.callThrough()
+
+    tr.block(true)
+    expect(tr.blocked).toBe(true)
+    tr.detectFinish()
+    expect(tr.end).not.toHaveBeenCalled()
+
+    tr.block(false)
+    expect(tr.end).toHaveBeenCalled()
   })
 
   it('should mark events', function() {

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -70,19 +70,21 @@ describe('transaction.Transaction', function() {
 
   it('should add and remove tasks', function() {
     var tr = new Transaction('/', 'transaction')
-    expect(tr._scheduledTasks).toEqual([])
+    expect(tr._activeTasks.size).toEqual(0)
     tr.addTask()
-    expect(tr._scheduledTasks).toEqual(['task1'])
+    expect(tr._activeTasks).toContain('task1')
     tr.addTask('task2')
-    expect(tr._scheduledTasks).toEqual(['task1', 'task2'])
+    expect(tr._activeTasks).toContain('task2')
     tr.removeTask('task1')
+    expect(tr._activeTasks.size).toEqual(1)
     tr.addTask('my-task')
-    expect(tr._scheduledTasks).toEqual(['task2', 'my-task'])
+    expect(tr._activeTasks).toContain('my-task')
+    expect(tr._activeTasks.size).toEqual(2)
+    tr.addTask('my-task')
+    expect(tr._activeTasks.size).toEqual(2)
     tr.removeTask('task2')
-    tr.addTask('my-task')
-    expect(tr._scheduledTasks).toEqual(['my-task'])
     tr.removeTask('my-task')
-    expect(tr._scheduledTasks).toEqual([])
+    expect(tr._activeTasks.size).toEqual(0)
   })
 
   it('should mark events', function() {

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -71,11 +71,11 @@ describe('transaction.Transaction', function() {
   it('should add and remove tasks', function() {
     var tr = new Transaction('/', 'transaction')
     expect(tr._activeTasks.size).toEqual(0)
-    tr.addTask()
-    expect(tr._activeTasks).toContain('task1')
+    const task1 = tr.addTask()
+    expect(tr._activeTasks).toContain(task1)
     tr.addTask('task2')
     expect(tr._activeTasks).toContain('task2')
-    tr.removeTask('task1')
+    tr.removeTask(task1)
     expect(tr._activeTasks.size).toEqual(1)
     tr.addTask('my-task')
     expect(tr._activeTasks).toContain('my-task')
@@ -85,6 +85,18 @@ describe('transaction.Transaction', function() {
     tr.removeTask('task2')
     tr.removeTask('my-task')
     expect(tr._activeTasks.size).toEqual(0)
+  })
+
+  it('should create task only for blocked spans', () => {
+    const tr = new Transaction('/', 'transaction')
+    const span1 = tr.startSpan('span1', 'custom', { blocked: true })
+    const span2 = tr.startSpan('span2', 'custom')
+
+    expect(tr._activeTasks.size).toBe(1)
+    span1.end()
+    span2.end()
+    expect(tr._activeTasks.size).toBe(0)
+    expect(tr.spans.length).toBe(2)
   })
 
   it('should mark events', function() {

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -153,10 +153,10 @@ export default class ApmBase {
       return
     }
 
-    tr.addTask(PAGE_LOAD)
+    tr.block(true)
     const sendPageLoadMetrics = () => {
       // to make sure PerformanceTiming.loadEventEnd has a value
-      setTimeout(() => tr.removeTask(PAGE_LOAD))
+      setTimeout(() => tr.block(false))
     }
 
     if (document.readyState === 'complete') {

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -149,16 +149,14 @@ export default class ApmBase {
       canReuse: true
     })
 
-    if (tr) {
-      tr.addTask(PAGE_LOAD)
+    if (!tr) {
+      return
     }
-    const sendPageLoadMetrics = function sendPageLoadMetrics() {
+
+    tr.addTask(PAGE_LOAD)
+    const sendPageLoadMetrics = () => {
       // to make sure PerformanceTiming.loadEventEnd has a value
-      setTimeout(function() {
-        if (tr) {
-          tr.removeTask(PAGE_LOAD)
-        }
-      })
+      setTimeout(() => tr.removeTask(PAGE_LOAD))
     }
 
     if (document.readyState === 'complete') {

--- a/packages/rum/test/e2e/standalone-html/opentracing.js
+++ b/packages/rum/test/e2e/standalone-html/opentracing.js
@@ -37,6 +37,6 @@ window.elasticApm.init({
 
 const tracer = window.elasticApm.createTracer()
 const span = tracer.startSpan('Opentracing span')
-span.finish(Date.now() + 100)
+span && span.finish(Date.now() + 100)
 
 testXHR(mockBackendUrl, renderTestElement)


### PR DESCRIPTION
+ fixes #841 
+ Improves upon the work that is already on the original PR #194 
+ Adds an option `blocking` to the `startSpan` method that keeps the transaction open and allow controlling the behaviour of all managed transactions created by the agent itself through auto instrumentation or through user. 
+ Added `transaction.block(true)` method which can be used to control the closing of managed transactions. 
+ Added documentation on the custom transactions part with unmanaged and managed transactions. 