### PR TITLE
fix(rum-core): measure fid correctly for experience metric

### DIFF
--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -250,7 +250,7 @@ export function captureObserverEntries(list, { capturePaint }) {
   const fidEntries = list.getEntriesByType(FIRST_INPUT)
   const fidSpan = createFirstInputDelaySpan(fidEntries)
   if (fidSpan) {
-    metrics.fid = fidSpan._start
+    metrics.fid = fidSpan.duration()
     result.spans.push(fidSpan)
   }
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -287,7 +287,7 @@ class TransactionService {
             }
 
             if (isPerfTypeSupported(LAYOUT_SHIFT)) {
-              tr.experience.cls = cls
+              tr.experience.cls = cls.toFixed(3)
             }
 
             if (fid > 0) {

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -287,7 +287,7 @@ class TransactionService {
             }
 
             if (isPerfTypeSupported(LAYOUT_SHIFT)) {
-              tr.experience.cls = cls.toFixed(3)
+              tr.experience.cls = cls
             }
 
             if (fid > 0) {

--- a/packages/rum-core/test/fixtures/fid-entries.js
+++ b/packages/rum-core/test/fixtures/fid-entries.js
@@ -1,0 +1,36 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+export default [
+  {
+    name: 'mousedown',
+    entryType: 'first-input',
+    startTime: 5482.669999997597,
+    duration: 16,
+    processingStart: 5489.029999997001,
+    processingEnd: 5489.0550000127405,
+    cancelable: true
+  }
+]

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -37,6 +37,7 @@ import {
   mockObserverEntryNames
 } from '../utils/globals-mock'
 import longtaskEntries from '../fixtures/longtask-entries'
+import fidEntries from '../fixtures/fid-entries'
 
 describe('Metrics', () => {
   describe('PerfEntryRecorder', () => {
@@ -50,6 +51,7 @@ describe('Metrics', () => {
       list.getEntriesByName.and.returnValue([])
       metrics.tbt = { start: Infinity, duration: 0 }
       metrics.cls = 0
+      metrics.fid = 0
     })
 
     it('should not create long tasks spans if entries are not present', () => {
@@ -225,27 +227,27 @@ describe('Metrics', () => {
       })
     })
 
-    it('should create first input delay span', () => {
-      let span = createFirstInputDelaySpan([
-        {
-          name: 'mousedown',
-          entryType: 'first-input',
-          startTime: 5482.669999997597,
-          duration: 16,
-          processingStart: 5489.029999997001,
-          processingEnd: 5489.0550000127405,
-          cancelable: true
-        }
-      ])
-      expect(span).toEqual(
-        jasmine.objectContaining({
-          name: 'First Input Delay',
-          type: 'first-input',
-          ended: true,
-          _end: 5489.029999997001,
-          _start: 5482.669999997597
+    describe('First Input Delay', () => {
+      it('should capture fid experience metric on input entries', () => {
+        list.getEntriesByType.and.callFake(mockObserverEntryTypes)
+        captureObserverEntries(list, {
+          capturePaint: true
         })
-      )
+        expect(metrics.fid).toBe(6)
+      })
+
+      it('should create first input delay span', () => {
+        let span = createFirstInputDelaySpan(fidEntries)
+        expect(span).toEqual(
+          jasmine.objectContaining({
+            name: 'First Input Delay',
+            type: 'first-input',
+            ended: true,
+            _end: 5489.029999997001,
+            _start: 5482.669999997597
+          })
+        )
+      })
     })
 
     it('should calculate Cumulative Layout Shift', () => {
@@ -287,7 +289,7 @@ describe('Metrics', () => {
           value: 0.01
         }
       ])
-      expect(metrics.cls.toFixed(5)).toEqual('0.06000')
+      expect(metrics.cls.toFixed(3)).toEqual('0.060')
     })
   })
 })

--- a/packages/rum-core/test/utils/globals-mock.js
+++ b/packages/rum-core/test/utils/globals-mock.js
@@ -29,13 +29,15 @@ import userTimingEntries from '../fixtures/user-timing-entries'
 import { TIMING_LEVEL2_ENTRIES } from '../fixtures/navigation-entries'
 import longtaskEntries from '../fixtures/longtask-entries'
 import largestContentfulPaintEntries from '../fixtures/lcp-entries'
+import firstInputDelayEntries from '../fixtures/fid-entries'
 import {
   LONG_TASK,
   LARGEST_CONTENTFUL_PAINT,
   MEASURE,
   NAVIGATION,
   RESOURCE,
-  FIRST_CONTENTFUL_PAINT
+  FIRST_CONTENTFUL_PAINT,
+  FIRST_INPUT
 } from '../../src/common/constants'
 
 export function mockObserverEntryTypes(type) {
@@ -43,6 +45,8 @@ export function mockObserverEntryTypes(type) {
     return longtaskEntries
   } else if (type === LARGEST_CONTENTFUL_PAINT) {
     return largestContentfulPaintEntries
+  } else if (type === FIRST_INPUT) {
+    return firstInputDelayEntries
   }
   return []
 }


### PR DESCRIPTION
+ fixes #898 
+ Also handles CLS values to be fixed with 3 decimals (Used in all core-vitals reports) 