### PR TITLE
ci(jenkins): enable slack notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,6 @@ pipeline {
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
               }
             }
-            notifyStatus(slackStatus: 'warning', subject: "TEST [${env.REPO}] notifications",
-                          body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.")
           }
         }
         /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,7 +304,7 @@ pipeline {
                       def releaseVersions = sh(label: 'Gather versions from last commit', script: 'git log -1 --format="%b"', returnStdout: true)
                       log(level: 'INFO', text: "Versions: ${releaseVersions}")
                       notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
-                                   body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.\n Changes: ${releaseVersions}")
+                                   body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.\n Changes: ${releaseVersions}")
                       input(message: 'Should we release a new version?', ok: 'Yes, we should.',
                             parameters: [text(description: 'Look at the versions to be released. They cannot be edited here',
                                               defaultValue: "${releaseVersions}", name: 'versions')])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,8 +303,8 @@ pipeline {
                       sh(label: 'Lerna version dry-run', script: 'npx lerna version --no-push --yes', returnStdout: true)
                       def releaseVersions = sh(label: 'Gather versions from last commit', script: 'git log -1 --format="%b"', returnStdout: true)
                       log(level: 'INFO', text: "Versions: ${releaseVersions}")
-                      emailext subject: "[${env.REPO}] Release ready to be pushed", to: "${NOTIFY_TO}",
-                               body: "Please go to ${env.BUILD_URL}input to approve or reject within 12 hours.\n Changes: ${releaseVersions}"
+                      notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
+                                   body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.\n Changes: ${releaseVersions}")
                       input(message: 'Should we release a new version?', ok: 'Yes, we should.',
                             parameters: [text(description: 'Look at the versions to be released. They cannot be edited here',
                                               defaultValue: "${releaseVersions}", name: 'versions')])
@@ -326,7 +326,7 @@ pipeline {
               }
               post {
                 success {
-                  emailext subject: "[${env.REPO}] Release published", to: "${env.NOTIFY_TO}", body: "Great news, the release has been done successfully."
+                  notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>)")
                 }
                 always {
                   script {
@@ -343,6 +343,11 @@ pipeline {
                   uploadToCDN()
                 }
               }
+            }
+          }
+          post {
+            failure {
+              notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
             }
           }
         }
@@ -531,4 +536,12 @@ def runTest(){
       goal: 'test'
     )
   }
+}
+
+def notifyStatus(def args = [:]) {
+  slackSend(channel: '#apm-agent-js', color: args.slackStatus, message: "${args.subject}. ${args.body}",
+            tokenCredentialId: 'jenkins-slack-integration-token')
+  // transform slack URL format '(<URL|description>)' to 'URL'.
+  def bodyEmail = args.body.replaceAll('\\(<', '').replaceAll('\\|.*>\\)', '')
+  emailext(subject: args.subject, to: "${env.NOTIFY_TO}", body: bodyEmail)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,7 +326,7 @@ pipeline {
               }
               post {
                 success {
-                  notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>)")
+                  notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://github.com/elastic/apm-agent-rum-js/releases|Here>)")
                 }
                 always {
                   script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,8 @@ pipeline {
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
               }
             }
+            notifyStatus(slackStatus: 'warning', subject: "TEST [${env.REPO}] notifications",
+                          body: "Please (<${env.BUILD_URL}input|approve>) it or reject within 12 hours.")
           }
         }
         /**


### PR DESCRIPTION
## What

Enable slack notifications, similar to the email notifications, when a release is triggered.
Enable notifications if something bad happened with the release.

## Why

Ensure the right audience is in the loop.

## Tests

the commit https://github.com/elastic/apm-agent-rum-js/pull/908/commits/24707b292729481c5041b5a248ee8be92706992f caused:

- Slack notification

![image](https://user-images.githubusercontent.com/2871786/94563501-b6ae7500-025e-11eb-923a-0b43c441286f.png)

- Email notification

![image](https://user-images.githubusercontent.com/2871786/94563595-d6459d80-025e-11eb-9980-7ea8679ba2fd.png)
