### PR TITLE
fix(rum-core): ensure apmRequest is called for events

### DIFF
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       apm-server -e
         -E apm-server.rum.enabled=true
         -E apm-server.rum.event_rate.limit=100000
+        -E apm-server.rum.allow_headers=["x-custom-header"]
         -E apm-server.host=0.0.0.0:8200
         -E apm-server.read_timeout=1m
         -E apm-server.shutdown_timeout=2m

--- a/dev-utils/test-servers.js
+++ b/dev-utils/test-servers.js
@@ -39,7 +39,7 @@ function startBackendAgentServer(port = 8003) {
     if (req.method === 'OPTIONS') {
       res.header(
         'Access-Control-Allow-Headers',
-        'Origin, traceparent, tracestate, Content-Type, Accept'
+        'Origin, traceparent, tracestate, Content-Type, Accept, x-custom-header'
       )
     }
     next()

--- a/dev-utils/test-servers.js
+++ b/dev-utils/test-servers.js
@@ -39,7 +39,7 @@ function startBackendAgentServer(port = 8003) {
     if (req.method === 'OPTIONS') {
       res.header(
         'Access-Control-Allow-Headers',
-        'Origin, traceparent, tracestate, Content-Type, Accept, x-custom-header'
+        'Origin, traceparent, tracestate, Content-Type, Accept'
       )
     }
     next()

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -82,7 +82,8 @@ class ApmServer {
       'Content-Type': 'application/x-ndjson'
     }
     const apmRequest = this._configService.get('apmRequest')
-    return compressPayload(payload, headers)
+    const params = { payload, headers, beforeSend: apmRequest }
+    return compressPayload(params)
       .catch(error => {
         if (__DEV__) {
           this._loggingService.debug(
@@ -90,7 +91,7 @@ class ApmServer {
             error.message
           )
         }
-        return { payload, headers, beforeSend: apmRequest }
+        return params
       })
       .then(result => this._makeHttpRequest('POST', endPoint, result))
       .then(({ responseText }) => responseText)

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -294,7 +294,7 @@ export function compressMetricsets(breakdowns) {
  * CompressionStream spec supported only in Chromium browsers
  * Spec : https://wicg.github.io/compression/
  */
-export function compressPayload(payload, headers, type = 'gzip') {
+export function compressPayload(params, type = 'gzip') {
   const isCompressionStreamSupported = typeof CompressionStream === 'function'
   return new Promise(resolve => {
     /**
@@ -302,9 +302,9 @@ export function compressPayload(payload, headers, type = 'gzip') {
      * is not supported in browser
      */
     if (!isCompressionStreamSupported) {
-      return resolve({ payload, headers })
+      return resolve(params)
     }
-
+    const { payload, headers, beforeSend } = params
     /**
      * create a blob with the original payload data and convert it
      * as readable stream
@@ -323,7 +323,7 @@ export function compressPayload(payload, headers, type = 'gzip') {
      */
     return new Response(compressedStream).blob().then(payload => {
       headers['Content-Encoding'] = type
-      return resolve({ payload, headers })
+      return resolve({ payload, headers, beforeSend })
     })
   })
 }

--- a/packages/rum-core/test/benchmarks/compress.bench.js
+++ b/packages/rum-core/test/benchmarks/compress.bench.js
@@ -43,8 +43,9 @@ suite('Compress', () => {
     .join('')
 
   benchmark('compress payload', async () => {
-    await compressPayload(ndjsonPayload, {
-      'Content-Type': 'application/x-ndjson'
+    await compressPayload({
+      payload: ndjsonPayload,
+      headers: { 'Content-Type': 'application/x-ndjson' }
     })
   })
 })

--- a/packages/rum-core/test/common/compress.spec.js
+++ b/packages/rum-core/test/common/compress.spec.js
@@ -297,10 +297,10 @@ describe('Compress', function () {
       .join('')
     const isCompressionStreamSupported = typeof CompressionStream === 'function'
     const originalHeaders = { 'Content-Type': 'application/x-ndjson' }
-    let { payload, headers } = await compressPayload(
-      ndjsonPayload,
-      originalHeaders
-    )
+    let { payload, headers } = await compressPayload({
+      payload: ndjsonPayload,
+      headers: originalHeaders
+    })
     if (isCompressionStreamSupported) {
       const decompressedBlob = await decompressPayload(payload)
       payload = await view(decompressedBlob)

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -41,7 +41,7 @@ const elasticApm = createApmBase({
   pageLoadSampled: true,
   session: true,
   apmRequest: ({ xhr }) => {
-    xhr.setRequestHeader('custom', 'value')
+    xhr.setRequestHeader('x-custom-header', 'foo')
     return true
   }
 })

--- a/packages/rum/test/e2e/general-usecase/app.js
+++ b/packages/rum/test/e2e/general-usecase/app.js
@@ -40,7 +40,7 @@ const elasticApm = createApmBase({
   pageLoadSpanId: 'bbd8bcc3be14d814',
   pageLoadSampled: true,
   session: true,
-  apmRequest(xhr) {
+  apmRequest: ({ xhr }) => {
     xhr.setRequestHeader('custom', 'value')
     return true
   }


### PR DESCRIPTION
+ fix elastic/apm-agent-rum-js#1054 
+ When payload is compressed the `apmRequest` function was not sent correctly which made the function return `undefined` for all cases. Now we correctly propagate the function to all callers. 