### PR TITLE
ci(jenkins): release input parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,8 @@ pipeline {
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'saucelab_test', defaultValue: "true", description: "Enable run a Sauce lab test")
-    booleanParam(name: 'parallel_test', defaultValue: "true", description: "Enable run tests in parallel")
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
-    booleanParam(name: 'release', defaultValue: false, description: 'Release.')
+    booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from master.')
   }
   stages {
     stage('Initializing'){
@@ -148,6 +147,13 @@ pipeline {
               branch 'master'
               expression { return params.saucelab_test }
               expression { return env.ONLY_DOCS == "false" }
+              // Releases from master should skip this particular stage.
+              not {
+                allOf {
+                  branch 'master'
+                  expression { return params.release }
+                }
+              }
             }
           }
           steps {
@@ -224,6 +230,13 @@ pipeline {
               }
               expression { return params.bench_ci }
               expression { return env.ONLY_DOCS == "false" }
+              // Releases from master should skip this particular stage.
+              not {
+                allOf {
+                  branch 'master'
+                  expression { return params.release }
+                }
+              }
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,6 +177,13 @@ pipeline {
               changeRequest()
               expression { return params.saucelab_test }
               expression { return env.ONLY_DOCS == "false" }
+              // Releases from master should skip this particular stage.
+              not {
+                allOf {
+                  branch 'master'
+                  expression { return params.release }
+                }
+              }
             }
           }
           steps {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,10 +44,8 @@ The release process is also automated in the way any specific commit from the ma
 
 1. Login to apm-ci.elastic.co
 1. Go to the [master](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/master/) pipeline.
-1. Click on `Build with parameters` with the below checkboxes:
+1. Click on `Build with parameters` with the below checkbox:
   * `release` to be selected.
-  * `bench_ci` to be unselected.
-  * `saucelab_test` to be unselected.
   * other checkboxes should be left as default.
 1. Click on `Build`.
 1. Wait for an email to confirm the release is ready to be approved, it might take roughly 30 minutes.


### PR DESCRIPTION
## What

- Simplify the release process by filling only the required checkbox (`release`)
- Other input parameters will be ignored when release happens from the master branch.
- Update docs
- Remove unused parameter `parallel_test`

## Why

Every commit in the master branch runs the benchmark and saucelabs stages by default. Therefore, since the release happens from a particular commit in the master branch then it's not required to run those stages anymore.