### PR TITLE
fix(rum-angular): recover compatibility with angular 9.0.x

### DIFF
--- a/packages/rum-angular/src/apm.service.ts
+++ b/packages/rum-angular/src/apm.service.ts
@@ -24,11 +24,11 @@
  */
 
 import { Router } from '@angular/router'
-import type { NavigationStart } from '@angular/router'
+import { NavigationStart } from '@angular/router'
 import { Inject, Injectable, NgZone } from '@angular/core'
 import { afterFrame } from '@elastic/apm-rum-core'
 import { ApmBase } from '@elastic/apm-rum'
-import type { AgentConfigOptions } from '@elastic/apm-rum'
+import { AgentConfigOptions } from '@elastic/apm-rum'
 import { APM } from './apm.module'
 
 @Injectable({


### PR DESCRIPTION
# Context

The agent [documentation](https://www.elastic.co/guide/en/apm/agent/rum-js/current/angular-integration.html) indicates that the package @elastic/apm-rum-angular 2.x supports Angular versions ≥ 9.0.

# What was the bug?

The file containing the ApmService types declaration had an occurrence of import `type`. Such syntax is only available from TypeScript 3.8.x. This is important because angular 9.0.x only works with TypeScript 3.6 and 3.7. 

Note: Angular versions ≥ 9.1. are the first to be compatible with Typescript 3.8.x

# What was the fix?

Remove the `type` syntax.

