### PR TITLE
docs: update link to APM server 7.0 upgrade guide

### DIFF
--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -100,7 +100,7 @@ Added option:
 ==== Upgrade APM Server
 
 Version `5.x` of the RUM Agent requires APM Server version >= `7.0`.
-The {apm-guide-ref}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
+The {apm-guide-7x}/upgrading-to-70.html[APM Server `7.0` upgrade guide] can help with the upgrade process.
 
 NOTE: APM Server version >= `7.0` requires Elasticsearch and Kibana versions >= `7.0` as well.
 


### PR DESCRIPTION
Updates a link to the [APM Server 7.0 upgrade guide](https://www.elastic.co/guide/en/apm/guide/7.17/upgrading-to-70.html). This link doesn't exist in 8.0+ and will break when we release 8.0 GA.

**NOTE:** The link currently directs users to 7.17 so we may want to wait until after the 7.17 release before merging.

We'll also need to backport to 5.x.

Relates to https://github.com/elastic/docs/pull/2312

### Preview
https://apm-agent-rum-js_1153.docs-preview.app.elstc.co/guide/en/apm/agent/rum-js/master/upgrade-to-v5.html#v5-upgrade-server