### PR TITLE
docs: update broken links for apm-guide-ref #1385

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -68,7 +68,7 @@ For each call, the properties of the context argument are shallow merged with th
 The given `context` argument must be an object and can contain any property that can be JSON encoded.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 
 [float]
@@ -86,7 +86,7 @@ Starting with APM Server 7.6+, the labels are added to spans as well.
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>). You can set multiple labels.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 Arguments:
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -32,7 +32,7 @@ captures the following information:
 === Additional Components
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 
 include::./set-up.asciidoc[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,7 +31,7 @@ captures the following information:
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
 The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -32,7 +32,7 @@ captures the following information:
 === Additional Components
 
 APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 
 include::./set-up.asciidoc[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,7 +31,7 @@ captures the following information:
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
 The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -2,7 +2,7 @@
 == Set up the Agent
 
 To start reporting your web page performance to Elastic APM,
-you must first {apm-server-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
+you must first {apm-guide-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
 
 Once the APM Server endpoint has been configured, you can:
 
@@ -152,7 +152,7 @@ If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
 
 A list of permitted origins can be supplied to the
-{apm-server-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
+{apm-guide-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
 configuration option.
 By default, APM Server allows all origins.
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -2,7 +2,7 @@
 == Set up the Agent
 
 To start reporting your web page performance to Elastic APM,
-you must first {apm-guide-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
+you must first {apm-guide-ref}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
 
 Once the APM Server endpoint has been configured, you can:
 
@@ -152,7 +152,7 @@ If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
 
 A list of permitted origins can be supplied to the
-{apm-guide-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
+{apm-guide-ref}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
 configuration option.
 By default, APM Server allows all origins.
 

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -10,17 +10,17 @@ without losing the ability to quickly and easily debug your applications.
 
 There are three steps required to enable, upload, and apply a source map to error stack traces.
 An overview is listed below, and a complete walk-through is available in the
-{apm-server-ref-v}/sourcemaps.html[generate and upload a source map] guide.
+{apm-guide-ref-v}/sourcemaps.html[generate and upload a source map] guide.
 
 1. Set the <<service-version,`serviceVersion`>> when initializing the RUM Agent.
-2. {apm-server-ref-v}/sourcemaps.html#sourcemap-rum-generate[Generate a source map]
+2. {apm-guide-ref-v}/sourcemaps.html#sourcemap-rum-generate[Generate a source map]
 for your application with the `serviceVersion` from step one.
-3. {apm-server-ref-v}/sourcemaps.html#sourcemap-rum-upload[Enable and upload the source map file] to APM Server.
+3. {apm-guide-ref-v}/sourcemaps.html#sourcemap-rum-upload[Enable and upload the source map file] to APM Server.
 
 // Don't link to this section
 [[secret-token]]
-You can also configure a {apm-server-ref-v}/secret-token.html[secret token] or
-{apm-server-ref-v}/api-key.html[API key] to restrict the uploading of sourcemaps.
+You can also configure a {apm-guide-ref-v}/secret-token.html[secret token] or
+{apm-guide-ref-v}/api-key.html[API key] to restrict the uploading of sourcemaps.
 
 TIP: Don't forget,
-you must enable {apm-server-ref-v}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.
+you must enable {apm-guide-ref-v}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -10,17 +10,17 @@ without losing the ability to quickly and easily debug your applications.
 
 There are three steps required to enable, upload, and apply a source map to error stack traces.
 An overview is listed below, and a complete walk-through is available in the
-{apm-guide-ref-v}/sourcemaps.html[generate and upload a source map] guide.
+{apm-guide-ref}/sourcemaps.html[generate and upload a source map] guide.
 
 1. Set the <<service-version,`serviceVersion`>> when initializing the RUM Agent.
-2. {apm-guide-ref-v}/sourcemaps.html#sourcemap-rum-generate[Generate a source map]
+2. {apm-guide-ref}/sourcemaps.html#sourcemap-rum-generate[Generate a source map]
 for your application with the `serviceVersion` from step one.
-3. {apm-guide-ref-v}/sourcemaps.html#sourcemap-rum-upload[Enable and upload the source map file] to APM Server.
+3. {apm-guide-ref}/sourcemaps.html#sourcemap-rum-upload[Enable and upload the source map file] to APM Server.
 
 // Don't link to this section
 [[secret-token]]
-You can also configure a {apm-guide-ref-v}/secret-token.html[secret token] or
-{apm-guide-ref-v}/api-key.html[API key] to restrict the uploading of sourcemaps.
+You can also configure a {apm-guide-ref}/secret-token.html[secret token] or
+{apm-guide-ref}/api-key.html[API key] to restrict the uploading of sourcemaps.
 
 TIP: Don't forget,
-you must enable {apm-guide-ref-v}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.
+you must enable {apm-guide-ref}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -126,7 +126,7 @@ it will also get tagged with the same labels.
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 Arguments:
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -100,7 +100,7 @@ Added option:
 ==== Upgrade APM Server
 
 Version `5.x` of the RUM Agent requires APM Server version >= `7.0`.
-The {apm-guide-ref-v}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
+The {apm-guide-ref}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
 
 NOTE: APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 The following upgrade guides are also available:
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -100,7 +100,7 @@ Added option:
 ==== Upgrade APM Server
 
 Version `5.x` of the RUM Agent requires APM Server version >= `7.0`.
-The {apm-server-ref-v}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
+The {apm-guide-ref-v}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
 
 NOTE: APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
 


### PR DESCRIPTION
Links updated as per elastic/observability-docs#1385. The old links will break when 7.17 releases. This PR and all backports must be merged before the 7.17 release. Thanks!

### Backports

- [ ] 5.x: https://github.com/elastic/apm-agent-rum-js/pull/1145
- [ ] 4.x: https://github.com/elastic/apm-agent-rum-js/pull/1144