### PR TITLE
perf(rum-core): avoid creating options when transaction exists

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -76,9 +76,9 @@ class TransactionService {
     })
   }
 
-  ensureCurrentTransaction(name, type, options) {
+  createCurrentTransaction(name, type, options) {
     const tr = new Transaction(name, type, options)
-    this.setCurrentTransaction(tr)
+    this.currentTransaction = tr
     return tr
   }
 
@@ -86,10 +86,6 @@ class TransactionService {
     if (this.currentTransaction && !this.currentTransaction.ended) {
       return this.currentTransaction
     }
-  }
-
-  setCurrentTransaction(value) {
-    this.currentTransaction = value
   }
 
   createOptions(options) {
@@ -114,7 +110,7 @@ class TransactionService {
     let tr = this.getCurrentTransaction()
     let isRedefined = false
     if (!tr) {
-      tr = this.ensureCurrentTransaction(name, type, perfOptions)
+      tr = this.createCurrentTransaction(name, type, perfOptions)
     } else if (tr.canReuse() && perfOptions.canReuse) {
       /*
        * perfOptions could also have `canReuse:true` in which case we
@@ -152,7 +148,7 @@ class TransactionService {
         )
       }
       tr.end()
-      tr = this.ensureCurrentTransaction(name, type, perfOptions)
+      tr = this.createCurrentTransaction(name, type, perfOptions)
     }
 
     if (tr.type === PAGE_LOAD) {
@@ -399,7 +395,7 @@ class TransactionService {
   startSpan(name, type, options) {
     let tr = this.getCurrentTransaction()
     if (!tr) {
-      tr = this.ensureCurrentTransaction(
+      tr = this.createCurrentTransaction(
         undefined,
         TEMPORARY_TYPE,
         this.createOptions({

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -77,13 +77,8 @@ class TransactionService {
   }
 
   ensureCurrentTransaction(name, type, options) {
-    let tr = this.getCurrentTransaction()
-    if (tr) {
-      return tr
-    } else {
-      tr = new Transaction(name, type, options)
-      this.setCurrentTransaction(tr)
-    }
+    const tr = new Transaction(name, type, options)
+    this.setCurrentTransaction(tr)
     return tr
   }
 
@@ -402,25 +397,26 @@ class TransactionService {
   }
 
   startSpan(name, type, options) {
-    const tr = this.ensureCurrentTransaction(
-      undefined,
-      TEMPORARY_TYPE,
-      this.createOptions({
-        canReuse: true,
-        managed: true
-      })
-    )
-
-    if (tr) {
-      const span = tr.startSpan(name, type, options)
-      if (__DEV__) {
-        this._logger.debug(
-          `startSpan(${name}, ${span.type})`,
-          `on transaction(${tr.id}, ${tr.name})`
-        )
-      }
-      return span
+    let tr = this.getCurrentTransaction()
+    if (!tr) {
+      tr = this.ensureCurrentTransaction(
+        undefined,
+        TEMPORARY_TYPE,
+        this.createOptions({
+          canReuse: true,
+          managed: true
+        })
+      )
     }
+
+    const span = tr.startSpan(name, type, options)
+    if (__DEV__) {
+      this._logger.debug(
+        `startSpan(${name}, ${span.type})`,
+        `on transaction(${tr.id}, ${tr.name})`
+      )
+    }
+    return span
   }
 
   endSpan(span, context) {

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -24,7 +24,6 @@
  */
 
 import TransactionService from '../../src/performance-monitoring/transaction-service'
-import Transaction from '../../src/performance-monitoring/transaction'
 import Span from '../../src/performance-monitoring/span'
 import Config from '../../src/common/config-service'
 import LoggingService from '../../src/common/logging-service'
@@ -70,9 +69,11 @@ describe('TransactionService', function() {
   })
 
   it('should call startSpan on current Transaction', function() {
-    var tr = new Transaction('transaction', 'transaction')
+    const tr = transactionService.createCurrentTransaction(
+      'transaction',
+      'transaction'
+    )
     spyOn(tr, 'startSpan').and.callThrough()
-    transactionService.setCurrentTransaction(tr)
     transactionService.startSpan('test-span', 'test-span', { test: 'passed' })
     expect(
       transactionService.getCurrentTransaction().startSpan
@@ -201,10 +202,13 @@ describe('TransactionService', function() {
 
   it('should reuse Transaction', function() {
     transactionService = new TransactionService(logger, config)
-    const reusableTr = new Transaction('test-name', 'test-type', {
-      canReuse: true
-    })
-    transactionService.setCurrentTransaction(reusableTr)
+    const reusableTr = transactionService.createCurrentTransaction(
+      'test-name',
+      'test-type',
+      {
+        canReuse: true
+      }
+    )
     const pageLoadTr = transactionService.startTransaction(name, 'page-load', {
       managed: true,
       canReuse: true
@@ -268,8 +272,10 @@ describe('TransactionService', function() {
       done()
     })
 
-    const zoneTr = new Transaction('test', 'test-transaction')
-    customTransactionService.setCurrentTransaction(zoneTr)
+    const zoneTr = transactionService.createCurrentTransaction(
+      'test',
+      'test-transaction'
+    )
     const span = zoneTr.startSpan('GET http://example.com', 'external.http')
     span.end()
 
@@ -349,14 +355,6 @@ describe('TransactionService', function() {
       unMock()
       done()
     })
-  })
-
-  it('should ensureCurrentTransaction once per startTransaction', function() {
-    spyOn(transactionService, 'ensureCurrentTransaction').and.callThrough()
-    transactionService.startTransaction('test-name', 'test-type', {
-      managed: true
-    })
-    expect(transactionService.ensureCurrentTransaction).toHaveBeenCalledTimes(1)
   })
 
   it('should include size & server timing in page load context', done => {

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -357,6 +357,14 @@ describe('TransactionService', function() {
     })
   })
 
+  it('should call createCurrentTransaction once per startTransaction', function() {
+    spyOn(transactionService, 'createCurrentTransaction').and.callThrough()
+    transactionService.startTransaction('test-name', 'test-type', {
+      managed: true
+    })
+    expect(transactionService.createCurrentTransaction).toHaveBeenCalledTimes(1)
+  })
+
   it('should include size & server timing in page load context', done => {
     const unMock = mockGetEntriesByType()
     const customTrService = new TransactionService(logger, config)


### PR DESCRIPTION
+ `apm.startSpan` was creating options object even when there was an active transaction present which is wasteful to do in the first place. 
+ This PR improves the performance of `startSpan`method and skips options creation when there is already an active transaction.