### PR TITLE
feat(rum): propagate sampling decision through tracestate

### DIFF
--- a/dev-utils/test-servers.js
+++ b/dev-utils/test-servers.js
@@ -46,10 +46,10 @@ function startBackendAgentServer(port = 8003) {
   })
 
   function dTRespond(req, res) {
-    const dtHeader = req.headers['traceparent']
+    const header = req.headers['traceparent']
     let payload = { noHeader: true }
-    if (dtHeader) {
-      const splited = dtHeader.split('-')
+    if (header) {
+      const splited = header.split('-')
       payload = {
         version: splited[0],
         traceId: splited[1],

--- a/dev-utils/test-servers.js
+++ b/dev-utils/test-servers.js
@@ -39,17 +39,17 @@ function startBackendAgentServer(port = 8003) {
     if (req.method === 'OPTIONS') {
       res.header(
         'Access-Control-Allow-Headers',
-        'Origin, traceparent, Content-Type, Accept'
+        'Origin, traceparent, tracestate, Content-Type, Accept'
       )
     }
     next()
   })
 
   function dTRespond(req, res) {
-    const header = req.headers['traceparent']
+    const dtHeader = req.headers['traceparent']
     let payload = { noHeader: true }
-    if (header) {
-      const splited = header.split('-')
+    if (dtHeader) {
+      const splited = dtHeader.split('-')
       payload = {
         version: splited[0],
         traceId: splited[1],

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -226,6 +226,17 @@ var options = {
 ----
 
 [float]
+[[propagate-tracestate]]
+=== `propagateTracestate`
+
+* *Type:* Boolean
+* *Default:* `false`
+
+When distributed tracing is enabled, this option can be used to propagate the https://www.w3.org/TR/trace-context/#tracestate-header[tracestate]
+HTTP header to the configured origins. Before enabling this flag, make sure to change your <<server-configuration, server configuration>> to avoid
+Cross-Origin Resource Sharing errors.
+
+[float]
 [[event-throttling]]
 === Event throttling
 

--- a/docs/distributed-tracing-guide.asciidoc
+++ b/docs/distributed-tracing-guide.asciidoc
@@ -29,7 +29,20 @@ var apm = initApm({
 This effectively tells the agent to add the distributed tracing HTTP header (`traceparent`)
 to requests made to `https://api.example.com`.
 
-Note that distributed tracing headers are only appended to API calls.
+
+[float]
+[[enable-tracestate]]
+==== Propagate Tracestate
+
+https://www.w3.org/TR/trace-context/#tracestate-header[Tracestate] can be used to provide additional vendor
+specific trace information across different tracing systems and is a companion header for the `traceparent` field.
+
+By default, the RUM agent does not propagate the `tracestate` HTTP header to the configured origins. However, 
+the user can change that by enabling the <<propagate-tracestate, propagateTracestate>> flag which
+effectively tells the agent to add `tracestate` HTTP header to the configured origins.
+
+
+NOTE: distributed tracing headers (traceparent and tracestate) are only appended to API calls.
 To view the full trace from a backend service, see <<dynamic-html-doc>>.
 To read more about cross-origin requests and why this process is necessary,
 please see the MDN page on https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing].
@@ -46,7 +59,7 @@ Specifically, `https://api.example.com` will receive an `OPTIONS` request with t
 
 [source,header]
 ----
-Access-Control-Request-Headers: traceparent
+Access-Control-Request-Headers: traceparent, tracestate
 Access-Control-Request-Method: [request-method]
 Origin: [request-origin]
 ----
@@ -55,12 +68,12 @@ And should respond to it with these headers:
 
 [source,header]
 ----
-Access-Control-Allow-Headers: traceparent
+Access-Control-Allow-Headers: traceparent, tracestate
 Access-Control-Allow-Methods: [allowed-methods]
 Access-Control-Allow-Origin: [request-origin]
 ----
 
-NOTE: `Access-Control-Request-Headers` might include more headers than just `traceparent`.
+NOTE: `Access-Control-Request-Headers` might include more headers than `traceparent` and `tracestate`.
 The response should include all headers if the server wishes to let the browser send the original request.
 
 NOTE: To make sure all components in a distributed trace are included,

--- a/docs/distributed-tracing-guide.asciidoc
+++ b/docs/distributed-tracing-guide.asciidoc
@@ -38,9 +38,10 @@ https://www.w3.org/TR/trace-context/#tracestate-header[Tracestate] can be used t
 specific trace information across different tracing systems and is a companion header for the `traceparent` field.
 
 By default, the RUM agent does not propagate the `tracestate` HTTP header to the configured origins. However, 
-the user can change that by enabling the <<propagate-tracestate, propagateTracestate>> flag which
-effectively tells the agent to add `tracestate` HTTP header to the configured origins.
-
+the user can change that behaviour by enabling the <<propagate-tracestate, propagateTracestate>> flag which 
+effectively adds `tracestate` HTTP header to the configured origins. As of today, only the sampling decision is 
+propagated through the tracestate header. This information is then used by the APM server and the UI to
+calculate the service metrics like distributions and throughput (Service Maps).
 
 NOTE: distributed tracing headers (traceparent and tracestate) are only appended to API calls.
 To view the full trace from a backend service, see <<dynamic-html-doc>>.

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -212,6 +212,7 @@ export function compressTransaction(transaction) {
       sd: spans.length
     },
     sm: transaction.sampled,
+    sr: transaction.sampleRate,
     o: transaction.outcome
   }
 

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -174,7 +174,8 @@ export function compressTransaction(transaction) {
       s: span.start,
       d: span.duration,
       c: compressContext(span.context),
-      o: span.outcome
+      o: span.outcome,
+      sr: span.sample_rate
     }
     /**
      * Set parentId only for spans that are child of other spans

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -212,7 +212,7 @@ export function compressTransaction(transaction) {
       sd: spans.length
     },
     sm: transaction.sampled,
-    sr: transaction.sampleRate,
+    sr: transaction.sample_rate,
     o: transaction.outcome
   }
 

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -85,6 +85,7 @@ class Config {
       pageLoadSpanId: '',
       pageLoadSampled: false,
       pageLoadTransactionName: '',
+      propagateTracestate: false,
       transactionSampleRate: 1.0,
       centralConfig: false,
       monitorLongtasks: true,

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -117,6 +117,35 @@ function isDtHeaderValid(header) {
   )
 }
 
+function getTSHeaderValue(span) {
+  const sampleRate = span.sampleRate
+  if (sampleRate == null) {
+    return
+  }
+  const NAMESPACE = 'es'
+  const SEPARATOR = '='
+  /**
+   * We propagate the sampling decision through `es` tracestate key
+   * tracestate: es=s:0.1
+   * https://github.com/elastic/apm/blob/master/specs/agents/tracing-distributed-tracing.md#tracestate
+   */
+  return `${NAMESPACE}${SEPARATOR}s:${sampleRate}`
+}
+
+/**
+ * Appends request header to API calls depending on
+ * the call made through XHR, Fetch, etc.
+ */
+function setRequestHeader(target, name, value) {
+  if (typeof target.setRequestHeader === 'function') {
+    target.setRequestHeader(name, value)
+  } else if (target.headers && typeof target.headers.append === 'function') {
+    target.headers.append(name, value)
+  } else {
+    target[name] = value
+  }
+}
+
 function checkSameOrigin(source, target) {
   let isSame = false
   if (typeof target === 'string') {
@@ -377,6 +406,7 @@ export {
   parseDtHeaderValue,
   getServerTimingInfo,
   getDtHeaderValue,
+  getTSHeaderValue,
   getCurrentScript,
   getElasticScript,
   getTimeOrigin,
@@ -391,6 +421,7 @@ export {
   scheduleMacroTask,
   scheduleMicroTask,
   setLabel,
+  setRequestHeader,
   stripQueryStringFromUrl,
   find,
   removeInvalidChars,

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -118,8 +118,22 @@ function isDtHeaderValid(header) {
 }
 
 function getTSHeaderValue(span) {
-  const sampleRate = span.sampleRate
-  if (sampleRate == null) {
+  if (span.sampleRate == null) {
+    return
+  }
+  const sampleRate = String(span.sampleRate)
+  /**
+   * Validate sampling rate value
+   * Value is opaque string up to 256 characters printable ASCII RFC0020
+   * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+   * es entry must not contain `:` and `;` characters.
+   */
+  const VALID_VALUE_REGEX = /^[ -~]{0,255}[!-~]$/
+  const INVALID_VALUE_REGEX = /,|=|:|;/
+  if (
+    !VALID_VALUE_REGEX.test(sampleRate) ||
+    INVALID_VALUE_REGEX.test(sampleRate)
+  ) {
     return
   }
   const NAMESPACE = 'es'

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -117,23 +117,8 @@ function isDtHeaderValid(header) {
   )
 }
 
-function getTSHeaderValue(span) {
-  if (span.sampleRate == null) {
-    return
-  }
-  const sampleRate = String(span.sampleRate)
-  /**
-   * Validate sampling rate value
-   * Value is opaque string up to 256 characters printable ASCII RFC0020
-   * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
-   * es entry must not contain `:` and `;` characters.
-   */
-  const VALID_VALUE_REGEX = /^[ -~]{0,255}[!-~]$/
-  const INVALID_VALUE_REGEX = /,|=|:|;/
-  if (
-    !VALID_VALUE_REGEX.test(sampleRate) ||
-    INVALID_VALUE_REGEX.test(sampleRate)
-  ) {
+function getTSHeaderValue({ sampleRate }) {
+  if (typeof sampleRate !== 'number' || String(sampleRate).length > 256) {
     return
   }
   const NAMESPACE = 'es'

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -348,8 +348,8 @@ export default class PerformanceMonitoring {
   injectTSHeader(span, target) {
     /**
      * As the root trace is started from the browser for API calls, we
-     * are not doing any validation and only propagating the header
-     * to backend systems
+     * perform minimum validation only for the values and propagate the
+     * decision to the backend systems
      * https://www.w3.org/TR/trace-context/#tracestate-header
      */
     const headerValue = getTSHeaderValue(span)

--- a/packages/rum-core/src/performance-monitoring/span-base.js
+++ b/packages/rum-core/src/performance-monitoring/span-base.js
@@ -49,6 +49,7 @@ class SpanBase {
     this.id = options.id || generateRandomId(16)
     this.traceId = options.traceId
     this.sampled = options.sampled
+    this.sampleRate = options.sampleRate
     this.timestamp = options.timestamp
     this._start = getTime(options.startTime)
     this._end = undefined

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -90,7 +90,7 @@ class TransactionService {
 
   createOptions(options) {
     const config = this._config.config
-    let presetOptions = { sampleRate: config.transactionSampleRate }
+    let presetOptions = { transactionSampleRate: config.transactionSampleRate }
     let perfOptions = extend(presetOptions, options)
     if (perfOptions.managed) {
       perfOptions = extend(

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -90,7 +90,7 @@ class TransactionService {
 
   createOptions(options) {
     const config = this._config.config
-    let presetOptions = { transactionSampleRate: config.transactionSampleRate }
+    let presetOptions = { sampleRate: config.transactionSampleRate }
     let perfOptions = extend(presetOptions, options)
     if (perfOptions.managed) {
       perfOptions = extend(

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -174,8 +174,10 @@ class Transaction extends SpanBase {
     deleted && this.detectFinish()
   }
 
-  resetSpans() {
+  resetFields() {
     this.spans = []
+    this.sampleRate = 0
+    this.context = null
   }
 
   _onSpanEnd(span) {

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -52,7 +52,8 @@ class Transaction extends SpanBase {
 
     this.breakdownTimings = []
 
-    this.sampled = Math.random() <= this.options.transactionSampleRate
+    this.sampleRate = this.options.sampleRate
+    this.sampled = Math.random() <= this.sampleRate
   }
 
   addMarks(obj) {
@@ -98,6 +99,7 @@ class Transaction extends SpanBase {
     }
     opts.traceId = this.traceId
     opts.sampled = this.sampled
+    opts.sampleRate = this.sampleRate
 
     if (!opts.parentId) {
       opts.parentId = this.id

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -52,7 +52,7 @@ class Transaction extends SpanBase {
 
     this.breakdownTimings = []
 
-    this.sampleRate = this.options.sampleRate
+    this.sampleRate = this.options.transactionSampleRate
     this.sampled = Math.random() <= this.sampleRate
   }
 

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -177,7 +177,6 @@ class Transaction extends SpanBase {
   resetFields() {
     this.spans = []
     this.sampleRate = 0
-    this.context = null
   }
 
   _onSpanEnd(span) {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -336,7 +336,7 @@ describe('ApmServer', function() {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true}}'
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()
@@ -365,7 +365,7 @@ describe('ApmServer', function() {
     const result = apmServer.ndjsonTransactions(payload)
     /* eslint-disable max-len */
     const expected = [
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true}}\n',
+      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true,"sample_rate":0.1}}\n',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -336,7 +336,7 @@ describe('ApmServer', function() {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"m":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()
@@ -366,7 +366,7 @@ describe('ApmServer', function() {
     /* eslint-disable max-len */
     const expected = [
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true,"sample_rate":0.1}}\n',
-      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}\n',
+      '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10,"sample_rate":0.1}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type","subtype":"subtype"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'

--- a/packages/rum-core/test/common/compress.spec.js
+++ b/packages/rum-core/test/common/compress.spec.js
@@ -113,6 +113,7 @@ const V3_MAPPING = {
   responseStart: 'rs',
   runtime: 'ru',
   sampled: 'sm',
+  sample_rate: 'sr',
   samples: 'sa',
   'server-timing': 'set',
   service: 'se',

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -213,14 +213,17 @@ describe('lib/utils', function() {
   })
 
   it('should get correct tracestate value', function() {
-    const span = new Span('span1', 'span1', {
-      sampleRate: 0.115
-    })
-    expect(utils.getTSHeaderValue(span)).toBe('es=s:0.115')
-    span.sampleRate = 0
-    expect(utils.getTSHeaderValue(span)).toBe('es=s:0')
-    span.sampleRate = undefined
-    expect(utils.getTSHeaderValue(span)).toBeUndefined()
+    const span = new Span()
+    const validValues = [0.11, 0, 0.21311]
+    for (const value of validValues) {
+      span.sampleRate = value
+      expect(utils.getTSHeaderValue(span)).toBe(`es=s:${value}`)
+    }
+    const invalidValues = [undefined, null, 'a'.repeat(257), '1.2;-', '=0.23']
+    for (const value of invalidValues) {
+      span.sampleRate = value
+      expect(utils.getTSHeaderValue(span)).toBeUndefined()
+    }
   })
 
   it('should getTimeOrigin', function() {

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -212,6 +212,17 @@ describe('lib/utils', function() {
     expect(result).toBe(undefined)
   })
 
+  it('should get correct tracestate value', function() {
+    const span = new Span('span1', 'span1', {
+      sampleRate: 0.115
+    })
+    expect(utils.getTSHeaderValue(span)).toBe('es=s:0.115')
+    span.sampleRate = 0
+    expect(utils.getTSHeaderValue(span)).toBe('es=s:0')
+    span.sampleRate = undefined
+    expect(utils.getTSHeaderValue(span)).toBeUndefined()
+  })
+
   it('should getTimeOrigin', function() {
     var now = Date.now()
     var result = utils.getTimeOrigin()

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -219,7 +219,13 @@ describe('lib/utils', function() {
       span.sampleRate = value
       expect(utils.getTSHeaderValue(span)).toBe(`es=s:${value}`)
     }
-    const invalidValues = [undefined, null, 'a'.repeat(257), '1.2;-', '=0.23']
+    const invalidValues = [undefined, null, '1.2;-', '=0.23']
+    /**
+     * IE and Older browser versions does not support repeat function
+     */
+    if (typeof String.prototype.repeat === 'function') {
+      invalidValues.push('a'.repeat(257))
+    }
     for (const value of invalidValues) {
       span.sampleRate = value
       expect(utils.getTSHeaderValue(span)).toBeUndefined()

--- a/packages/rum-core/test/index.js
+++ b/packages/rum-core/test/index.js
@@ -74,6 +74,7 @@ export function generateTransaction(count, breakdown = false) {
     if (breakdown) {
       tr.sampled = true
       tr.sampleRate = 0.1
+      span.sampleRate = 0.1
       tr.selfTime = tr.duration() - span.duration()
       tr.breakdownTimings = captureBreakdown(tr)
     }

--- a/packages/rum-core/test/index.js
+++ b/packages/rum-core/test/index.js
@@ -73,6 +73,7 @@ export function generateTransaction(count, breakdown = false) {
     tr.end(1000)
     if (breakdown) {
       tr.sampled = true
+      tr.sampleRate = 0.1
       tr.selfTime = tr.duration() - span.duration()
       tr.breakdownTimings = captureBreakdown(tr)
     }

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -883,7 +883,6 @@ describe('PerformanceMonitoring', function() {
       expect(tr.sampled).toBe(false)
       const adjustedTransaction = adjustTransaction(tr)
       expect(adjustedTransaction.spans.length).toBe(0)
-      expect(adjustedTransaction.context).toEqual(null)
       expect(adjustedTransaction.sampleRate).toEqual(0)
     })
   })


### PR DESCRIPTION
+ fix #845 
+ Adds a new option `propagateTracestate` boolean to optionally add the tracestate header to all outgoing requests from the browser that are captured as transactions and spans . 
+ sent as `sample_rate` and `sr` in both v2 and v3 spec in the APM server. 
+ Updated the config doc and also CORS docs. 