### PR TITLE
chore(jenkins): minor refinements

### DIFF
--- a/.ci/.jenkins_rum.yml
+++ b/.ci/.jenkins_rum.yml
@@ -1,0 +1,2 @@
+NODEJS_VERSION:
+  - "12"

--- a/.ci/.jenkins_rum.yml
+++ b/.ci/.jenkins_rum.yml
@@ -1,2 +1,5 @@
 NODEJS_VERSION:
   - "12"
+TEST_LIBRARIES:
+  - playwright
+  - puppeteer

--- a/.ci/.jenkins_scope.yaml
+++ b/.ci/.jenkins_scope.yaml
@@ -1,6 +1,0 @@
-SCOPE:
-  - "@elastic/apm-rum-core"
-  - "@elastic/apm-rum"
-  - "@elastic/apm-rum-react"
-  - "@elastic/apm-rum-angular"
-  - "@elastic/apm-rum-vue"

--- a/.ci/.jenkins_stack_versions.yaml
+++ b/.ci/.jenkins_stack_versions.yaml
@@ -1,4 +1,0 @@
-STACK_VERSION:
-  - '8.0.0-SNAPSHOT'
-  - '7.6.0'
-  - '7.0.0'

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -1,10 +1,12 @@
 # Little bit customized version of microsoft/playwright:bionic image
-
+ARG NODEJS_VERSION
 FROM ubuntu:bionic
+# this second declaration is needed because ARG before FROM works differently. See https://docs.docker.com/compose/compose-file/#args
+ARG NODEJS_VERSION
 
 # 1. Install node12
 RUN apt-get -qq update && apt-get -qq install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
     apt-get -qq install -y nodejs
 
 # 2. Install git (used to tag commit in benchmark runner)

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -1,5 +1,5 @@
 # Little bit customized version of microsoft/playwright:bionic image
-ARG NODEJS_VERSION
+ARG NODEJS_VERSION=12
 FROM ubuntu:bionic
 # this second declaration is needed because ARG before FROM works differently. See https://docs.docker.com/compose/compose-file/#args
 ARG NODEJS_VERSION

--- a/.ci/docker/node-puppeteer/Dockerfile
+++ b/.ci/docker/node-puppeteer/Dockerfile
@@ -1,5 +1,5 @@
 #Dockerfile for docker.elastic.co/observability-ci/node-puppeteer:12
-ARG NODEJS_VERSION
+ARG NODEJS_VERSION=12
 FROM node:${NODEJS_VERSION}
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)

--- a/.ci/docker/node-puppeteer/Dockerfile
+++ b/.ci/docker/node-puppeteer/Dockerfile
@@ -1,5 +1,6 @@
 #Dockerfile for docker.elastic.co/observability-ci/node-puppeteer:12
-FROM node:12
+ARG NODEJS_VERSION
+FROM node:${NODEJS_VERSION}
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xueo pipefail
 
-pip3 install docker-compose>=1.25.4
+pip install docker-compose>=1.25.4
 
 USER_ID="$(id -u):$(id -g)" \
 docker-compose \

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xueo pipefail
 
-pip install docker-compose>=1.25.4
+pip3 install docker-compose>=1.25.4
 
 USER_ID="$(id -u):$(id -g)" \
 docker-compose \

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.npm
 .DS_Store
 
 *.e2e-bundle.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.config
 .npm
 .DS_Store
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ pipeline {
         stage('Stack 8.0.0-SNAPSHOT SauceLabs') {
           agent { label 'linux && immutable' }
           environment {
-            SAUCELABS_SECRET=  "${isPR() ? env.SAUCELABS_SECRET : env.SAUCELABS_SECRET_CORE}"
+            SAUCELABS_SECRET =  "${isPR() ? env.SAUCELABS_SECRET : env.SAUCELABS_SECRET_CORE}"
             STACK_VERSION = "8.0.0-SNAPSHOT"
             MODE = "saucelabs"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ pipeline {
         stage('Stack 8.0.0-SNAPSHOT SauceLabs') {
           agent { label 'linux && immutable' }
           environment {
-            SAUCELABS_SECRET =  "${isPR() ? env.SAUCELABS_SECRET : env.SAUCELABS_SECRET_CORE}"
+            SAUCELABS_SECRET = "${isPR() ? env.SAUCELABS_SECRET : env.SAUCELABS_SECRET_CORE}"
             STACK_VERSION = "8.0.0-SNAPSHOT"
             MODE = "saucelabs"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -458,10 +458,10 @@ def runScript(Map args = [:]){
           sleep randomNumber(min: 5, max: 10)
           if(env.MODE == 'saucelabs'){
             withSaucelabsEnv(){
-              sh(label: "Start Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
+              sh(label: "Run tests: Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
             }
           } else {
-            sh(label: "Start Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
+            sh(label: "Run tests: Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
           }
         }
       } catch(e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,43 +138,16 @@ pipeline {
         stage('Stack 8.0.0-SNAPSHOT SauceLabs') {
           agent { label 'linux && immutable' }
           environment {
-            SAUCELABS_SECRET = "${env.SAUCELABS_SECRET_CORE}"
+            SAUCELABS_SECRET=  "${isPR() ? env.SAUCELABS_SECRET : env.SAUCELABS_SECRET_CORE}"
             STACK_VERSION = "8.0.0-SNAPSHOT"
             MODE = "saucelabs"
           }
           when {
             allOf {
-              branch 'master'
-              expression { return params.saucelab_test }
-              expression { return env.ONLY_DOCS == "false" }
-              // Releases from master should skip this particular stage.
-              not {
-                allOf {
-                  branch 'master'
-                  expression { return params.release }
-                }
+              anyOf {
+                branch 'master'
+                changeRequest()
               }
-            }
-          }
-          steps {
-            runAllScopes()
-          }
-          post {
-            cleanup {
-              wrappingUp()
-            }
-          }
-        }
-        stage('Stack 8.0.0-SNAPSHOT SauceLabs PR') {
-          agent { label 'linux && immutable' }
-          environment {
-            SAUCELABS_SECRET="${env.SAUCELABS_SECRET}"
-            STACK_VERSION="8.0.0-SNAPSHOT"
-            MODE = "saucelabs"
-          }
-          when {
-            allOf {
-              changeRequest()
               expression { return params.saucelab_test }
               expression { return env.ONLY_DOCS == "false" }
               // Releases from master should skip this particular stage.

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -125,7 +125,10 @@ services:
           - wait-for-apm-server
 
   node-puppeteer:
-    build: ../.ci/docker/node-puppeteer
+    build:
+      context: ../.ci/docker/node-puppeteer
+      args:
+        - NODEJS_VERSION=12
     container_name: node-puppeteer
     image: docker.elastic.co/observability-ci/node-puppeteer:12
     environment:
@@ -157,7 +160,10 @@ services:
     user: ${USER_ID}
 
   node-benchmark:
-    build: ../.ci/docker/node-playwright
+    build:
+      context: ../.ci/docker/node-playwright
+      args:
+        - NODEJS_VERSION=12
     container_name: node-playwright
     image: docker.elastic.co/observability-ci/node-playwright:12
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18152,9 +18152,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         },
         "rimraf": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:js": "eslint . --ext .js,.jsx,.ts",
     "lint:license": "node scripts/license-checker",
     "test": "npm run build && lerna run test --scope=$SCOPE --no-prefix  --concurrency=1",
+    "test:unit": "lerna run test:unit --scope=$SCOPE --no-prefix --concurrency=1",
     "build": "lerna run build",
     "bundlesize": "lerna run build:module && lerna run bundlesize",
     "serve": "node ./dev-utils/run-script.js startTestServers",


### PR DESCRIPTION
## What does this PR do?
It renames a shell script label to display a clearer name in the UI.

Minor improvements:
- Ignore .config and .npm from Git
- ~~Enforce pip3 when installing docker-compose (failed locally on my Mac)~~
>pip3 fails in the CI worker
- remove unused files
- bump `mime` dependency after running `npm install`
- join Saucelabs stage for PRs and merges to master, as they shared the same code
- Support building NodeJS 12 test images in a parameterised manner
- add descriptor file for nightly builds to build the Docker images, so that it's possible to consume them without building them on CI
- add a top-level script to run the unit tests by scope: `npm run test:unit`

```shell
$ SCOPE="@elastic/apm-rum-core" npm run test:unit
```

## Related issues
- Closes #932
- Relates https://github.com/elastic/apm-pipeline-library/pull/851