### PR TITLE
fix(rum): use noop tracer on unsupported platforms

### DIFF
--- a/packages/rum/src/opentracing.js
+++ b/packages/rum/src/opentracing.js
@@ -24,9 +24,17 @@
  */
 
 import { init, apm, apmBase, ApmBase } from './index'
+import { Tracer } from 'opentracing/lib/tracer'
 import { createTracer as createElasticTracer } from '@elastic/apm-rum-core'
 
 function createTracer(apmBase) {
+  /**
+   * If the platform is not supported, return
+   * the default tracer from OT
+   */
+  if (apmBase._disable) {
+    return new Tracer()
+  }
   return createElasticTracer(apmBase.serviceFactory)
 }
 

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -43,7 +43,7 @@ const elasticApm = createApmBase({
 
 const tracer = createTracer(elasticApm)
 const otSpan = tracer.startSpan('OpenTracing span')
-otSpan.finish(Date.now() + 200)
+otSpan && otSpan.finish(Date.now() + 200)
 
 elasticApm.setInitialPageLoadName('general-usecase-initial-page-load')
 


### PR DESCRIPTION
+ This is a bug that was captured while doing tests in failsafe browsers. 
+ On IE 10, we still create transactions from the OT tracer API which is not correct and should be a Noop. 
Blocks the other PR #866 