### PR TITLE
chore: update elastic stack release version 7.15.2 7.16.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     booleanParam(name: 'saucelab_test', defaultValue: "true", description: "Enable run a Sauce lab test")
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from master.')
-    string(name: 'stack_version', defaultValue: '7.16.0', description: "What's the Stack Version to be used for the load testing?")
+    string(name: 'stack_version', defaultValue: '7.15.2', description: "What's the Stack Version to be used for the load testing?")
   }
   stages {
     stage('Initializing'){


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 7.15.2 7.16.0