### PR TITLE
ci: simplify docker command to attempt to avoid occasional error

### DIFF
--- a/.ci/scripts/load-testing.sh
+++ b/.ci/scripts/load-testing.sh
@@ -16,7 +16,5 @@ NODEJS_VERSION="${NODEJS_VERSION}" \
 STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml up \
   --build \
-  --abort-on-container-exit \
   --exit-code-from load-testing \
-  --remove-orphans \
   load-testing


### PR DESCRIPTION
This is an attempt to possibly avoid the following error when running a command such as `.ci/scripts/load-testing.sh 7.13.1`:

```
[2021-09-22T12:53:35.652Z] node-playwright        | found 672 vulnerabilities (481 low, 108 moderate, 83 high)
[2021-09-22T12:53:35.652Z] node-playwright        |   run `npm audit fix` to fix them, or `npm audit` for details
[2021-09-22T12:53:35.652Z] node-playwright        | + set -eo pipefail
[2021-09-22T12:53:35.652Z] node-playwright        | + npx lerna run build:main
[2021-09-22T12:53:36.351Z] node-playwright        | lerna notice cli v3.19.0
[2021-09-22T12:53:36.351Z] node-playwright        | lerna info versioning independent
[2021-09-22T12:53:36.351Z] node-playwright        | lerna info ci enabled
[2021-09-22T12:53:36.351Z] node-playwright        | lerna info Executing command in 4 packages: "npm run build:main"
[2021-09-22T12:53:36.351Z] node-playwright        | @elastic/apm-rum-core: > @elastic/apm-rum-core@5.12.1 build:main /app/packages/rum-core
[2021-09-22T12:53:36.351Z] node-playwright        | @elastic/apm-rum-core: > BABEL_ENV=BROWSER_PROD npx babel src -d dist/lib
[2021-09-22T12:53:39.488Z] node-playwright        | @elastic/apm-rum-core: Successfully compiled 41 files with Babel (3138ms).
[2021-09-22T12:53:40.186Z] node-playwright        | @elastic/apm-rum: > @elastic/apm-rum@5.9.1 build:main /app/packages/rum
[2021-09-22T12:53:40.187Z] node-playwright        | @elastic/apm-rum: > BABEL_ENV=BROWSER_PROD npx babel src -d dist/lib
[2021-09-22T12:53:41.725Z] node-playwright        | @elastic/apm-rum: Successfully compiled 3 files with Babel (1479ms).
[2021-09-22T12:53:41.725Z] node-playwright        | @elastic/apm-rum-react: > @elastic/apm-rum-react@1.3.1 build:main /app/packages/rum-react
[2021-09-22T12:53:41.725Z] node-playwright        | @elastic/apm-rum-react: > BABEL_ENV=BROWSER_PROD npx babel src -d dist/lib
[2021-09-22T12:53:41.726Z] node-playwright        | @elastic/apm-rum-vue: > @elastic/apm-rum-vue@1.3.1 build:main /app/packages/rum-vue
[2021-09-22T12:53:41.726Z] node-playwright        | @elastic/apm-rum-vue: > BABEL_ENV=BROWSER_PROD npx babel src -d dist/lib
[2021-09-22T12:53:43.174Z] node-playwright        | @elastic/apm-rum-vue: Successfully compiled 3 files with Babel (1322ms).
[2021-09-22T12:53:43.174Z] node-playwright        | @elastic/apm-rum-react: Successfully compiled 3 files with Babel (1587ms).
[2021-09-22T12:53:43.174Z] node-playwright        | lerna success run Ran npm script 'build:main' in 4 packages in 7.0s:
[2021-09-22T12:53:43.174Z] node-playwright        | lerna success - @elastic/apm-rum-core
[2021-09-22T12:53:43.174Z] node-playwright        | lerna success - @elastic/apm-rum-react
[2021-09-22T12:53:43.174Z] node-playwright        | lerna success - @elastic/apm-rum-vue
[2021-09-22T12:53:43.174Z] node-playwright        | lerna success - @elastic/apm-rum
[2021-09-22T12:53:43.174Z] node-playwright        | + node ./scripts/apm-server-load-test.js apm-agent-load-testing-results.json
[2021-09-22T12:54:12.287Z] node-playwright exited with code 0
[2021-09-22T12:54:12.287Z] No such container: 756a247431c5f37c17033c3a9ed5ecf404faf59e0f52b53c9bde5186f95800a3
[2021-09-22T12:54:12.287Z] Aborting on container exit...
script returned exit code 1
```

Link to CI job with failure: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/master/433/pipeline/2340/

It's not totally clear what's happening here but the error that's causing the script to fail is clearly being emitted from the Docker engine.

This change does two things:

1. Removes ` --abort-on-container-exit`. This change is cosmetic, because `--exit-code-from` implies ` --abort-on-container-exit` as [per the Docker documentation](https://docs.docker.com/compose/reference/up/).
2. Removes `--remove-orphans`. This seems as if it is the most likely candidate for Docker getting confused.

In looking at the logs, there is no sign of any reference to the container which can't be found, so it's not clear where it's coming from. I don't think there's any harm in failing to clean up orphans in the final invocation of `docker compose` in the shell script.

WDYT?