### PR TITLE
docs: 4.x link fixes

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -68,7 +68,7 @@ For each call, the properties of the context argument are shallow merged with th
 The given `context` argument must be an object and can contain any property that can be JSON encoded.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 
 [float]
@@ -92,7 +92,7 @@ Starting with APM Server 7.6+, the labels are added to spans as well.
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>). You can set multiple labels.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 Arguments:
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,8 +31,8 @@ For all transactions, the agent automatically captures <<breakdown-metrics-docs,
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 
 include::./set-up.asciidoc[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -13,7 +13,7 @@ This enables you to analyze performance throughout your microservice architectur
 
 The RUM Agent automatically instruments the following:
 
-* <<page-load-metrics,Page load metrics>> 
+* <<page-load-metrics,Page load metrics>>
 * Load time of Static Assets
 * API requests (XMLHttpRequest and Fetch)
 
@@ -31,7 +31,8 @@ For all transactions, the agent automatically captures <<breakdown-metrics-docs,
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together.
+APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
 
 include::./set-up.asciidoc[]

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -2,7 +2,7 @@
 == Set up the Agent
 
 To start reporting your web page performance to Elastic APM,
-you must first {apm-server-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
+you must first {apm-guide-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
 
 Once the APM Server endpoint has been configured, you can:
 
@@ -117,7 +117,7 @@ If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
 
 A list of permitted origins can be supplied to the
-{apm-server-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
+{apm-guide-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
 configuration option.
 By default, APM Server allows all origins.
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -2,7 +2,7 @@
 == Set up the Agent
 
 To start reporting your web page performance to Elastic APM,
-you must first {apm-guide-ref-v}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
+you must first {apm-guide-ref}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
 
 Once the APM Server endpoint has been configured, you can:
 
@@ -117,7 +117,7 @@ If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
 
 A list of permitted origins can be supplied to the
-{apm-guide-ref-v}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
+{apm-guide-ref}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
 configuration option.
 By default, APM Server allows all origins.
 

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -67,13 +67,13 @@ import { init as initApm } from '@elastic/apm-rum'
 var apm = initApm({
   // Set required service name
   serviceName: 'service-name',
-  
+
   // Set service version (required for source map feature)
   serviceVersion: serviceVersion
 })
 ----
 
-NOTE: Make sure to upload the generated source map file to APM server with the same "serviceVersion" 
+NOTE: Make sure to upload the generated source map file to APM server with the same "serviceVersion"
 and "serviceName".
 
 Here is a Node.js example of uploading source map file to the APM server:
@@ -127,7 +127,7 @@ curl http://localhost:8200/assets/v1/sourcemaps -X POST \
 [[secret-token]]
 === Using a secret token
 
-You can {apm-server-ref-v}/secure-communication-agents.html[configure a secret token on APM Server] to restrict uploading sourcemaps.
+You can {apm-guide-ref}/secret-token.html[configure a secret token on APM Server] to restrict uploading sourcemaps.
 
 Here's how to add the secret token to a curl command:
 
@@ -143,5 +143,5 @@ curl http://localhost:8200/assets/v1/sourcemaps -X POST \
 ----
 
 
-NOTE: Please note that the previously provided endpoint (`/v1/rum/sourcemaps`) 
+NOTE: Please note that the previously provided endpoint (`/v1/rum/sourcemaps`)
 has been deprecated and will be removed starting with APM Server version 7.0+.

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -2,8 +2,8 @@
 == Source Maps
 
 TIP: Additional information on the source map endpoint is available in the
-APM Server's {apm-server-ref-v}/sourcemaps.html[source map documentation].
-Don't forget, you must enable {apm-server-ref-v}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.
+APM Server's {apm-guide-ref}//source-map-how-to.html[source map documentation].
+Don't forget, you must enable {apm-guide-ref}/input-apm.html[RUM support] in the APM Server for this endpoint to work.
 
 It's a common practice to minify JavaScript bundles.
 However, debugging minified files is inherently difficult. To resolve this issue,

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -94,7 +94,7 @@ it will also get tagged with the same labels.
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 Arguments:
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 [float]
 [[end-of-life-dates]]


### PR DESCRIPTION
Backports the pertinent bits of https://github.com/elastic/apm-agent-rum-js/pull/1143 to 4.x