### PR TITLE
chore: remove alpha from docs and cleanup

### DIFF
--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -15,7 +15,7 @@ Install the `@elastic/apm-rum-angular` package as a dependency to your applicati
 
 [source,bash]
 ----
-npm install @elastic/apm-rum-angular@alpha --save
+npm install @elastic/apm-rum-angular --save
 ----
 
 NOTE: If you are using an Angular version < 9.0, use @elastic/apm-rum-angular 1.x to instrument your application. Details are available in a https://www.elastic.co/guide/en/apm/agent/rum-js/4.x/angular-integration.html[prior release].

--- a/packages/rum-angular/package.json
+++ b/packages/rum-angular/package.json
@@ -17,7 +17,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && cd dist",
+    "prepublishOnly": "npm run build",
     "build": "ng build --prod",
     "build:e2e": "ng build app --prod",
     "test:unit": "ng test",


### PR DESCRIPTION
+ Major version ^2.x.x has been published, so we dont need the `alpha` flag anymore. 
+ cd directory is not required as lerna would use the `publishConfig.directory` while publishing contents. 