### PR TITLE
chore(jenkins): fix running issues with the packer-cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -9,8 +9,8 @@ puppeteer"
 if [ -x "$(command -v docker)" ]; then
   for flavour in ${FLAVOURS}
   do
-  local di="docker.elastic.co/observability-ci/node-${flavour}:${NODEJS_VERSION}"
+  di="docker.elastic.co/observability-ci/node-${flavour}:${NODEJS_VERSION}"
   (retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"
-  docker build --build-arg NODEJS_VERSION=${NODEJS_VERSION} -t ${di} ./.ci/docker/node-${flavour}
+  docker build --build-arg NODEJS_VERSION="${NODEJS_VERSION}" -t "${di}" .ci/docker/node-"${flavour}"  || echo "Error building ${flavour} Docker image, we continue"
   done
 fi


### PR DESCRIPTION
### What

Fix an issue with the local prefix that's only supported for functions

### Why

Otherwise the packer cache automation won't cache those docker images