### PR TITLE
refactor: perf entries for hard & soft navigation

### DIFF
--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -181,7 +181,8 @@ export function calculateTotalBlockingTime(longtaskEntries) {
  */
 export function calculateCumulativeLayoutShift(clsEntries) {
   clsEntries.forEach(entry => {
-    if (!entry.hadRecentInput) {
+    // Only add the layout shift events without recent user input
+    if (!entry.hadRecentInput && entry.value) {
       metrics.cls += entry.value
     }
   })
@@ -195,7 +196,7 @@ export function calculateCumulativeLayoutShift(clsEntries) {
  *   marks: {}
  * }
  */
-export function captureObserverEntries(list, { capturePaint, trStart }) {
+export function captureObserverEntries(list, { isHardNavigation, trStart }) {
   const longtaskEntries = list.getEntriesByType(LONG_TASK).filter(entry => {
     return entry.startTime >= trStart
   })
@@ -206,9 +207,10 @@ export function captureObserverEntries(list, { capturePaint, trStart }) {
     marks: {}
   }
   /**
-   * Paint timings like FCP and LCP are available only for page-load navigation
+   * Web vitals including CLS, FID, LCP and other paint metrics are only
+   * available for hard navigation
    */
-  if (!capturePaint) {
+  if (!isHardNavigation) {
     return result
   }
   /**
@@ -265,6 +267,7 @@ export function captureObserverEntries(list, { capturePaint, trStart }) {
   }
 
   calculateTotalBlockingTime(longtaskEntries)
+
   const clsEntries = list.getEntriesByType(LAYOUT_SHIFT)
   calculateCumulativeLayoutShift(clsEntries)
 

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -65,19 +65,16 @@ class TransactionService {
     this.recorder = new PerfEntryRecorder(list => {
       const tr = this.getCurrentTransaction()
       if (tr && tr.captureTimings) {
-        let capturePaint = false
         /**
          * For page load transactions, we capture all web vitals
          * metrics including paint timings data and also the
          * relative start time of transaction is set to zero
          * to include all the buffered events
          */
-        if (tr.type === PAGE_LOAD) {
-          capturePaint = true
-        }
+        const isHardNavigation = tr.type === PAGE_LOAD
         const { spans, marks } = captureObserverEntries(list, {
-          capturePaint,
-          trStart: capturePaint ? 0 : tr._start
+          isHardNavigation,
+          trStart: isHardNavigation ? 0 : tr._start
         })
         tr.spans.push(...spans)
         tr.addMarks({ agent: marks })

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -62,45 +62,45 @@ describe('Metrics', () => {
 
     it('should not create long tasks spans if entries are not present', () => {
       const { spans } = captureObserverEntries(list, {
-        capturePaint: false
+        isHardNavigation: false
       })
       expect(spans).toEqual([])
     })
 
     it('should not mark LCP & FCP if entries are not preset ', () => {
       const { marks } = captureObserverEntries(list, {
-        capturePaint: true
+        isHardNavigation: true
       })
       expect(marks).toEqual({})
     })
 
-    it('should return largest contentful paint if capturePaint is true', () => {
+    it('should return largest contentful paint if isHardNavigation is true', () => {
       list.getEntriesByType.and.callFake(mockObserverEntryTypes)
-      const { marks: paintFalse } = captureObserverEntries(list, {
-        capturePaint: false
+      const { marks: notHardNavigation } = captureObserverEntries(list, {
+        isHardNavigation: false
       })
-      expect(paintFalse).toEqual({})
+      expect(notHardNavigation).toEqual({})
 
-      const { marks: paintTrue } = captureObserverEntries(list, {
-        capturePaint: true
+      const { marks: hardNavigation } = captureObserverEntries(list, {
+        isHardNavigation: true
       })
 
-      expect(paintTrue).toEqual({
+      expect(hardNavigation).toEqual({
         largestContentfulPaint: 1040
       })
     })
 
-    it('should set firstContentfulPaint if capturePaint is true ', () => {
+    it('should set firstContentfulPaint if isHardNavigation is true ', () => {
       list.getEntriesByName.and.callFake(mockObserverEntryNames)
-      const { marks: paintFalse } = captureObserverEntries(list, {
-        capturePaint: false
+      const { marks: notHardNavigation } = captureObserverEntries(list, {
+        isHardNavigation: false
       })
-      expect(paintFalse).toEqual({})
+      expect(notHardNavigation).toEqual({})
 
-      const { marks: paintTrue } = captureObserverEntries(list, {
-        capturePaint: true
+      const { marks: hardNavigation } = captureObserverEntries(list, {
+        isHardNavigation: true
       })
-      expect(paintTrue).toEqual({
+      expect(hardNavigation).toEqual({
         firstContentfulPaint: jasmine.any(Number)
       })
     })
@@ -108,7 +108,7 @@ describe('Metrics', () => {
     it('should create long tasks attribution data in span context', () => {
       list.getEntriesByType.and.callFake(mockObserverEntryTypes)
       const { spans } = captureObserverEntries(list, {
-        capturePaint: false,
+        isHardNavigation: false,
         trStart: 0
       })
       expect(spans.length).toBe(3)
@@ -147,7 +147,7 @@ describe('Metrics', () => {
     it('should consider transaction startTime while creating longtask spans', () => {
       list.getEntriesByType.and.callFake(mockObserverEntryTypes)
       const { spans } = captureObserverEntries(list, {
-        capturePaint: false,
+        isHardNavigation: false,
         trStart: 1200
       })
       expect(spans.length).toBe(1)
@@ -211,7 +211,7 @@ describe('Metrics', () => {
       it('should update tbt when longtasks are dispatched at different times', () => {
         list.getEntriesByType.and.callFake(mockObserverEntryTypes)
         captureObserverEntries(list, {
-          capturePaint: true,
+          isHardNavigation: true,
           trStart: 0
         })
         expect(metrics.tbt).toEqual({
@@ -221,7 +221,7 @@ describe('Metrics', () => {
 
         // simulating second longtask entry list
         captureObserverEntries(list, {
-          capturePaint: true,
+          isHardNavigation: true,
           trStart: 0
         })
         expect(metrics.tbt).toEqual({
@@ -233,7 +233,7 @@ describe('Metrics', () => {
       it('should consider transaction startTime while updating TBT', () => {
         list.getEntriesByType.and.callFake(mockObserverEntryTypes)
         captureObserverEntries(list, {
-          capturePaint: true,
+          isHardNavigation: true,
           trStart: 800
         })
         expect(metrics.tbt).toEqual({
@@ -273,7 +273,7 @@ describe('Metrics', () => {
       it('should capture fid experience metric on input entries', () => {
         list.getEntriesByType.and.callFake(mockObserverEntryTypes)
         captureObserverEntries(list, {
-          capturePaint: true
+          isHardNavigation: true
         })
         expect(metrics.fid).toBe(6)
       })


### PR DESCRIPTION
+ using `isHardNavigation` flag to distinguish hard and soft navigations to make it clear that we are capturing different observer entries for `page-load` and other transactions. 