### PR TITLE
fix(rum-core): discard buggy navigation marks for page-load

### DIFF
--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -260,21 +260,20 @@ function getNavigationTimingMarks(timing) {
    * https://bugs.webkit.org/show_bug.cgi?id=186919
    */
   if (
-    (navigationStart && fetchStart < navigationStart) ||
-    (responseStart && responseStart < fetchStart) ||
-    (responseStart && responseEnd && responseEnd < responseStart)
+    fetchStart >= navigationStart &&
+    responseStart >= fetchStart &&
+    responseEnd >= responseStart
   ) {
-    return null
+    const marks = {}
+    NAVIGATION_TIMING_MARKS.forEach(function(timingKey) {
+      const m = timing[timingKey]
+      if (m && m >= fetchStart) {
+        marks[timingKey] = parseInt(m - fetchStart)
+      }
+    })
+    return marks
   }
-
-  const marks = {}
-  NAVIGATION_TIMING_MARKS.forEach(function(timingKey) {
-    const m = timing[timingKey]
-    if (m && m >= fetchStart) {
-      marks[timingKey] = parseInt(m - fetchStart)
-    }
-  })
-  return marks
+  return null
 }
 
 function getPageLoadMarks(timing) {

--- a/packages/rum-core/src/performance-monitoring/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-navigation.js
@@ -251,14 +251,19 @@ const COMPRESSED_NAV_TIMING_MARKS = [
 ]
 
 function getNavigationTimingMarks(timing) {
-  const { fetchStart, navigationStart } = timing
+  const { fetchStart, navigationStart, responseStart, responseEnd } = timing
   /**
    * Detect if NavigationTiming data is buggy and discard
    * capturing navigation marks for the transaction
    *
-   * Webkit bug - https://bugs.webkit.org/show_bug.cgi?id=168057
+   * https://bugs.webkit.org/show_bug.cgi?id=168057
+   * https://bugs.webkit.org/show_bug.cgi?id=186919
    */
-  if (navigationStart && fetchStart < navigationStart) {
+  if (
+    (navigationStart && fetchStart < navigationStart) ||
+    (responseStart && responseStart < fetchStart) ||
+    (responseStart && responseEnd && responseEnd < responseStart)
+  ) {
     return null
   }
 

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -437,7 +437,7 @@ describe('Capture hard navigation', function() {
       timingCopy.loadEventStart = 0
 
       const marks = getPageLoadMarks(timingCopy)
-      expect(marks).toBe(null)
+      expect(marks).toEqual(null)
     })
 
     it('requestStart & responseStart before fetchStart', () => {
@@ -451,10 +451,19 @@ describe('Capture hard navigation', function() {
       timingCopy.responseStart = timingCopy.fetchStart - 500
 
       const marks = getPageLoadMarks(timingCopy)
+      expect(marks).toEqual(null)
+    })
 
-      expect(marks.navigationTiming.responseStart).toBe(undefined)
-      expect(marks.navigationTiming.requestStart).toBe(undefined)
-      expect(marks.agent.timeToFirstByte).toBe(undefined)
+    it('responseStart > responseEnd out of order data', () => {
+      /**
+       * Webkit bug NavigationTiming corrupt data
+       * https://bugs.webkit.org/show_bug.cgi?id=186919
+       */
+      const timingCopy = extend({}, timings)
+      timingCopy.responseStart = timingCopy.responseEnd + 100
+
+      const marks = getPageLoadMarks(timingCopy)
+      expect(marks).toEqual(null)
     })
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -267,7 +267,6 @@ describe('TransactionService', function() {
       expect(
         tr.spans.filter(({ type }) => type === 'app').length
       ).toBeGreaterThanOrEqual(1)
-      expect(tr.marks.navigationTiming).toBeDefined()
       unMock()
       done()
     })


### PR DESCRIPTION
+ fix #901 
+ I had a look at our data for past 30 days and confirmed this fix should make our CSM page account for all bugs. Also, the bug is applicable only to Safari users. 
+ Link to webkit issues - https://bugs.webkit.org/show_bug.cgi?id=186919, https://bugs.webkit.org/show_bug.cgi?id=168055