### PR TITLE
chore(rum-angular): fix build warnings in prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29494,9 +29494,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "stats-lite": "^2.2.0",
     "terser-webpack-plugin": "^3.1.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.7.3",
+    "typescript": "^3.8.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.7.2",
     "vue-router": "^3.1.3",

--- a/packages/rum-angular/karma.conf.js
+++ b/packages/rum-angular/karma.conf.js
@@ -25,7 +25,7 @@
 
 const { baseConfig, prepareConfig } = require('../../dev-utils/karma.js')
 
-module.exports = function(config) {
+module.exports = function (config) {
   const { watch, codeCoverage } = config.buildWebpack.options
   const angularConfig = {
     ...baseConfig,

--- a/packages/rum-angular/src/apm.service.ts
+++ b/packages/rum-angular/src/apm.service.ts
@@ -23,10 +23,12 @@
  *
  */
 
-import { Router, NavigationStart } from '@angular/router'
+import { Router } from '@angular/router'
+import type { NavigationStart } from '@angular/router'
 import { Inject, Injectable, NgZone } from '@angular/core'
 import { afterFrame } from '@elastic/apm-rum-core'
 import { ApmBase } from '@elastic/apm-rum'
+import type { AgentConfigOptions } from '@elastic/apm-rum'
 import { APM } from './apm.module'
 
 @Injectable({
@@ -39,7 +41,7 @@ export class ApmService {
     private readonly ngZone: NgZone
   ) {}
 
-  init(config) {
+  init(config: AgentConfigOptions) {
     const apmInstance = this.ngZone.runOutsideAngular(() =>
       this.apm.init(config)
     )


### PR DESCRIPTION
+ Updates typescript to 3.8 for importing the type information and fix the build warnings as a result of that. 
+ Use the `AgentConfigOption` for initialising the service. 