### PR TITLE
fix(rum): discard longtask spans from prev transaction

### DIFF
--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -287,8 +287,7 @@ export class PerfEntryRecorder {
   constructor(callback) {
     this.po = {
       observe: noop,
-      disconnect: noop,
-      takeRecords: noop
+      disconnect: noop
     }
     if (window.PerformanceObserver) {
       this.po = new PerformanceObserver(callback)
@@ -315,11 +314,6 @@ export class PerfEntryRecorder {
   }
 
   stop() {
-    /**
-     * Empties out the performance entries from the
-     * current observer
-     */
-    this.po.takeRecords()
     this.po.disconnect()
   }
 }

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -66,10 +66,19 @@ class TransactionService {
       const tr = this.getCurrentTransaction()
       if (tr && tr.captureTimings) {
         let capturePaint = false
+        /**
+         * For page load transactions, we capture all web vitals
+         * metrics including paint timings data and also the
+         * relative start time of transaction is set to zero
+         * to include all the buffered events
+         */
         if (tr.type === PAGE_LOAD) {
           capturePaint = true
         }
-        const { spans, marks } = captureObserverEntries(list, { capturePaint })
+        const { spans, marks } = captureObserverEntries(list, {
+          capturePaint,
+          trStart: capturePaint ? 0 : tr._start
+        })
         tr.spans.push(...spans)
         tr.addMarks({ agent: marks })
       }

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -108,7 +108,8 @@ describe('Metrics', () => {
     it('should create long tasks attribution data in span context', () => {
       list.getEntriesByType.and.callFake(mockObserverEntryTypes)
       const { spans } = captureObserverEntries(list, {
-        capturePaint: false
+        capturePaint: false,
+        trStart: 0
       })
       expect(spans.length).toBe(3)
       expect(spans).toEqual([
@@ -133,6 +134,27 @@ describe('Metrics', () => {
         }),
         jasmine.objectContaining({
           name: 'Longtask(same-origin-ancestor)',
+          context: {
+            custom: {
+              attribution: 'unknown',
+              type: 'window'
+            }
+          }
+        })
+      ])
+    })
+
+    it('should consider transaction startTime while creating longtask spans', () => {
+      list.getEntriesByType.and.callFake(mockObserverEntryTypes)
+      const { spans } = captureObserverEntries(list, {
+        capturePaint: false,
+        trStart: 1200
+      })
+      expect(spans.length).toBe(1)
+      expect(spans).toEqual([
+        jasmine.objectContaining({
+          name: 'Longtask(same-origin-ancestor)',
+          _start: 1923.40999995591,
           context: {
             custom: {
               attribution: 'unknown',
@@ -189,7 +211,8 @@ describe('Metrics', () => {
       it('should update tbt when longtasks are dispatched at different times', () => {
         list.getEntriesByType.and.callFake(mockObserverEntryTypes)
         captureObserverEntries(list, {
-          capturePaint: true
+          capturePaint: true,
+          trStart: 0
         })
         expect(metrics.tbt).toEqual({
           start: 745.4100000031758,
@@ -198,11 +221,24 @@ describe('Metrics', () => {
 
         // simulating second longtask entry list
         captureObserverEntries(list, {
-          capturePaint: true
+          capturePaint: true,
+          trStart: 0
         })
         expect(metrics.tbt).toEqual({
           start: 745.4100000031758,
           duration: 499.85999991185963
+        })
+      })
+
+      it('should consider transaction startTime while updating TBT', () => {
+        list.getEntriesByType.and.callFake(mockObserverEntryTypes)
+        captureObserverEntries(list, {
+          capturePaint: true,
+          trStart: 800
+        })
+        expect(metrics.tbt).toEqual({
+          start: 1023.40999995591,
+          duration: 245.35999997751787
         })
       })
 


### PR DESCRIPTION
+ fix #988 
+ We filter all of the longtasks for the page load transaction that happened even before it to make sure we calculate all of the buffered long tasks as well starting from 0.
+ For all subsequent route-change transactions, we only account for long tasks that happened after the transaction start time. This ensures that we are not including all previous buffered long task entries. 

**As a result all of the managed transactions gets adjusted to the start time of the first span, Now all of the subsequent transaction timings would be wrong and broken in the UI**