### PR TITLE
fix(rum): do not instrument frameworks when agent is inactive

### DIFF
--- a/packages/rum-angular/src/apm-service.ts
+++ b/packages/rum-angular/src/apm-service.ts
@@ -38,10 +38,7 @@ export class ApmService {
   init(config) {
     const apmInstance = ApmService.apm.init(config)
 
-    const configService = ApmService.apm.serviceFactory.getService(
-      'ConfigService'
-    )
-    if (!configService.isActive()) {
+    if (!apmInstance.isActive()) {
       return apmInstance
     }
 

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -106,10 +106,6 @@ class Config {
     this.setConfig(scriptData)
   }
 
-  isActive() {
-    return this.get('active')
-  }
-
   setVersion(version) {
     this.version = version
   }

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -48,8 +48,7 @@ function isReactClassComponent(Component) {
 function getWithTransaction(apm) {
   return function withTransaction(name, type, callback = () => {}) {
     return function(Component) {
-      const configService = apm.serviceFactory.getService('ConfigService')
-      if (!configService.isActive()) {
+      if (!apm.isActive()) {
         return Component
       }
 

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -72,6 +72,22 @@ describe('withTransaction', function() {
     TestComponent(apmBase)
   })
 
+  it('should not log warning or create transaction if apm is not active', function() {
+    const [loggingService, transactionService] = serviceFactory.getService([
+      'LoggingService',
+      'TransactionService'
+    ])
+    spyOn(loggingService, 'warn')
+    spyOn(transactionService, 'startTransaction')
+
+    const notInitializedAPM = new ApmBase(serviceFactory, false)
+    const withTransaction = getWithTransaction(notInitializedAPM)
+    const comp = withTransaction('test-name', 'test-type')(undefined)
+    expect(comp).toBe(undefined)
+    expect(loggingService.warn).not.toHaveBeenCalled()
+    expect(transactionService.startTransaction).not.toHaveBeenCalled()
+  })
+
   it('should start transaction for components', function() {
     const transactionService = serviceFactory.getService('TransactionService')
     spyOn(transactionService, 'startTransaction')

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -82,8 +82,9 @@ describe('withTransaction', function() {
 
     const notInitializedAPM = new ApmBase(serviceFactory, false)
     const withTransaction = getWithTransaction(notInitializedAPM)
-    const comp = withTransaction('test-name', 'test-type')(undefined)
-    expect(comp).toBe(undefined)
+    const testComponent = {}
+    const comp = withTransaction('test-name', 'test-type')(testComponent)
+    expect(comp).toEqual(testComponent)
     expect(loggingService.warn).not.toHaveBeenCalled()
     expect(transactionService.startTransaction).not.toHaveBeenCalled()
   })

--- a/packages/rum-vue/src/index.js
+++ b/packages/rum-vue/src/index.js
@@ -35,6 +35,10 @@ export const ApmVuePlugin = {
      */
     apm.init(config)
 
+    if (!apm.isActive()) {
+      return
+    }
+
     /**
      * Hook router if provided
      */

--- a/packages/rum-vue/src/index.js
+++ b/packages/rum-vue/src/index.js
@@ -35,23 +35,21 @@ export const ApmVuePlugin = {
      */
     apm.init(config)
 
-    if (!apm.isActive()) {
-      return
-    }
-
-    /**
-     * Hook router if provided
-     */
-    if (router) {
-      routeHooks(router, apm)
-    }
-
-    if (captureErrors) {
+    if (apm.isActive()) {
       /**
-       * Global error handler for capturing errors during
-       * component renders
+       * Hook router if provided
        */
-      Vue.config.errorHandler = getErrorHandler(Vue, apm)
+      if (router) {
+        routeHooks(router, apm)
+      }
+
+      if (captureErrors) {
+        /**
+         * Global error handler for capturing errors during
+         * component renders
+         */
+        Vue.config.errorHandler = getErrorHandler(Vue, apm)
+      }
     }
     /**
      * Provide the APM instance via $apm to be accessed in all Vue Components

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -239,7 +239,7 @@ export default class ApmBase {
 
   // Should call this method before 'load' event on window is fired
   setInitialPageLoadName(name) {
-    var configService = this.serviceFactory.getService(CONFIG_SERVICE)
+    const configService = this.serviceFactory.getService(CONFIG_SERVICE)
     configService.setConfig({
       pageLoadTransactionName: name
     })

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -39,6 +39,15 @@ export default class ApmBase {
     this._initialized = false
   }
 
+  isEnabled() {
+    return !this._disable
+  }
+
+  isActive() {
+    const configService = this.serviceFactory.getService(CONFIG_SERVICE)
+    return this.isEnabled() && this._initialized && configService.get('active')
+  }
+
   init(config) {
     if (this.isEnabled() && !this._initialized) {
       this._initialized = true
@@ -59,7 +68,8 @@ export default class ApmBase {
       /**
        * Deactive agent when the active config flag is set to false
        */
-      if (configService.isActive()) {
+      const isConfigActive = configService.get('active')
+      if (isConfigActive) {
         this.serviceFactory.init()
 
         const flags = getInstrumentationFlags(
@@ -166,10 +176,6 @@ export default class ApmBase {
     }
   }
 
-  isEnabled() {
-    return !this._disable
-  }
-
   observe(name, fn) {
     const configService = this.serviceFactory.getService(CONFIG_SERVICE)
     configService.events.observe(name, fn)
@@ -233,12 +239,10 @@ export default class ApmBase {
 
   // Should call this method before 'load' event on window is fired
   setInitialPageLoadName(name) {
-    if (this.isEnabled()) {
-      var configService = this.serviceFactory.getService(CONFIG_SERVICE)
-      configService.setConfig({
-        pageLoadTransactionName: name
-      })
-    }
+    var configService = this.serviceFactory.getService(CONFIG_SERVICE)
+    configService.setConfig({
+      pageLoadTransactionName: name
+    })
   }
 
   startTransaction(name, type, options) {

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -44,6 +44,21 @@ describe('ApmBase', function() {
     apmBase = new ApmBase(serviceFactory, !enabled)
   })
 
+  it('should report whether agent is active or inactive', () => {
+    expect(apmBase.isActive()).toBe(false)
+    apmBase.config({ active: false })
+    expect(apmBase.isActive()).toBe(false)
+    apmBase.config({ active: true })
+    expect(apmBase.isActive()).toBe(false)
+    apmBase.init({
+      serviceName,
+      serverUrl,
+      active: true,
+      instrument: false
+    })
+    expect(apmBase.isActive()).toBe(true)
+  })
+
   it('should send page load metrics after load event', done => {
     apmBase.config({ serviceName, serverUrl })
     apmBase._sendPageLoadMetrics()


### PR DESCRIPTION
+ fix #881 
+ PR address the issue when the react ApmRoute component is used on the application and instrumentation should not happen when the RUM agent is not initialised. 
+ Added an `isActive` method on the APM agent which is used across all packages to check for three conditions
    - is Platform supported
    - Is the agent initialised
    - Is the `active` config flag set to true

+ removed the isActive method from Config service to avoid confusion with the agent API. 