### PR TITLE
ci: bump elastic stack version

### DIFF
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -31,7 +31,7 @@ for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/script
   git add $FILE
 done
 
-git diff --staged --quiet || git commit -m "[Automation] Update elastic stack release version to ${VERSION_RELEASE} and ${VERSION_DEV}"
+git diff --staged --quiet || git commit -m "chore: update elastic stack release ${VERSION_RELEASE} and ${VERSION_DEV}"
 git --no-pager log -1
 
 echo "You can now push and create a Pull Request"

--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,15 +23,14 @@ else
 fi
 
 echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
-${SED} -E -e "s#(values '8.0.0-SNAPSHOT', '7.x',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" .ci/Jenkinsfile
-${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" .ci/Jenkinsfile
-git add .ci/Jenkinsfile
+${SED} -E -e "s#(values '8.0.0-SNAPSHOT', '7.x',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
+${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" Jenkinsfile
+git add Jenkinsfile
 for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/scripts/test.sh dev-utils/docker-compose.yml ; do
   ${SED} -E -e "s#:-[0-9]+\.[0-9]+\.[0-9]+#:-${VERSION_RELEASE}#g" $FILE
   git add $FILE
 done
 
-git add .ci/Jenkinsfile
 git diff --staged --quiet || git commit -m "[Automation] Update elastic stack release version to ${VERSION_RELEASE} and ${VERSION_DEV}"
 git --no-pager log -1
 

--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Given the stack version this script will bump the release version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the minor version to be bumped. Mandatory.
+#	$1 -> the major version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+VERSION_RELEASE=${1:?$MSG}
+VERSION_DEV=${2:?$MSG}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
+${SED} -E -e "s#(values '8.0.0-SNAPSHOT', '7.x',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" .ci/Jenkinsfile
+${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" .ci/Jenkinsfile
+git add .ci/Jenkinsfile
+for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/scripts/test.sh dev-utils/docker-compose.yml ; do
+  ${SED} -E -e "s#:-[0-9]+\.[0-9]+\.[0-9]+#:-${VERSION_RELEASE}#g" $FILE
+  git add $FILE
+done
+
+git add .ci/Jenkinsfile
+git diff --staged --quiet || git commit -m "[Automation] Update elastic stack release version to ${VERSION_RELEASE} and ${VERSION_DEV}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"

--- a/.ci/scripts/load-testing.sh
+++ b/.ci/scripts/load-testing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-STACK_VERSION=${1:-7.10.0}
+STACK_VERSION=${1:-7.13.1}
 USER_ID="$(id -u):$(id -g)"
 NODEJS_VERSION=$(cat ./dev-utils/.node-version)
 

--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 export NODEJS_VERSION=$(cat ./dev-utils/.node-version)
-export STACK_VERSION=${STACK_VERSION:-7.10.0}
+export STACK_VERSION=${STACK_VERSION:-7.13.1}
 
 STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures
 
 # We are building the images here even though the Docker images are already cached in Packer.
 # This is because there could be changes in the PR affecting the files copied to the Docker image,
-# which we want to test in the current build. 
+# which we want to test in the current build.
 NODEJS_VERSION="${NODEJS_VERSION}" \
 STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO build >docker-compose.log 2>docker-compose.err

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -xeo pipefail
-STACK_VERSION=${STACK_VERSION:-7.10.0}
+STACK_VERSION=${STACK_VERSION:-7.13.1}
 
 pip install docker-compose>=1.25.4
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -557,11 +557,11 @@ def prepareRelease(String nodeVersion='node:lts', Closure body){
 
 def runAllScopes(){
   def scopes = [
-    'SCOPE=@elastic/apm-rum-core',
-    'SCOPE=@elastic/apm-rum',
-    'SCOPE=@elastic/apm-rum-react',
-    'SCOPE=@elastic/apm-rum-angular',
-    'SCOPE=@elastic/apm-rum-vue'
+    '@elastic/apm-rum-core',
+    '@elastic/apm-rum',
+    '@elastic/apm-rum-react',
+    '@elastic/apm-rum-angular',
+    '@elastic/apm-rum-vue'
   ]
   scopes.each{ scope ->
     runTest(stack: env.STACK_VERSION, scope: scope)

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.13.1}
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
@@ -34,7 +34,7 @@ services:
 
   apm-server:
     container_name: apm-server
-    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.13.1}
     ports:
       - "127.0.0.1:${APM_SERVER_PORT:-8200}:8200"
     environment:
@@ -84,7 +84,7 @@ services:
 
   kibana:
     container_name: kibana
-    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.13.1}
     environment:
       SERVER_NAME: kibana.example.org
       ELASTICSEARCH_URL: http://elasticsearch:9200


### PR DESCRIPTION
### What

* Bump version 7.10.0 to 7.13.1
* Script to bump release versions automatically

### Actions

* Add this repo to the bump release automation

### Issues

There is no a tracked issue for this particular PR. I identified this particular need when raising a couple of issues regarding build failures in the CI.

### Test

```bash
$ git checkout master
$ .ci/bump-stack-release-version.sh 7.13.1 7.13.2
```

produces


```diff
diff --git a/.ci/scripts/load-testing.sh b/.ci/scripts/load-testing.sh
index f77462d..4a09667 100755
--- a/.ci/scripts/load-testing.sh
+++ b/.ci/scripts/load-testing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-STACK_VERSION=${1:-7.10.0}
+STACK_VERSION=${1:-7.13.1}
 USER_ID="$(id -u):$(id -g)"
 NODEJS_VERSION=$(cat ./dev-utils/.node-version)
 
diff --git a/.ci/scripts/pull_and_build.sh b/.ci/scripts/pull_and_build.sh
index bd49254..b070202 100755
--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export NODEJS_VERSION=$(cat ./dev-utils/.node-version)
-export STACK_VERSION=${STACK_VERSION:-7.10.0}
+export STACK_VERSION=${STACK_VERSION:-7.13.1}
 
 STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures
diff --git a/.ci/scripts/test.sh b/.ci/scripts/test.sh
index f629f1b..25f1c9a 100755
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -xeo pipefail
-STACK_VERSION=${STACK_VERSION:-7.10.0}
+STACK_VERSION=${STACK_VERSION:-7.13.1}
 
 pip install docker-compose>=1.25.4
 
diff --git a/Jenkinsfile b/Jenkinsfile
index 17ecb9f..2ed3113 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     booleanParam(name: 'saucelab_test', defaultValue: "true", description: "Enable run a Sauce lab test")
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from master.')
-    string(name: 'stack_version', defaultValue: '7.10.0', description: "What's the Stack Version to be used for the load testing?")
+    string(name: 'stack_version', defaultValue: '7.13.1', description: "What's the Stack Version to be used for the load testing?")
   }
   stages {
     stage('Initializing'){
@@ -112,11 +112,7 @@ pipeline {
             axes {
                 axis {
                   name 'STACK_VERSION'
-                  values (
-                    '8.0.0-SNAPSHOT',
-                    '7.7.0',
-                    '7.0.0'
-                  )
+                  values '8.0.0-SNAPSHOT', '7.x', '7.13.2'
                 }
                 axis {
                   name 'SCOPE'
diff --git a/dev-utils/docker-compose.yml b/dev-utils/docker-compose.yml
index 54b3b9b..36ffc7b 100644
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.13.1}
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
@@ -34,7 +34,7 @@ services:
 
   apm-server:
     container_name: apm-server
-    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.13.1}
     ports:
       - "127.0.0.1:${APM_SERVER_PORT:-8200}:8200"
     environment:
@@ -84,7 +84,7 @@ services:
 
   kibana:
     container_name: kibana
-    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.10.0}
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.13.1}
     environment:
       SERVER_NAME: kibana.example.org
       ELASTICSEARCH_URL: http://elasticsearch:9200

```
