### PR TITLE
fix(rum-core): add default timeout for xhr post requests

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -119,11 +119,7 @@ class ApmServer {
     return new Error(message)
   }
 
-  _makeHttpRequest(
-    method,
-    url,
-    { timeout, payload, headers } = { timeout: 10000 }
-  ) {
+  _makeHttpRequest(method, url, { timeout = 10000, payload, headers } = {}) {
     return new Promise(function(resolve, reject) {
       var xhr = new window.XMLHttpRequest()
       xhr[XHR_IGNORE] = true


### PR DESCRIPTION
Added a default timeout to the `makeHttpRequest` method on apm-server
in the case, a payload or headers are passed to the function. Previously
the default timeout would only be applied if the third parameter was
not defined.

This will resolve the issue for https://github.com/elastic/apm-agent-rum-js/issues/896