### PR TITLE
chore: update angular changelog

### DIFF
--- a/packages/rum-angular/CHANGELOG.md
+++ b/packages/rum-angular/CHANGELOG.md
@@ -5,6 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.0.1](https://github.com/elastic/apm-agent-rum-js/compare/@elastic/apm-rum-angular@1.2.3...@elastic/apm-rum-angular@2.0.1) (2021-04-19)
 
+ * Please use version `2.0.1` for Angular 9-11 support. Version `2.0.0` has broken modules published, As a result it was marked as deprecated. 
+
 **Note:** Version bump only for package @elastic/apm-rum-angular
 
 


### PR DESCRIPTION
+ States the message as 2.0 is deprecated and explaining why 2.0.1 is the recommended package.