### PR TITLE
docs: document allowed naming for serviceName

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -10,7 +10,8 @@ While initializing the agent you can provide the following configuration options
 * *Type:* String
 * *Required*
 
-Your Elastic APM service name.
+The Elastic APM service name is used to differentiate data from each of your services. 
+Can only contain alphanumeric characters, spaces, underscores, and dashes (must match ^[a-zA-Z0-9 _-]+$).
 
 [float]
 [[server-url]]


### PR DESCRIPTION
Ensure limitations on naming are communicated for serviceName.
As per https://www.elastic.co/guide/en/apm/get-started/master/install-and-run.html#agents