### PR TITLE
ci: jjbb remove periodic-folder-trigger

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -53,7 +53,10 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
+    # Webhook based rather than polling otherwise the GitHub API quota
+    # will be overkilled. For such, periodic-folder-trigger is not needed
+    # anymore, so we keep the comment below for clarity.
+    # periodic-folder-trigger: 1w
     prune-dead-branches: true
     publishers:
     - email:


### PR DESCRIPTION
## What does this PR do?

Use the default value for periodic-folder-trigger = `none`

> periodic-folder-trigger (str): How often to scan for new branches or pull/change requests. Valid values: 1m, 2m, 5m, 10m, 15m, 20m, 25m, 30m, 1h, 2h, 4h, 8h, 12h, 1d, 2d, 1w, 2w, 4w. (default none)

[docs](https://docs.openstack.org/infra/jenkins-job-builder/project_workflow_multibranch.html)

## Why

We don't need to build PRs when there is change in their target branch, the reason is reducing the number of resources needed in the cloud.