### PR TITLE
chore(benchmarks): fix playwright image dependencies

### DIFF
--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get -qq install -y  --no-install-recommends \
     libharfbuzz-icu0 \
     libgstreamer-gl1.0-0 \
     libgstreamer-plugins-bad1.0-0 \
-    gstreamer1.0-plugins-good
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav
 
 # 4. Install Chromium dependencies
 RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
+ Fix the playwright webkit dependencies to run the benchmark script on master and on all PR's. 

```

Install missing packages with:
sudo apt-get install gstreamer1.0-libav

```
https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/PR-981/1/pipeline/