### PR TITLE
docs: add angular supported version

### DIFF
--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -6,7 +6,7 @@ This document covers how to use Real User Monitoring JavaScript agent with Angul
 [[angular-supported-versions]]
 ==== Supported versions
 
-This integration supports Angular versions ≤ 8.2.2.
+This integration supports Angular versions < 9.
 
 [[installing-angular-integration]]
 ==== Installing Elastic APM Angular package

--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -6,7 +6,7 @@ This document covers how to use Real User Monitoring JavaScript agent with Angul
 [[angular-supported-versions]]
 ==== Supported versions
 
-This integration supports Angular versions ≤ 8.8.2.
+This integration supports Angular versions ≤ 8.2.2.
 
 [[installing-angular-integration]]
 ==== Installing Elastic APM Angular package

--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -3,6 +3,11 @@
 
 This document covers how to use Real User Monitoring JavaScript agent with Angular applications.
 
+[[angular-supported-versions]]
+==== Supported versions
+
+This integration supports Angular versions ≤ 8.8.2.
+
 [[installing-angular-integration]]
 ==== Installing Elastic APM Angular package
 
@@ -16,11 +21,11 @@ npm install @elastic/apm-rum-angular --save
 [float]
 ==== Instrumenting your Angular application
 
-The Angular integration package comes with a `ApmService` which uses Angular Depedency injection pattern and 
-will start subscribing to https://angular.io/api/router/Event[Angular Router Events] once the service is initialized. 
+The Angular integration package comes with a `ApmService` which uses Angular Depedency injection pattern and
+will start subscribing to https://angular.io/api/router/Event[Angular Router Events] once the service is initialized.
 
-`ApmService` must be initialized from either the application module or application component since 
-the RUM agent has to start capturing all the resources and API calls as soon as possible. 
+`ApmService` must be initialized from either the application module or application component since
+the RUM agent has to start capturing all the resources and API calls as soon as possible.
 
 
 [source,js]


### PR DESCRIPTION
Adds angular integration supported versions to reduce confusion. Per @vigneshshanmugam, Angular versions < 9 are supported.

Related to https://github.com/elastic/apm-agent-rum-js/issues/962.