### PR TITLE
chore: enable stale bot for issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,19 +1,19 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 335
+daysUntilStale: 100
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 30
+daysUntilClose: 20
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: []
+onlyLabels:
+  - question
+  - discuss
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-- question
-- discuss
+exemptLabels: []
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
@@ -29,7 +29,7 @@ staleLabel: Stalled
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
+  This PR/Issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 
@@ -54,7 +54,7 @@ pulls:
   markComment: >
     Hi!
 
-    We just realized that we haven't looked into this PR in a while. We're
+    We just realized that we haven't looked into this PR/Issue in a while. We're
     sorry!
 
 
@@ -68,13 +68,13 @@ pulls:
   closeComment: >
     Hi!
 
-    This PR has been stale for a while and we're going to close it as part of
+    This PR/Issue has been stale for a while and we're going to close it as part of
     our cleanup procedure.
 
     We appreciate your contribution and would like to apologize if we have not
     been able to review it, due to the current heavy load of the team.
 
-    Feel free to re-open this PR if you think it should stay open and is worth rebasing.
+    Feel free to re-open this PR/Issue if you think it should stay open and is worth rebasing.
 
     Thank you for your contribution!
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -34,7 +34,7 @@ markComment: >
     We just realized that we haven't looked into this issue in a while. We're
     sorry!
 
-    We're labeling this issue as `Stale` to make it hit our filters and 
+    We're labeling this issue as `Stalled` to make it hit our filters and 
     make sure we get back to it in as soon as possible. In the meantime, it'd
     be extremely helpful if you could take a look at it as well and confirm its
     relevance. A simple comment with a nice emoji will be enough `:+1`.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -29,34 +29,10 @@ staleLabel: Stalled
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This PR/Issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-
-# Comment to post when removing the stale label.
-# unmarkComment: >
-#   Your comment here.
-
-# Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
-
-# Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 30
-
-# Limit to only `issues` or `pulls`
-# only: issues
-
-# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-pulls:
-  daysUntilStale: 30
-  daysUntilClose: 30
-  markComment: >
     Hi!
 
-    We just realized that we haven't looked into this PR/Issue in a while. We're
+    We just realized that we haven't looked into this issue in a while. We're
     sorry!
-
 
     We're labeling this issue as `Stale` to make it hit our filters and 
     make sure we get back to it in as soon as possible. In the meantime, it'd
@@ -64,20 +40,33 @@ pulls:
     relevance. A simple comment with a nice emoji will be enough `:+1`.
 
     Thank you for your contribution!
- 
-  closeComment: >
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
     Hi!
 
-    This PR/Issue has been stale for a while and we're going to close it as part of
+    This issue has been stale for a while and we're going to close it as part of
     our cleanup procedure.
 
     We appreciate your contribution and would like to apologize if we have not
     been able to review it, due to the current heavy load of the team.
 
-    Feel free to re-open this PR/Issue if you think it should stay open and is worth rebasing.
+    Feel free to re-open this issue if you think it should stay open.
 
     Thank you for your contribution!
 
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
 
 # issues:
 #   exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,84 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 335
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+- question
+- discuss
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: Stalled
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 30
+  daysUntilClose: 30
+  markComment: >
+    Hi!
+
+    We just realized that we haven't looked into this PR in a while. We're
+    sorry!
+
+
+    We're labeling this issue as `Stale` to make it hit our filters and 
+    make sure we get back to it in as soon as possible. In the meantime, it'd
+    be extremely helpful if you could take a look at it as well and confirm its
+    relevance. A simple comment with a nice emoji will be enough `:+1`.
+
+    Thank you for your contribution!
+ 
+  closeComment: >
+    Hi!
+
+    This PR has been stale for a while and we're going to close it as part of
+    our cleanup procedure.
+
+    We appreciate your contribution and would like to apologize if we have not
+    been able to review it, due to the current heavy load of the team.
+
+    Feel free to re-open this PR if you think it should stay open and is worth rebasing.
+
+    Thank you for your contribution!
+
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
## What

Enable [stale bot](https://github.com/probot/stale) to notify and then close the Issues that haven't had any activity for 120 days, a notification will be sent after 100 days and if nothing else happens they will get closed 20 days later.

## How it works

- Support `issues` only as stated
- It uses the `Stalled` label to categorise the ones that have been informed without any activity in 120 days.
- It looks for the issues that got the label `discuss` and `question`.
- Those `Stalled` issues will be closed if no further activity after 20 days.
- Those issues without a label are excluded from the bot. (There is no support for such). The workaround will be as simple as label them with `Stalled` then the bot will close them after 20 days.

### Issues

Closes #912 
Relates to https://github.com/elastic/beats/pull/19157


### Questions

~@cachedout what do we do to enable the botelastic to work with this repo?~ I'll ask infra to enable it