### PR TITLE
ci: notify when pre-release starts or fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -423,7 +423,7 @@ pipeline {
     }
     failure {
       whenTrue(params.release && env.PRE_RELEASE_STAGE == 'true') {
-        notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Pre release steps failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+        notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Pre-release steps failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,6 @@ pipeline {
         */
         stage('Checkout') {
           steps {
-            setEnvVar('PRE_RELEASE_STAGE', 'true')
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
@@ -70,6 +69,12 @@ pipeline {
                 // Skip all the stages except docs for PR's with asciidoc/md changes only
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
               }
+            }
+
+            whenTrue(params.release) {
+              setEnvVar('PRE_RELEASE_STAGE', 'true')
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release build just started",
+                           body: "Please go to (<${env.BUILD_URL}|here>) to see the build status or wait for further notifications.")
             }
           }
         }


### PR DESCRIPTION
### Why

Notify when things are not working before the release has even started