### PR TITLE
feat(rum): add missing methods to types

### DIFF
--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -39,7 +39,6 @@ declare module '@elastic/apm-rum' {
      */
     isEnabled(): boolean
     isActive(): boolean
-    fetchCentralConfig(): Promise<AgentConfigOptions | undefined>
     observe(name: TransactionEvents, callback: (tr: Transaction) => void): void
     config(config: AgentConfigOptions): void
     setUserContext(user: UserObject): void

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -38,7 +38,10 @@ declare module '@elastic/apm-rum' {
      * undocumented, might be removed in future versions
      */
     isEnabled(): boolean
+    isActive(): boolean
+    fetchCentralConfig(): Promise<AgentConfigOptions | undefined>
     observe(name: TransactionEvents, callback: (tr: Transaction) => void): void
+    config(config: AgentConfigOptions): void
     setUserContext(user: UserObject): void
     setCustomContext(custom: object): void
     addLabels(labels: Labels): void


### PR DESCRIPTION
Add typings for methods: `isActive`, `fetchCentralConfig`, `config`.

Since none of them has underscore at the beginning of their function names, I believed that they ought to be public methods, and should be typed.