### PR TITLE
fix: set stage result

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ pipeline {
               post {
                 always {
                   archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  catchError(message: 'sendBenchmarks failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                     log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
                     whenTrue(env.CHANGE_ID == null){
                       sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
@@ -276,7 +276,7 @@ pipeline {
               post {
                 always {
                   archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  catchError(message: 'sendBenchmarks failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                     log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
                     whenTrue(env.CHANGE_ID == null){
                       sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmarks-rum-load-test')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ pipeline {
               post {
                 always {
                   archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
+                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
                     whenTrue(env.CHANGE_ID == null){
                       sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
@@ -276,7 +276,7 @@ pipeline {
               post {
                 always {
                   archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
+                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
                     whenTrue(env.CHANGE_ID == null){
                       sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmarks-rum-load-test')


### PR DESCRIPTION
The catchError is hidden and stage error so we need to force the stage result to know which stage is failing.

```
Benchmarks: there was a response with an error. Review response {"took":8,"errors":true,"items":[{"index":{"_index":"benchmarks-rum-load-test","_type":"_doc","_id":"3tGPJXoBfbEDP-36W9O7","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse","caused_by":{"type":"not_x_content_exception","reason":"not_x_content_exception: Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes"}}}}]}
```