### PR TITLE
feat(rum-core): add serverUrlPrefix config option

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -22,6 +22,21 @@ Your Elastic APM service name.
 The URL used to make requests to the APM Server.
 
 [float]
+[[server-url-prefix]]
+=== `serverUrlPrefix`
+
+* *Type:* String
+* *Default* `/intake/v${apiVersion}/rum/events`
+
+The server prefix URL used to make requests to the APM Server. Some ad blockers block outgoing requests
+from the browser if the default server prefix URL is being used. Using a custom server prefix URL can be used to
+evade the ad blocker.
+
+NOTE: If the default server prefix URL is overwritten, the reverse proxy that sits between the 
+APM Server and the rum agent must reroute traffic to `/intake/v${apiVersion}/rum/events`
+so the APM Server knows what intake API to use.
+
+[float]
 [[service-version]]
 === `serviceVersion`
 

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -336,7 +336,9 @@ class ApmServer {
       this.ndjsonTransactions(filteredPayload[TRANSACTIONS], compress)
     )
     const ndjsonPayload = ndjson.join('')
-    const endPoint = cfg.get('serverUrl') + `/intake/v${apiVersion}/rum/events`
+    const serverUrlPrefix =
+      cfg.get('serverUrlPrefix') || `/intake/v${apiVersion}/rum/events`
+    const endPoint = cfg.get('serverUrl') + serverUrlPrefix
     return this._postJson(endPoint, ndjsonPayload)
   }
 }

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -69,6 +69,7 @@ class Config {
       serviceVersion: '',
       environment: '',
       serverUrl: 'http://localhost:8200',
+      serverUrlPrefix: '',
       active: true,
       instrument: true,
       disableInstrumentations: [],

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -28,6 +28,7 @@ declare module '@elastic/apm-rum' {
     apiVersion?: 2 | 3
     serviceName?: string
     serverUrl?: string
+    serverUrlPrefix?: string
     serviceVersion?: string
     active?: boolean
     instrument?: boolean


### PR DESCRIPTION
Change hardcoded serverUrlPrefix to passable parameter to evade ad blockers

fixes issue #1078