### PR TITLE
chore: use local servers in unit test

### DIFF
--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -136,9 +136,10 @@ describe('xhrPatch', function () {
     const req = new window.XMLHttpRequest()
     const getEvents = registerEventListener(req)
     try {
-      req.open('GET', 'https://somewhere.org/i-dont-exist', false)
+      req.open('GET', 'http://localhost:1234/doesnotexist', false)
       req.send()
     } catch (e) {
+      console.log(JSON.stringify(getEvents(true), null, 2))
       expect(
         getEvents(true).map(e => ({
           event: e.event,
@@ -154,7 +155,7 @@ describe('xhrPatch', function () {
   it('should correctly schedule events when async xhr fails', function (done) {
     const req = new window.XMLHttpRequest()
     const getEvents = registerEventListener(req)
-    req.open('GET', 'https://somewhere.org/i-dont-exist')
+    req.open('GET', 'http://localhost:1234/doesnotexist')
 
     req.addEventListener('loadend', () => {
       expect(

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -136,7 +136,7 @@ describe('xhrPatch', function () {
     const req = new window.XMLHttpRequest()
     const getEvents = registerEventListener(req)
     try {
-      req.open('GET', 'http://localhost:1234/doesnotexist', false)
+      req.open('GET', 'https://localhost:1234/doesnotexist', false)
       req.send()
     } catch (e) {
       expect(
@@ -154,7 +154,7 @@ describe('xhrPatch', function () {
   it('should correctly schedule events when async xhr fails', function (done) {
     const req = new window.XMLHttpRequest()
     const getEvents = registerEventListener(req)
-    req.open('GET', 'http://localhost:1234/doesnotexist')
+    req.open('GET', 'https://localhost:1234/doesnotexist')
 
     req.addEventListener('loadend', () => {
       expect(

--- a/packages/rum-core/test/common/xhr-patch.spec.js
+++ b/packages/rum-core/test/common/xhr-patch.spec.js
@@ -139,7 +139,6 @@ describe('xhrPatch', function () {
       req.open('GET', 'http://localhost:1234/doesnotexist', false)
       req.send()
     } catch (e) {
-      console.log(JSON.stringify(getEvents(true), null, 2))
       expect(
         getEvents(true).map(e => ({
           event: e.event,


### PR DESCRIPTION
+ Having public ips in the unit tests is flaky and would trigger disconnect errors like this - https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/PR-991/2/pipeline if the remote endpoint is having issues or changed. 
+ Disconnect is mainly due to these tests as the DNS query is more than 2 seconds. https://github.com/elastic/apm-agent-rum-js/blob/6b75589f0ed2c7fa90462396e256a9bc0e9ac33c/packages/rum-core/test/common/xhr-patch.spec.js#L139
