### PR TITLE
feat(rum): expose agent configuration type info

### DIFF
--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -24,6 +24,36 @@
  */
 
 declare module '@elastic/apm-rum' {
+  export interface AgentConfigOptions {
+    apiVersion?: 2 | 3
+    serviceName?: string
+    serverUrl?: string
+    serviceVersion?: string
+    active?: boolean
+    instrument?: boolean
+    disableInstrumentations?: Array<InstrumentationTypes>
+    environment?: string
+    logLevel?: LogLevel
+    breakdownMetrics?: boolean
+    flushInterval?: number
+    pageLoadTraceId?: string
+    pageLoadSampled?: boolean
+    pageLoadSpanId?: string
+    pageLoadTransactionName?: string
+    distributedTracing?: boolean
+    distributedTracingOrigins?: Array<string | RegExp>
+    errorThrottleLimit?: number
+    errorThrottleInterval?: number
+    transactionThrottleLimit?: number
+    transactionThrottleInterval?: number
+    transactionSampleRate?: number
+    centralConfig?: boolean
+    ignoreTransactions?: Array<string | RegExp>
+    propagateTracestate?: boolean
+    eventsLimit?: number
+    queueLimit?: number
+  }
+
   type Init = (options?: AgentConfigOptions) => ApmBase
   const init: Init
 
@@ -106,32 +136,7 @@ declare class Span extends BaseSpan {
   sync: boolean
 }
 
-interface AgentConfigOptions {
-  apiVersion?: 2 | 3
-  serviceName?: string
-  serverUrl?: string
-  serviceVersion?: string
-  active?: boolean
-  instrument?: boolean
-  disableInstrumentations?: Array<InstrumentationTypes>
-  environment?: string
-  logLevel?: LogLevel
-  breakdownMetrics?: boolean
-  flushInterval?: number
-  pageLoadTraceId?: string
-  pageLoadSampled?: boolean
-  pageLoadSpanId?: string
-  pageLoadTransactionName?: string
-  distributedTracing?: boolean
-  distributedTracingOrigins?: Array<string>
-  errorThrottleLimit?: number
-  errorThrottleInterval?: number
-  transactionThrottleLimit?: number
-  transactionThrottleInterval?: number
-  transactionSampleRate?: number
-  centralConfig?: boolean
-  ignoreTransactions?: Array<string | RegExp>
-}
+
 
 interface TransactionOptions {
   managed?: boolean

--- a/packages/rum/test/types/index.spec.ts
+++ b/packages/rum/test/types/index.spec.ts
@@ -23,13 +23,14 @@
  *
  */
 
-import { ApmBase, init } from '@elastic/apm-rum'
+import { ApmBase, init, AgentConfigOptions } from '@elastic/apm-rum'
 
 const config: AgentConfigOptions = {
   active: true,
   logLevel: 'info',
   distributedTracing: true,
-  disableInstrumentations: ['xmlhttprequest', 'page-load']
+  disableInstrumentations: ['xmlhttprequest', 'page-load'],
+  distributedTracingOrigins: ['http://localhost:8080', /test/]
 }
 
 /** APM Base */


### PR DESCRIPTION
+ exposes the configuration option type info which could be used by other internal packages or libraries. 
+ `@elastic/apm-rum-angular` can use this exposed interface to improve its `init` function
+ Added the `RegExp` to the distributedTracingOrigins types since we added the support recently. 