### PR TITLE
feat(rum-core): custom transaction name for user-interactions

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -88,6 +88,15 @@ to the server, the agent discards transactions with no spans (e.g. no network ac
 if the click interaction results in route change, then a `route-change`
 transaction would be captured instead.
 
+The transaction name can be influenced either by using the `name` or preferably the `data-transaction-name` HTML attribute. 
+Examples of transaction names based on the html attributes present: 
+
+* `<button></button>`: `Click - button`
+
+* `<button name="purchase"></button>`: `Click - button["purchase"]`
+
+* `<button data-transaction-name="purchase"></button>`: `Click - purchase`
+
 
 [float]
 [[spa]]

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -191,15 +191,13 @@ export default class PerformanceMonitoring {
         const tagName = target.tagName.toLowerCase()
 
         // use custom html attribute 'data-transaction-name' - otherwise fall back to "tagname" + "name"-Attribute
-        let transactionName = ''
+        let transactionName = tagName
         if (!!target.dataset.transactionName) {
           transactionName = target.dataset.transactionName
         } else {
           const name = target.getAttribute('name')
           if (!!name) {
             transactionName = `${tagName}["${name}"]`
-          } else {
-            transactionName = tagName
           }
         }
 

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -188,14 +188,20 @@ export default class PerformanceMonitoring {
         task.eventType === 'click'
       ) {
         const target = task.target
-        const name = target.getAttribute('name')
-
-        let additionalInfo = ''
-        if (name) {
-          additionalInfo = `["${name}"]`
-        }
-
         const tagName = target.tagName.toLowerCase()
+
+        // use custom html attribute 'data-transaction-name' - otherwise fall back to "tagname" + "name"-Attribute
+        let transactionName = ''
+        if (!!target.dataset.transactionName) {
+          transactionName = target.dataset.transactionName
+        } else {
+          const name = target.getAttribute('name')
+          if (!!name) {
+            transactionName = `${tagName}["${name}"]`
+          } else {
+            transactionName = tagName
+          }
+        }
 
         /**
          * We reduce the reusability threshold to make sure
@@ -203,7 +209,7 @@ export default class PerformanceMonitoring {
          * related to this interaction.
          */
         const tr = transactionService.startTransaction(
-          `Click - ${tagName}${additionalInfo}`,
+          `Click - ${transactionName}`,
           USER_INTERACTION,
           {
             managed: true,

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -719,19 +719,20 @@ describe('PerformanceMonitoring', function () {
 
   if (window.EventTarget) {
     it('should create click transactions', () => {
-      let transactionService = performanceMonitoring._transactionService
+      const transactionService = performanceMonitoring._transactionService
       let etsub = performanceMonitoring.getEventTargetSub()
-      patchEventHandler.observe(EVENT_TARGET, (event, task) => {
-        etsub(event, task)
-      })
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
       let element = document.createElement('button')
       element.setAttribute('class', 'cool-button purchase-style')
 
-      const listener = e => {
+      element.addEventListener('click', e => {
         expect(e.type).toBe('click')
-      }
-
-      element.addEventListener('click', listener)
+      })
       element.click()
 
       let tr = transactionService.getCurrentTransaction()
@@ -748,6 +749,7 @@ describe('PerformanceMonitoring', function () {
 
       expect(newTr).toBe(tr)
       expect(newTr.name).toBe('Click - button["purchase"]')
+      cancelEventTargetSub()
     })
 
     it('should respect the transaction type priority order', function () {
@@ -781,39 +783,39 @@ describe('PerformanceMonitoring', function () {
       cancelHistorySub()
       cancelEventTargetSub()
     })
-  }
 
-  it('should respect the custom transaction name', function () {
-    const historySubFn = performanceMonitoring.getHistorySub()
-    const cancelHistorySub = patchEventHandler.observe(HISTORY, historySubFn)
-    let etsub = performanceMonitoring.getEventTargetSub()
-    const cancelEventTargetSub = patchEventHandler.observe(
-      EVENT_TARGET,
-      (event, task) => {
-        etsub(event, task)
+    it('should respect the custom transaction name', function () {
+      const historySubFn = performanceMonitoring.getHistorySub()
+      const cancelHistorySub = patchEventHandler.observe(HISTORY, historySubFn)
+      let etsub = performanceMonitoring.getEventTargetSub()
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
+      const transactionService = performanceMonitoring._transactionService
+
+      let element = document.createElement('button')
+      element.setAttribute('data-transaction-name', 'purchase-transaction')
+
+      const listener = () => {
+        let tr = transactionService.getCurrentTransaction()
+        expect(tr.type).toBe('user-interaction')
+        history.pushState(undefined, undefined, 'test')
       }
-    )
-    const transactionService = performanceMonitoring._transactionService
 
-    let element = document.createElement('button')
-    element.setAttribute('data-transaction-name', 'purchase-transaction')
+      element.addEventListener('click', listener)
+      element.click()
 
-    const listener = () => {
       let tr = transactionService.getCurrentTransaction()
-      expect(tr.type).toBe('user-interaction')
-      history.pushState(undefined, undefined, 'test')
-    }
+      expect(tr.name).toBe('Click - purchase-transaction')
+      expect(tr.type).toBe('route-change')
 
-    element.addEventListener('click', listener)
-    element.click()
-
-    let tr = transactionService.getCurrentTransaction()
-    expect(tr.name).toBe('Click - purchase-transaction')
-    expect(tr.type).toBe('route-change')
-
-    cancelHistorySub()
-    cancelEventTargetSub()
-  })
+      cancelHistorySub()
+      cancelEventTargetSub()
+    })
+  }
 
   it('should set outcome on transaction and spans', done => {
     let transactionService = performanceMonitoring._transactionService


### PR DESCRIPTION
+ fix https://github.com/elastic/apm-agent-rum-js/issues/1091
adds support for custom user-interaction transaction names through custom data-attribute as explained here: https://github.com/elastic/apm-agent-rum-js/issues/1091
