### PR TITLE
feat(rum-core): support ignore error

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -75,6 +75,7 @@ class Config {
       logLevel: 'warn',
       breakdownMetrics: false,
       ignoreTransactions: [],
+      ignoreErrors: [],
       eventsLimit: 80,
       queueLimit: -1,
       flushInterval: 500,

--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -154,11 +154,31 @@ class ErrorLogging {
       return
     }
     var errorObject = this.createErrorDataModel(errorEvent)
-    if (typeof errorObject.exception.message === 'undefined') {
+    if (
+      typeof errorObject.exception.message === 'undefined' ||
+      this.shouldIgnoreError(errorObject.exception.message)
+    ) {
       return
     }
 
     this._apmServer.addError(errorObject)
+  }
+
+  shouldIgnoreError(errorMessage) {
+    const ignoreList = this._configService.get('ignoreErrors')
+    if (ignoreList && ignoreList.length) {
+      for (let i = 0; i < ignoreList.length; i++) {
+        const element = ignoreList[i]
+        if (typeof element.test === 'function') {
+          if (element.test(errorMessage)) {
+            return true
+          }
+        } else if (element === errorMessage) {
+          return true
+        }
+      }
+    }
+    return false
   }
 
   registerListeners() {

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -458,4 +458,24 @@ describe('ErrorLogging', function() {
       .then(done)
       .catch(reason => fail(reason))
   })
+
+  it('should ignore error', function() {
+    apmServer.init()
+    configService.setConfig({
+      serviceName: 'serviceName',
+      ignoreErrors: [/ignore*/, 'some error']
+    })
+    spyOn(apmServer, 'sendEvents')
+    try {
+      throw new Error('ignore error')
+    } catch (error) {
+      errorLogging.logErrorEvent({ error })
+      errorLogging.logErrorEvent({ error })
+      errorLogging.logError(error)
+      errorLogging.logError('some error')
+      errorLogging.logError('test error')
+      expect(apmServer.sendEvents).not.toHaveBeenCalled()
+      expect(apmServer.queue.items.length).toBe(1)
+    }
+  })
 })


### PR DESCRIPTION
* The purpose of this pull request is to support ignoring some errors. In my project, I can safely ignore some errors, such as [https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded),but apm agent will report all errors.
I noticed that apm agent config has ignoreTransactions, Hope to add ignoreErrors.
