### PR TITLE
feat(rum-react): add render/children prop support

### DIFF
--- a/docs/react-integration.asciidoc
+++ b/docs/react-integration.asciidoc
@@ -17,7 +17,7 @@ npm install @elastic/apm-rum-react --save
 [float]
 ==== Instrumenting your React application
 
-The React integration package provides two approaches to instrumenting your application:
+The React integration package provides multiple ways to instrument your application:
 
 [float]
 ===== Instrumenting application routes
@@ -38,7 +38,7 @@ import { ApmRoute } from '@elastic/apm-rum-react'
 
 Then, you should replace `Route` components from the `react-router` library
 with `ApmRoute`. You can use `ApmRoute` in any of the routes that you would like to monitor,
- therefore, you don't have to change all of your routes:
+therefore, you don't have to change all of your routes:
 
 
 [source,js]
@@ -46,7 +46,7 @@ with `ApmRoute`. You can use `ApmRoute` in any of the routes that you would like
 class App extends React.Component {
   render() {
     return (
-      <div>
+      <>
         <ApmRoute
           exact
           path="/"
@@ -58,17 +58,16 @@ class App extends React.Component {
             />
           )}
         />
-        <ApmRoute path="/home" component={HomeComponent} />
-        <Route path="/about" component={AboutComponent} />
-      </div>
+        <ApmRoute path="/faq" component={FaqComponent} />
+        <ApmRoute path="/home" render={HomeComponent} />
+        <ApmRoute path="/about">
+          {AboutComponent}
+        </ApmRoute>
+      </>
     )
   }
 }
 ----
-
-NOTE: `ApmRoute` only instruments the route if component property is provided, in other cases, e.g. using `render` or `children` properties, 
-ApmRoute will only renders the route without instrumenting it, 
-please instrument the individual component using `withTransaction` in these cases instead.
 
 
 [float]
@@ -131,3 +130,4 @@ function Routes() {
 class LazyComponent extends Component {}
 export default withTransaction('LazyComponent', 'component')(LazyComponent)
 ----
+

--- a/packages/rum-react/src/get-apm-route.js
+++ b/packages/rum-react/src/get-apm-route.js
@@ -51,7 +51,7 @@ function getApmRoute(apm) {
 
     static getDerivedStateFromProps(nextProps, prevState) {
       const initial = prevState.apmComponent == null
-      const { path, component } = nextProps
+      const { path, component, render, children } = nextProps
       const pathChanged = path != prevState.path
 
       /**
@@ -60,9 +60,14 @@ function getApmRoute(apm) {
        * Ex: Query param changes should not result in new apmComponent
        */
       if (initial || pathChanged) {
+        /**
+         * Route children takes precedence over component and render function
+         * to keep in sync with the Route Component
+         */
         return {
-          path,
-          apmComponent: withTransaction(
+          render: null,
+          children: null,
+          component: withTransaction(
             path,
             'route-change',
             (transaction, props) => {
@@ -71,14 +76,14 @@ function getApmRoute(apm) {
                 name && (transaction.name = name)
               }
             }
-          )(component)
+          )(children || component || render)
         }
       }
       return null
     }
 
     render() {
-      return <Route {...this.props} component={this.state.apmComponent} />
+      return <Route {...this.props} {...this.state} />
     }
   }
 }

--- a/packages/rum-react/src/get-with-transaction.js
+++ b/packages/rum-react/src/get-with-transaction.js
@@ -54,9 +54,7 @@ function getWithTransaction(apm) {
 
       if (!Component) {
         const loggingService = apm.serviceFactory.getService('LoggingService')
-        loggingService.warn(
-          `${name} is not instrumented since component property is not provided`
-        )
+        loggingService.warn(`${name} is not instrumented by the agent`)
         return Component
       }
 

--- a/packages/rum-react/test/e2e/components/topic-component.js
+++ b/packages/rum-react/test/e2e/components/topic-component.js
@@ -50,7 +50,7 @@ class TopicComponent extends React.Component {
 
   render() {
     return (
-      <div>
+      <div id="topics-container">
         <h3>
           <span>{this.props.match.path}</span>
         </h3>

--- a/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/general.e2e-spec.js
@@ -96,7 +96,7 @@ describe('General usecase with react-router', function() {
     )
     /**
      * `app` and `resource` span type will not be captured in safari 9 since
-     * User and Resource API is not supported.
+     * User and Resource Timing API is not supported.
      */
     const { name } = getBrowserInfo()
     if (name.indexOf('safari') >= 0) {

--- a/packages/rum-react/test/e2e/with-router/general.js
+++ b/packages/rum-react/test/e2e/with-router/general.js
@@ -87,7 +87,7 @@ class App extends React.Component {
           <ApmRoute
             exact
             path="/"
-            component={() => (
+            render={() => (
               <Redirect
                 to={{
                   pathname: '/home'
@@ -96,10 +96,10 @@ class App extends React.Component {
             )}
           />
           <ApmRoute path="/home" component={MainComponent} />
-          <Route path="/about" render={() => <div>about</div>} />
+          <ApmRoute path="/about" render={() => <div>about</div>} />
           <ApmRoute path="/func" component={FunctionalComponent} />
-          <ApmRoute path="/topics" component={MainComponent} />
-          <ApmRoute path="/topic/:id" component={TopicComponent} />
+          <ApmRoute path="/topics" render={TopicComponent} />
+          <ApmRoute path="/topic/:id">{TopicComponent}</ApmRoute>
           <Route
             path="/manual"
             component={() => (

--- a/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
@@ -67,4 +67,32 @@ describe('Using Switch component of react router', function() {
      */
     expect(foundSpans.length).toBeGreaterThanOrEqual(1)
   })
+
+  it('should capture render props as transaction', () => {
+    browser.waitUntil(
+      () => {
+        $('#topics').click()
+        const componentContainer = $('#topics-container')
+        return componentContainer.getText().indexOf('/topics') !== -1
+      },
+      5000,
+      'expected topic component to be rendered'
+    )
+
+    const { sendEvents } = waitForApmServerCalls(0, 2)
+    const { transactions } = sendEvents
+
+    const pageLoadTransaction = transactions[0]
+    expect(pageLoadTransaction.type).toBe('page-load')
+    expect(pageLoadTransaction.name).toBe('/notfound')
+
+    const routeTransaction = transactions[1]
+    expect(routeTransaction.name).toBe('/topics')
+    expect(routeTransaction.type).toBe('route-change')
+
+    const foundSpans = routeTransaction.spans.filter(
+      span => span.name === 'GET /test/e2e/data.json'
+    )
+    expect(foundSpans.length).toBe(1)
+  })
 })

--- a/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
+++ b/packages/rum-react/test/e2e/with-router/switch.e2e-spec.js
@@ -79,14 +79,10 @@ describe('Using Switch component of react router', function() {
       'expected topic component to be rendered'
     )
 
-    const { sendEvents } = waitForApmServerCalls(0, 2)
+    const { sendEvents } = waitForApmServerCalls(0, 3)
     const { transactions } = sendEvents
 
-    const pageLoadTransaction = transactions[0]
-    expect(pageLoadTransaction.type).toBe('page-load')
-    expect(pageLoadTransaction.name).toBe('/notfound')
-
-    const routeTransaction = transactions[1]
+    const routeTransaction = transactions[2]
     expect(routeTransaction.name).toBe('/topics')
     expect(routeTransaction.type).toBe('route-change')
 

--- a/packages/rum-react/test/e2e/with-router/switch.js
+++ b/packages/rum-react/test/e2e/with-router/switch.js
@@ -29,6 +29,7 @@ import React, { Suspense } from 'react'
 import { render } from 'react-dom'
 import { BrowserRouter, Link, Switch } from 'react-router-dom'
 import FunctionalComponent from '../components/func-component'
+import TopicComponent from '../components/topic-component'
 import { ApmRoute } from '../../../src'
 import createApmBase from '..'
 
@@ -49,10 +50,19 @@ function App() {
             Functional
           </Link>
         </li>
+        <li>
+          <Link id="topics" to="/topics">
+            Topics
+          </Link>
+        </li>
       </ul>
       <Suspense fallback={<div>Loading...</div>}>
         <Switch>
           <ApmRoute path="/func" component={FunctionalComponent} />
+          <ApmRoute
+            path="/topics"
+            render={props => <TopicComponent {...props} />}
+          />
           <ApmRoute component={NotFound} />
         </Switch>
       </Suspense>

--- a/packages/rum-react/test/specs/get-with-transaction.spec.js
+++ b/packages/rum-react/test/specs/get-with-transaction.spec.js
@@ -112,7 +112,7 @@ describe('withTransaction', function() {
     const comp = withTransaction('test-name', 'test-type')(undefined)
     expect(comp).toBe(undefined)
     expect(loggingService.warn).toHaveBeenCalledWith(
-      'test-name is not instrumented since component property is not provided'
+      'test-name is not instrumented by the agent'
     )
   })
 


### PR DESCRIPTION
+ fix #905 
+ Added Unit/E2e tests for the same
+ Updated docs with the new changes and removed warning with `render` and `children` props. 

### Usage
```jsx
<ApmRoute path="/about" render={(props) => <AboutComponent {...props}/>} />
<ApmRoute path="/func" component={FunctionalComponent} />
<ApmRoute path="/topics" render={TopicComponent} />
<ApmRoute path="/topic/:id">{TopicComponent}</ApmRoute>
```