### PR TITLE
fix: null is not an object (evaluating 'reason.message')

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -172,7 +172,10 @@ class ErrorLogging {
 
   logPromiseEvent(promiseRejectionEvent) {
     const prefix = 'Unhandled promise rejection: '
-    let { reason = '<no reason specified>' } = promiseRejectionEvent
+    let { reason } = promiseRejectionEvent
+    if (reason == null) {
+      reason = '<no reason specified>'
+    }
     let errorEvent
 
     if (typeof reason.message === 'string') {

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -401,6 +401,13 @@ describe('ErrorLogging', function() {
       'Unhandled promise rejection: <function>'
     )
 
+    errorLogging.logPromiseEvent({
+      reason: null
+    })
+    expect(getEvents()[9][ERRORS].exception.message).toBe(
+      'Unhandled promise rejection: <no reason specified>'
+    )
+
     const events = getEvents()
 
     clearQueue()


### PR DESCRIPTION
When reason is null, apm sdk crashes on evaluating `reason.message`.