### PR TITLE
feat: add span and transaction outcome

### DIFF
--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -173,7 +173,8 @@ export function compressTransaction(transaction) {
       t: span.type,
       s: span.start,
       d: span.duration,
-      c: compressContext(span.context)
+      c: compressContext(span.context),
+      o: span.outcome
     }
     /**
      * Set parentId only for spans that are child of other spans
@@ -210,7 +211,8 @@ export function compressTransaction(transaction) {
     yc: {
       sd: spans.length
     },
-    sm: transaction.sampled
+    sm: transaction.sampled,
+    o: transaction.outcome
   }
 
   if (transaction.experience) {

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -80,6 +80,13 @@ const TRANSACTION_TYPE_ORDER = [
 ]
 
 /**
+ * Transaction & Span outcomes
+ */
+
+const OUTCOME_SUCCESS = 'success'
+const OUTCOME_FAILURE = 'failure'
+
+/**
  * Check only for long tasks that are more than 60ms
  */
 const USER_TIMING_THRESHOLD = 60
@@ -195,5 +202,7 @@ export {
   APM_SERVER,
   TRUNCATED_TYPE,
   FIRST_INPUT,
-  LAYOUT_SHIFT
+  LAYOUT_SHIFT,
+  OUTCOME_SUCCESS,
+  OUTCOME_FAILURE
 }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -308,9 +308,13 @@ export default class PerformanceMonitoring {
           status = target.status
         }
 
-        let outcome = OUTCOME_SUCCESS
-        if (status >= 400 || (status == 0 && data.status != 'abort')) {
-          outcome = OUTCOME_FAILURE
+        let outcome = null
+        if (data.status != 'abort') {
+          if (status >= 400 || status == 0) {
+            outcome = OUTCOME_FAILURE
+          } else {
+            outcome = OUTCOME_SUCCESS
+          }
         }
         span.outcome = outcome
         const tr = transactionService.getCurrentTransaction()

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -309,7 +309,7 @@ export default class PerformanceMonitoring {
         }
 
         let outcome = OUTCOME_SUCCESS
-        if (status >= 400 || status == 0) {
+        if (status >= 400 || (status == 0 && data.status != 'abort')) {
           outcome = OUTCOME_FAILURE
         }
         span.outcome = outcome

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -403,7 +403,8 @@ export default class PerformanceMonitoring {
         sync: span.sync,
         start: parseInt(span._start - transactionStart),
         duration: span.duration(),
-        context: span.context
+        context: span.context,
+        outcome: span.outcome
       }
       return truncateModel(SPAN_MODEL, spanData)
     })
@@ -422,7 +423,8 @@ export default class PerformanceMonitoring {
         started: spans.length
       },
       sampled: transaction.sampled,
-      experience: transaction.experience
+      experience: transaction.experience,
+      outcome: transaction.outcome
     }
     return truncateModel(TRANSACTION_MODEL, transactionData)
   }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -308,7 +308,7 @@ export default class PerformanceMonitoring {
           status = target.status
         }
 
-        let outcome = null
+        let outcome
         if (data.status != 'abort') {
           if (status >= 400 || status == 0) {
             outcome = OUTCOME_FAILURE

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -53,6 +53,7 @@ class SpanBase {
     this._start = getTime(options.startTime)
     this._end = undefined
     this.ended = false
+    this.outcome = undefined
     this.onEnd = options.onEnd
   }
 

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -752,6 +752,30 @@ describe('PerformanceMonitoring', function() {
     })
   }
 
+  it('should set outcome on transaction and spans', () => {
+    let transactionService = performanceMonitoring._transactionService
+
+    let task = createXHRTask('GET', '/')
+
+    performanceMonitoring.processAPICalls('schedule', task)
+    let tr = transactionService.getCurrentTransaction()
+
+    let spanTask = createXHRTask('GET', '/span')
+    performanceMonitoring.processAPICalls('schedule', spanTask)
+
+    spanTask.data.target = { status: 200 }
+    performanceMonitoring.processAPICalls('invoke', spanTask)
+
+    expect(tr.type).toBe('http-request')
+    expect(task.data.target.status).toBe(0)
+    performanceMonitoring.processAPICalls('invoke', task)
+    expect(tr.ended).toBe(true)
+    expect(tr.outcome).toBe('failure')
+    expect(tr.spans.length).toBe(2)
+    expect(tr.spans[0].outcome).toBe('success')
+    expect(tr.spans[1].outcome).toBe('failure')
+  })
+
   describe('PerformanceMonitoring Utils', () => {
     it('should group small continuously similar spans up until the last one', function() {
       var tr = new Transaction('transaction', 'transaction', { startTime: 10 })

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -752,7 +752,7 @@ describe('PerformanceMonitoring', function() {
     })
   }
 
-  it('should set outcome on transaction and spans', () => {
+  it('should set outcome on transaction and spans', done => {
     let transactionService = performanceMonitoring._transactionService
 
     let task = createXHRTask('GET', '/')
@@ -778,6 +778,17 @@ describe('PerformanceMonitoring', function() {
     const payload = performanceMonitoring.createTransactionDataModel(tr)
     expect(payload.outcome).toBe('failure')
     expect(payload.spans[0].outcome).toBe('success')
+    const promise = apmServer.sendEvents([
+      {
+        [TRANSACTIONS]: payload
+      }
+    ])
+    expect(promise).toBeDefined()
+    promise
+      .catch(reason => {
+        fail('Failed sending transactions to the server, reason: ' + reason)
+      })
+      .then(() => done())
   })
 
   describe('PerformanceMonitoring Utils', () => {

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -774,6 +774,10 @@ describe('PerformanceMonitoring', function() {
     expect(tr.spans.length).toBe(2)
     expect(tr.spans[0].outcome).toBe('success')
     expect(tr.spans[1].outcome).toBe('failure')
+
+    const payload = performanceMonitoring.createTransactionDataModel(tr)
+    expect(payload.outcome).toBe('failure')
+    expect(payload.spans[0].outcome).toBe('success')
   })
 
   describe('PerformanceMonitoring Utils', () => {


### PR DESCRIPTION
This PR add outcome to Transactions and Spans. The outcome is only added for `http-request` transactions since based on the definition of outcome we can only infer that for these type of transactions. For all other transactions the outcome is `unknown` which is set by the APM Server. See the original issue for more detail.

Fixes #876