### PR TITLE
feat(rum-core): empty string for deprecated fields

### DIFF
--- a/packages/rum-core/src/common/context.js
+++ b/packages/rum-core/src/common/context.js
@@ -70,8 +70,8 @@ function getResponseContext(perfTimingEntry) {
   return respContext
 }
 
-function getDestination(parsedUrl, type) {
-  const { port, protocol, hostname, host } = parsedUrl
+function getDestination(parsedUrl) {
+  const { port, protocol, hostname } = parsedUrl
 
   const portNumber = getPortNumber(port, protocol)
 
@@ -95,9 +95,9 @@ function getDestination(parsedUrl, type) {
 
   return {
     service: {
-      name: protocol + '//' + host,
       resource: hostname + ':' + portNumber,
-      type
+      name: '', // @deprecated: remove it in 6.x release
+      type: '' // @deprecated: remove it in 6.x release
     },
     address,
     port: Number(portNumber)
@@ -108,7 +108,7 @@ function getResourceContext(data) {
   const { entry, url } = data
   const parsedUrl = new Url(url)
 
-  const destination = getDestination(parsedUrl, RESOURCE)
+  const destination = getDestination(parsedUrl)
   return {
     http: {
       url,
@@ -122,7 +122,7 @@ function getExternalContext(data) {
   const { url, method, target, response } = data
   const parsedUrl = new Url(url)
 
-  const destination = getDestination(parsedUrl, EXTERNAL)
+  const destination = getDestination(parsedUrl)
 
   const context = {
     http: {
@@ -146,7 +146,7 @@ function getNavigationContext(data) {
   const { url } = data
   const parsedUrl = new Url(url)
 
-  const destination = getDestination(parsedUrl, HARD_NAVIGATION)
+  const destination = getDestination(parsedUrl)
   return { destination }
 }
 

--- a/packages/rum-core/test/common/context.spec.js
+++ b/packages/rum-core/test/common/context.spec.js
@@ -65,9 +65,9 @@ describe('Context', () => {
       },
       destination: {
         service: {
-          name: 'http://testing.local:1234',
+          name: '',
           resource: 'testing.local:1234',
-          type: 'external'
+          type: ''
         },
         address: 'testing.local',
         port: 1234
@@ -84,9 +84,9 @@ describe('Context', () => {
       },
       destination: {
         service: {
-          name: 'https://www.elastic.co',
+          name: '',
           resource: 'www.elastic.co:443',
-          type: 'external'
+          type: ''
         },
         address: 'www.elastic.co',
         port: 443
@@ -103,9 +103,9 @@ describe('Context', () => {
       },
       destination: {
         service: {
-          name: 'http://[::1]',
+          name: '',
           resource: '[::1]:80',
-          type: 'external'
+          type: ''
         },
         address: '::1',
         port: 80
@@ -126,9 +126,9 @@ describe('Context', () => {
       },
       destination: {
         service: {
-          name: 'https://[::1]:80',
+          name: '',
           resource: '[::1]:80',
-          type: 'external'
+          type: ''
         },
         address: '::1',
         port: 80
@@ -155,9 +155,9 @@ describe('Context', () => {
       },
       destination: {
         service: {
-          name: 'http://example.com',
+          name: '',
           resource: 'example.com:80',
-          type: 'resource'
+          type: ''
         },
         address: 'example.com',
         port: 80
@@ -174,9 +174,9 @@ describe('Context', () => {
     expect(span.context).toEqual({
       destination: {
         service: {
-          name: 'https://example.com',
+          name: '',
           resource: 'example.com:443',
-          type: 'hard-navigation'
+          type: ''
         },
         address: 'example.com',
         port: 443

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -167,9 +167,9 @@ describe('Capture hard navigation', function () {
         context: {
           destination: {
             service: {
-              name: 'http://localhost:9876',
+              name: '',
               resource: 'localhost:9876',
-              type: 'hard-navigation'
+              type: ''
             },
             address: 'localhost',
             port: 9876

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -368,9 +368,9 @@ describe('PerformanceMonitoring', function () {
             },
             destination: {
               service: {
-                name: 'http://localhost:9876',
+                name: '',
                 resource: 'localhost:9876',
-                type: 'external'
+                type: ''
               },
               address: 'localhost',
               port: 9876


### PR DESCRIPTION
# Context

The intake API has deprecated the following fields from the span destination: `destination.service.type` and `destination.service.name` but until the intake API version 7.15 they are required anyway, so we need to include them in the request payload.

# What we have done

We have hardcoded empty string as a value. An important nuance here is that the value that is going to be send in the event payload for those fields is "N/A" since changing the truncate logic only for this requirement requires many modifications and in an upcoming release are going to be removed.

# Next steps

In the release 6.x we will [remove all the logic](https://github.com/elastic/apm-agent-rum-js/issues/1106) related with the deprecated fields because the intake API (from 7.15) will not require them anymore.









