### PR TITLE
fix(rum-core): capture xhr error states in transaction

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -28,7 +28,6 @@
  */
 const SCHEDULE = 'schedule'
 const INVOKE = 'invoke'
-const CLEAR = 'clear'
 
 /**
  * Event listener methods
@@ -156,7 +155,6 @@ const KEYWORD_LIMIT = 1024
 export {
   SCHEDULE,
   INVOKE,
-  CLEAR,
   ADD_EVENT_LISTENER_STR,
   REMOVE_EVENT_LISTENER_STR,
   RESOURCE_INITIATOR_TYPES,

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -24,128 +24,80 @@
  */
 
 import {
-  apmSymbol,
   patchMethod,
   XHR_SYNC,
   XHR_URL,
   XHR_METHOD,
   XHR_IGNORE
 } from './patch-utils'
-
-import { scheduleMacroTask } from '../utils'
-
 import {
   SCHEDULE,
   INVOKE,
-  CLEAR,
   XMLHTTPREQUEST,
-  ADD_EVENT_LISTENER_STR,
-  REMOVE_EVENT_LISTENER_STR
+  ADD_EVENT_LISTENER_STR
 } from '../constants'
-
-const XHR_TASK = apmSymbol('xhrTask')
-const XHR_LISTENER = apmSymbol('xhrListener')
-const XHR_SCHEDULED = apmSymbol('xhrScheduled')
 
 export function patchXMLHttpRequest(callback) {
   const XMLHttpRequestPrototype = XMLHttpRequest.prototype
 
   let oriAddListener = XMLHttpRequestPrototype[ADD_EVENT_LISTENER_STR]
-  let oriRemoveListener = XMLHttpRequestPrototype[REMOVE_EVENT_LISTENER_STR]
   if (!oriAddListener) {
-    const XMLHttpRequestEventTarget = window['XMLHttpRequestEventTarget']
-    if (XMLHttpRequestEventTarget) {
-      const XMLHttpRequestEventTargetPrototype =
-        XMLHttpRequestEventTarget.prototype
-      oriAddListener =
-        XMLHttpRequestEventTargetPrototype[ADD_EVENT_LISTENER_STR]
-      oriRemoveListener =
-        XMLHttpRequestEventTargetPrototype[REMOVE_EVENT_LISTENER_STR]
-    }
+    return
   }
 
   const READY_STATE_CHANGE = 'readystatechange'
-  const LOAD = 'load'
+  const ERROR = 'error'
+  const TIMEOUT = 'timeout'
+  const ABORT = 'abort'
 
-  function invokeTask(task) {
-    task.state = INVOKE
-    callback(INVOKE, task)
+  function invokeTask(task, status) {
+    /**
+     * On some browsers XMLHttpRequest will fire onreadystatechange with
+     * readyState=4 multiple times, so we need to check task state and
+     * not invoke tasks multiple times
+     */
+    if (task.state !== INVOKE) {
+      task.state = INVOKE
+      task.data.status = status
+      callback(INVOKE, task)
+    }
   }
 
   function scheduleTask(task) {
-    XMLHttpRequest[XHR_SCHEDULED] = false
+    if (task.state === SCHEDULE) {
+      return
+    }
     task.state = SCHEDULE
     callback(SCHEDULE, task)
 
-    const { aborted, target } = task.data
-    if (!oriAddListener) {
-      oriAddListener = target[ADD_EVENT_LISTENER_STR]
-      oriRemoveListener = target[REMOVE_EVENT_LISTENER_STR]
-    }
+    const { target } = task.data
 
-    // remove existing event listener
-    const listener = target[XHR_LISTENER]
-    if (listener) {
-      oriRemoveListener.call(target, READY_STATE_CHANGE, listener)
-      oriRemoveListener.call(target, LOAD, listener)
-    }
-
-    let earlierEvent
-    const newListener = (target[XHR_LISTENER] = ({ type }) => {
-      /**
-       * In certain frameworks (e.g. angular/http) the http request is aborted
-       * as soon as it completes, and that causes the state of the XHR to change.
-       * See https://github.com/angular/angular/issues/33822 for more.
-       */
-      if (earlierEvent) {
-        if (earlierEvent != type) {
-          scheduleMacroTask(() => {
-            /**
-             * This check is necessary since the readystatechange event can be fired
-             * multiple times (e.g. in IE) and since we schedule a macro task
-             * to invoke the task, we need to make sure that we don't invoke
-             * the task multiple times.
-             */
-            if (task.state !== INVOKE) {
-              invokeTask(task)
-            }
-          })
-        }
-      } else {
-        if (target.readyState === target.DONE) {
-          /**
-           * On some browsers XMLHttpRequest will fire onreadystatechange with
-           * readyState=4 multiple times, so we need to check task state here
-           */
-          if (
-            !aborted &&
-            XMLHttpRequest[XHR_SCHEDULED] &&
-            task.state === SCHEDULE
-          ) {
-            earlierEvent = type
+    function addListener(name) {
+      target.addEventListener(name, ({ type }) => {
+        /**
+         * Invoke task when the request is completed and when the status is non-zero,
+         * denoting the request was aborted, timed out or errored which is handled in
+         * else block
+         */
+        if (type === READY_STATE_CHANGE) {
+          if (target.readyState === 4 && target.status !== 0) {
+            invokeTask(task, 'success')
           }
+        } else {
+          invokeTask(task, type)
         }
-      }
-    })
-    /**
-     * Register event listeners for readystatechange and load events
-     */
-    oriAddListener.call(target, READY_STATE_CHANGE, newListener)
-    oriAddListener.call(target, LOAD, newListener)
-
-    const storedTask = target[XHR_TASK]
-    if (!storedTask) {
-      target[XHR_TASK] = task
+      })
     }
-  }
 
-  function clearTask(task) {
-    task.state = CLEAR
-    callback(CLEAR, task)
-    const data = task.data
-    // Note - ideally, we would call data.target.removeEventListener here, but it's too late
-    // to prevent it from firing. So instead, we store info for the event listener.
-    data.aborted = true
+    /**
+     * Register event listeners for the current request
+     * We do not need to clear these listeners are the request object
+     * is garbage collected once its done
+     */
+    addListener(READY_STATE_CHANGE)
+    addListener(TIMEOUT)
+    addListener(ERROR)
+    addListener(ABORT)
   }
 
   const openNative = patchMethod(
@@ -180,35 +132,20 @@ export function patchXMLHttpRequest(callback) {
             method: self[XHR_METHOD],
             sync: self[XHR_SYNC],
             url: self[XHR_URL],
-            aborted: false
+            status: ''
           }
         }
-        scheduleTask(task)
-        const result = sendNative.apply(self, args)
-        XMLHttpRequest[XHR_SCHEDULED] = true
-        if (self[XHR_SYNC]) {
-          invokeTask(task)
+        try {
+          scheduleTask(task)
+          return sendNative.apply(self, args)
+        } catch (e) {
+          /**
+           * catch errors from Synchronous XHR when it fails to
+           * load the URL or request is aborted
+           */
+          invokeTask(task, ERROR)
+          throw e
         }
-        return result
-      }
-  )
-
-  const abortNative = patchMethod(
-    XMLHttpRequestPrototype,
-    'abort',
-    () =>
-      function(self, args) {
-        if (!self[XHR_IGNORE]) {
-          const task = self[XHR_TASK]
-          if (task && typeof task.type === 'string') {
-            // If the XHR has already been aborted, do nothing.
-            if (task.data && task.data.aborted) {
-              return
-            }
-            clearTask(task)
-          }
-        }
-        return abortNative.apply(self, args)
       }
   )
 }

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -50,6 +50,7 @@ export function patchXMLHttpRequest(callback) {
   }
 
   const READY_STATE_CHANGE = 'readystatechange'
+  const LOAD = 'load'
   const ERROR = 'error'
   const TIMEOUT = 'timeout'
   const ABORT = 'abort'
@@ -88,7 +89,8 @@ export function patchXMLHttpRequest(callback) {
             invokeTask(task, 'success')
           }
         } else {
-          invokeTask(task, type)
+          const status = type === LOAD ? 'success' : type
+          invokeTask(task, status)
         }
       })
     }
@@ -99,6 +101,7 @@ export function patchXMLHttpRequest(callback) {
      * is garbage collected once its done
      */
     addListener(READY_STATE_CHANGE)
+    addListener(LOAD)
     addListener(TIMEOUT)
     addListener(ERROR)
     addListener(ABORT)

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -39,9 +39,13 @@ import {
 
 export function patchXMLHttpRequest(callback) {
   const XMLHttpRequestPrototype = XMLHttpRequest.prototype
-
-  let oriAddListener = XMLHttpRequestPrototype[ADD_EVENT_LISTENER_STR]
-  if (!oriAddListener) {
+  /**
+   * Handle if the XMLHttpRequest object is patched on the page
+   */
+  if (
+    !XMLHttpRequestPrototype ||
+    !XMLHttpRequestPrototype[ADD_EVENT_LISTENER_STR]
+  ) {
     return
   }
 
@@ -73,7 +77,7 @@ export function patchXMLHttpRequest(callback) {
     const { target } = task.data
 
     function addListener(name) {
-      target.addEventListener(name, ({ type }) => {
+      target[ADD_EVENT_LISTENER_STR](name, ({ type }) => {
         /**
          * Invoke task when the request is completed and when the status is non-zero,
          * denoting the request was aborted, timed out or errored which is handled in

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -83,7 +83,6 @@ export function patchXMLHttpRequest(callback) {
          * denoting the request was aborted, timed out or errored which is handled in
          * else block
          */
-        console.log('XHR', type, target.readyState, target.status)
         if (type === READY_STATE_CHANGE) {
           if (target.readyState === 4 && target.status !== 0) {
             invokeTask(task, 'success')

--- a/packages/rum-core/src/common/patching/xhr-patch.js
+++ b/packages/rum-core/src/common/patching/xhr-patch.js
@@ -83,6 +83,7 @@ export function patchXMLHttpRequest(callback) {
          * denoting the request was aborted, timed out or errored which is handled in
          * else block
          */
+        console.log('XHR', type, target.readyState, target.status)
         if (type === READY_STATE_CHANGE) {
           if (target.readyState === 4 && target.status !== 0) {
             invokeTask(task, 'success')

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -23,21 +23,19 @@
  *
  */
 
+import patchEventHandler from './patch'
 import {
   XHR_IGNORE,
   XHR_METHOD,
-  XHR_URL
+  XHR_URL,
+  XHR_SYNC
 } from '../../src/common/patching/patch-utils'
-
-import { scheduleMacroTask } from '../../src/common/utils'
-import patchEventHandler from './patch'
 import { XMLHTTPREQUEST } from '../../src/common/constants'
-import { scheduleTaskCycles } from '../'
 
 function registerEventListener(target) {
-  let events = []
+  const events = []
 
-  let cancelFn = patchEventHandler.observe(XMLHTTPREQUEST, function(
+  const cancelFn = patchEventHandler.observe(XMLHTTPREQUEST, function(
     event,
     task
   ) {
@@ -53,7 +51,7 @@ function registerEventListener(target) {
     if (done) {
       cancelFn()
       if (typeof done === 'function') {
-        scheduleMacroTask(done)
+        done()
       }
     }
     return events
@@ -66,11 +64,12 @@ describe('xhrPatch', function() {
     return event
   }
 
-  it('should have correct url and method', function() {
+  it('should register symbols for url, sync and method', function() {
     var req = new window.XMLHttpRequest()
     req.open('GET', '/', true)
     expect(req[XHR_URL]).toBe('/')
     expect(req[XHR_METHOD]).toBe('GET')
+    expect(req[XHR_SYNC]).toBe(false)
   })
 
   it('should produce events', function(done) {
@@ -78,39 +77,36 @@ describe('xhrPatch', function() {
     let getEvents = registerEventListener(req)
     req.open('GET', '/', true)
     req.addEventListener('load', function() {
-      scheduleTaskCycles(() => {
-        expect(getEvents().map(mapEvent)).toEqual([
-          {
-            event: 'schedule',
-            task: {
-              source: XMLHTTPREQUEST,
-              state: 'invoke',
-              type: 'macroTask',
-              data: {
-                method: 'GET',
-                url: '/',
-                sync: false,
-                aborted: false
-              }
-            }
-          },
-          {
-            event: 'invoke',
-            task: {
-              source: XMLHTTPREQUEST,
-              state: 'invoke',
-              type: 'macroTask',
-              data: {
-                method: 'GET',
-                url: '/',
-                sync: false,
-                aborted: false
-              }
+      expect(getEvents(done).map(mapEvent)).toEqual([
+        {
+          event: 'schedule',
+          task: {
+            source: XMLHTTPREQUEST,
+            state: 'invoke',
+            type: 'macroTask',
+            data: {
+              method: 'GET',
+              url: '/',
+              sync: false,
+              status: 'success'
             }
           }
-        ])
-        getEvents(done)
-      }, 2)
+        },
+        {
+          event: 'invoke',
+          task: {
+            source: XMLHTTPREQUEST,
+            state: 'invoke',
+            type: 'macroTask',
+            data: {
+              method: 'GET',
+              url: '/',
+              sync: false,
+              status: 'success'
+            }
+          }
+        }
+      ])
     })
 
     req.send()
@@ -122,20 +118,53 @@ describe('xhrPatch', function() {
     req.open('GET', '/', false)
 
     req.send()
-    expect(getEvents().map(e => e.event)).toEqual(['schedule', 'invoke'])
+    expect(getEvents(true).map(e => e.event)).toEqual(['schedule', 'invoke'])
   })
 
-  it('should work with failing xhr', function(done) {
+  it('should correctly schedule events when sync xhr fails', function() {
+    const req = new window.XMLHttpRequest()
+    const getEvents = registerEventListener(req)
+    try {
+      req.open('GET', 'http://somewhere.org/does-not-exist', false)
+      req.send()
+    } catch (e) {
+      expect(
+        getEvents(true).map(e => ({
+          event: e.event,
+          status: e.task.data.status
+        }))
+      ).toEqual([
+        { event: 'schedule', status: 'error' },
+        { event: 'invoke', status: 'error' }
+      ])
+    }
+  })
+
+  it('should schedule events correctly for 404', function(done) {
     var req = new window.XMLHttpRequest()
     let getEvents = registerEventListener(req)
     req.open('GET', '/test.json', true)
-    req.addEventListener('load', function() {
-      scheduleTaskCycles(() => {
-        expect(getEvents(done).map(e => e.event)).toEqual([
-          'schedule',
-          'invoke'
-        ])
-      }, 2)
+    req.addEventListener('load', () => {
+      expect(getEvents(done).map(e => e.event)).toEqual(['schedule', 'invoke'])
+    })
+
+    req.send()
+  })
+
+  it('should schedule events correctly for CORS requests', function(done) {
+    var req = new window.XMLHttpRequest()
+    let getEvents = registerEventListener(req)
+    req.open('GET', 'https://elastic.co', true)
+    req.addEventListener('loadend', () => {
+      expect(
+        getEvents(done).map(e => ({
+          event: e.event,
+          status: e.task.data.status
+        }))
+      ).toEqual([
+        { event: 'schedule', status: 'error' },
+        { event: 'invoke', status: 'error' }
+      ])
     })
 
     req.send()
@@ -143,31 +172,34 @@ describe('xhrPatch', function() {
 
   it('should work with aborted xhr', function() {
     var req = new XMLHttpRequest()
-    let getEvents = registerEventListener(req)
+    const getEvents = registerEventListener(req)
     req.open('GET', '/', true)
-
     req.send()
     req.abort()
-    expect(getEvents(true).map(e => e.event)).toEqual(['schedule', 'clear'])
+
+    expect(
+      getEvents(true).map(e => ({ event: e.event, status: e.task.data.status }))
+    ).toEqual([
+      { event: 'schedule', status: 'abort' },
+      { event: 'invoke', status: 'abort' }
+    ])
   })
 
   it('should work properly when send request multiple times on single xmlRequest instance', function(done) {
     const req = new XMLHttpRequest()
-    let getEvents = registerEventListener(req)
+    const getEvents = registerEventListener(req)
     req.open('get', '/?multiple1', true)
     req.send()
     req.onload = function() {
       req.onload = null
       req.open('get', '/?multiple2', true)
       req.onload = function() {
-        scheduleTaskCycles(() => {
-          expect(getEvents(done).map(e => e.event)).toEqual([
-            'schedule',
-            'schedule',
-            'invoke',
-            'invoke'
-          ])
-        }, 2)
+        expect(getEvents(done).map(e => e.event)).toEqual([
+          'schedule',
+          'invoke',
+          'schedule',
+          'invoke'
+        ])
       }
       expect(() => {
         req.send()
@@ -183,8 +215,9 @@ describe('xhrPatch', function() {
     expect(XMLHttpRequest.DONE).toEqual(4)
   })
 
-  it('should work correctly when abort was called multiple times before request is done', function(done) {
+  it('should work correctly when abort was called before request is completed', function(done) {
     const req = new XMLHttpRequest()
+    const getEvents = registerEventListener(req)
     req.open('get', '/', true)
     req.send()
     req.addEventListener('readystatechange', function() {
@@ -192,33 +225,20 @@ describe('xhrPatch', function() {
         expect(() => {
           req.abort()
         }).not.toThrow()
-        done()
       }
     })
-  })
 
-  it('should return null when access ontimeout first time without error', function() {
-    let req = new XMLHttpRequest()
-    expect(req.ontimeout).toBe(null)
-  })
-
-  it('should allow aborting an XMLHttpRequest after its completed', function(done) {
-    let req
-
-    req = new XMLHttpRequest()
-    req.onreadystatechange = function() {
-      if (req.readyState === XMLHttpRequest.DONE) {
-        if (req.status !== 0) {
-          setTimeout(function() {
-            req.abort()
-            done()
-          }, 0)
-        }
-      }
-    }
-    req.open('get', '/', true)
-
-    req.send()
+    req.addEventListener('abort', () => {
+      expect(
+        getEvents(done).map(e => ({
+          event: e.event,
+          status: e.task.data.status
+        }))
+      ).toEqual([
+        { event: 'schedule', status: 'abort' },
+        { event: 'invoke', status: 'abort' }
+      ])
+    })
   })
 
   it('should preserve other setters', done => {
@@ -233,15 +253,6 @@ describe('xhrPatch', function() {
       // Android browser: using this setter throws, this should be preserved
       expect(e.message).toBe('INVALID_STATE_ERR: DOM Exception 11')
     }
-  })
-
-  it('should not throw error when get XMLHttpRequest.prototype.onreadystatechange the first time', function() {
-    const func = function() {
-      const req = new XMLHttpRequest()
-      // eslint-disable-next-line
-      req.onreadystatechange
-    }
-    expect(func).not.toThrow()
   })
 
   it('should not create events and pollute xhr when ignore flag is true', function(done) {
@@ -260,39 +271,14 @@ describe('xhrPatch', function() {
   })
 
   it('should consider load events registered on XHR', done => {
-    var req = new window.XMLHttpRequest()
-    let getEvents = registerEventListener(req)
+    const req = new window.XMLHttpRequest()
+    const getEvents = registerEventListener(req)
     req.open('GET', '/?loadtest')
-
-    var earlierEvent = false
-    function checkEvents() {
-      if (earlierEvent) {
-        expect(getEvents().map(e => e.event)).toEqual(['schedule'])
-
-        scheduleTaskCycles(() => {
-          expect(getEvents(done).map(e => e.event)).toEqual([
-            'schedule',
-            'invoke'
-          ])
-        }, 2)
-      } else {
-        expect(getEvents().map(e => e.event)).toEqual(['schedule'])
-        earlierEvent = true
-      }
-    }
-
-    req.addEventListener('readystatechange', () => {
-      if (req.readyState === req.DONE) {
-        checkEvents()
-      }
-    })
-    req.addEventListener('load', function() {
-      checkEvents()
-    })
 
     req.send()
     req.addEventListener('load', function() {
-      expect(getEvents().map(e => e.event)).toEqual(['schedule'])
+      expect(getEvents(done).map(e => e.event)).toEqual(['schedule', 'invoke'])
+      done()
     })
     expect(getEvents().map(e => e.event)).toEqual(['schedule'])
   })

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -121,7 +121,7 @@ describe('xhrPatch', function() {
     expect(getEvents(true).map(e => e.event)).toEqual(['schedule', 'invoke'])
   })
 
-  it('should correctly schedule events when sync xhr fails', function(done) {
+  it('should correctly schedule events when sync xhr fails', function() {
     const req = new window.XMLHttpRequest()
     const getEvents = registerEventListener(req)
     try {
@@ -129,7 +129,7 @@ describe('xhrPatch', function() {
       req.send()
     } catch (e) {
       expect(
-        getEvents(done).map(e => ({
+        getEvents(true).map(e => ({
           event: e.event,
           status: e.task.data.status
         }))

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -186,12 +186,21 @@ describe('xhrPatch', function() {
     ])
   })
 
+  it('should schedule events correctly for CORS requests', function(done) {
+    const req = new window.XMLHttpRequest()
+    const getEvents = registerEventListener(req)
+    req.open('GET', 'https://elastic.co/guide', true)
+    req.addEventListener('loadend', () => {
+      expect(getEvents(done).map(e => e.event)).toEqual(['schedule', 'invoke'])
+    })
+    req.send()
+  })
+
   it('should capture events correctly for timeouts', function(done) {
     const req = new XMLHttpRequest()
     const getEvents = registerEventListener(req)
-    req.timeout = 1
     req.open('GET', '/timeout', true)
-
+    req.timeout = 1
     req.addEventListener('loadend', () => {
       expect(
         getEvents(done).map(e => ({
@@ -203,7 +212,6 @@ describe('xhrPatch', function() {
         { event: 'invoke', status: 'timeout' }
       ])
     })
-
     req.send()
   })
 

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -154,8 +154,8 @@ describe('xhrPatch', function() {
   it('should schedule events correctly for CORS requests', function(done) {
     var req = new window.XMLHttpRequest()
     let getEvents = registerEventListener(req)
-    req.open('GET', 'https://elastic.co', true)
-    req.withCredentials = true
+    // This page has CSP headers set to same origin
+    req.open('GET', 'https://elastic.co/guide', true)
     req.addEventListener('loadend', () => {
       expect(
         getEvents(done).map(e => ({

--- a/packages/rum-core/test/index.js
+++ b/packages/rum-core/test/index.js
@@ -26,7 +26,6 @@
 import { createServiceFactory as originalFactory } from '../src'
 import Transaction from '../src/performance-monitoring/transaction'
 import { captureBreakdown } from '../src/performance-monitoring/breakdown'
-import { scheduleMacroTask } from '../src/common/utils'
 
 export function createServiceFactory() {
   var serviceFactory = originalFactory()
@@ -37,14 +36,6 @@ export function createServiceFactory() {
     }
   }
   return serviceFactory
-}
-
-export function scheduleTaskCycles(callback, cycles = 0) {
-  if (cycles > 0) {
-    scheduleMacroTask(scheduleTaskCycles.bind(this, callback, cycles - 1))
-  } else {
-    callback()
-  }
 }
 
 /**

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -452,11 +452,11 @@ describe('PerformanceMonitoring', function() {
             },
             {
               event: 'invoke',
-              source: FETCH
+              source: XMLHTTPREQUEST
             },
             {
               event: 'invoke',
-              source: XMLHTTPREQUEST
+              source: FETCH
             }
           ])
           cancelXHRSub()

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -153,10 +153,10 @@ export default class ApmBase {
       return
     }
 
-    tr.block(true)
+    tr.addTask(PAGE_LOAD)
     const sendPageLoadMetrics = () => {
       // to make sure PerformanceTiming.loadEventEnd has a value
-      setTimeout(() => tr.block(false))
+      setTimeout(() => tr.removeTask(PAGE_LOAD))
     }
 
     if (document.readyState === 'complete') {

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -32,7 +32,6 @@ import {
 import { TRANSACTION_END } from '@elastic/apm-rum-core/src/common/constants'
 import { getGlobalConfig } from '../../../../dev-utils/test-config'
 import Promise from 'promise-polyfill'
-import { scheduleTaskCycles } from '../../../rum-core/test'
 
 var enabled = bootstrap()
 const { serviceName, serverUrl } = getGlobalConfig('rum').agentConfig
@@ -209,11 +208,9 @@ describe('ApmBase', function() {
     var req = new window.XMLHttpRequest()
     req.open('GET', '/', true)
     req.addEventListener('load', function() {
-      scheduleTaskCycles(() => {
-        expect(tr.spans.length).toBe(1)
-        expect(tr.spans[0].name).toBe('GET /')
-        done()
-      }, 2)
+      expect(tr.spans.length).toBe(1)
+      expect(tr.spans[0].name).toBe('GET /')
+      done()
     })
 
     req.send()
@@ -231,11 +228,9 @@ describe('ApmBase', function() {
     var req = new window.XMLHttpRequest()
     req.open('GET', '/', true)
     req.addEventListener('load', function() {
-      scheduleTaskCycles(() => {
-        expect(tr.spans.length).toBe(1)
-        expect(tr.spans[0].name).toBe('GET /')
-        done()
-      }, 2)
+      expect(tr.spans.length).toBe(1)
+      expect(tr.spans[0].name).toBe('GET /')
+      done()
     })
     req.send()
     tr = apmBase.getCurrentTransaction()
@@ -257,7 +252,7 @@ describe('ApmBase', function() {
          * We patch and register symbols on the native XHR with
          * our own APM symbol keys
          */
-        expect(Object.keys(req).length).toBeGreaterThanOrEqual(5)
+        expect(Object.keys(req).length).toBeGreaterThanOrEqual(3)
         done()
       })
     })


### PR DESCRIPTION
+ fix #871 
+ fix #864 
+ PR improves our XHR instrumentation code to account for abort, timeout and error states that happen in both the async and sync XHR implementations. Also it fixes the bug that causes the transaction to not get ended since we have not handled the cases before. 
    - XHR being aborted
    - XHR being timedout
    - CORS error
    - URL being down - Both Sync and Async
 I have added tests for all cases to ensure they are covered. 
+ The timing information of the XHR would also be in sync with the resource timing Info as we don't schedule any macro task to for the auto instrumented XHR to get ended.
+ Confirmed with the Angular APP, this PR fixes the problem exposed in #864 as the macro task scheduling logic is gone and we correctly measure the real timings. 

### NOTE

+ We don't schedule macro-tasks for the XHR closing as it creates timing issues like this #864 and its not a good default behaviour, so we instead rely on our blocking API #866 that provides necessary abstractions to work around the transaction being closed too early problem instead of showing wrong numbers. 