### PR TITLE
fix: identify on which element occurred a click event

### DIFF
--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -133,11 +133,11 @@ export function patchEventTarget(callback) {
     existingTasks.push(task)
 
     function wrappingFn() {
-      // To identify properly the element on which the event occurred we need to make sure we distinguish between currentTarget and target
+      // To identify properly the element on which the event occurred we need to make sure
+      // we distinguish between currentTarget and target
       // currentTarget always refers to the element to which the event handler has been attached
       // target identifies the element on which the element occurred
       const [event] = arguments
-      task.currentTarget = event.currentTarget
       task.target = event.target
 
       callback(SCHEDULE, task)

--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -41,7 +41,7 @@ for (let i = 0; i < eventTypes.length; i++) {
 }
 
 function shouldInstrumentEvent(target, eventType, listenerFn) {
-  // EventTarget has many children. E.g. Element, Document and Window
+  // EventTarget has multiple children. E.g. Element, Document and Window
   // and since we are only handling clicks is not necessary to exclude others
   // such as XMLHttpRequest or AudioContext. Hence, we can rely on EventTarget being enough
   return (

--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -136,7 +136,7 @@ export function patchEventTarget(callback) {
       // To identify properly the element on which the event occurred we need to make sure
       // we distinguish between currentTarget and target
       // currentTarget always refers to the element to which the event handler has been attached
-      // target identifies the element on which the element occurred
+      // target identifies the element on which the event occurred
       const [event] = arguments
       task.target = event.target
 

--- a/packages/rum-core/src/common/patching/event-target-patch.js
+++ b/packages/rum-core/src/common/patching/event-target-patch.js
@@ -41,8 +41,11 @@ for (let i = 0; i < eventTypes.length; i++) {
 }
 
 function shouldInstrumentEvent(target, eventType, listenerFn) {
+  // EventTarget has many children. E.g. Element, Document and Window
+  // and since we are only handling clicks is not necessary to exclude others
+  // such as XMLHttpRequest or AudioContext. Hence, we can rely on EventTarget being enough
   return (
-    target instanceof Element &&
+    target instanceof EventTarget &&
     eventTypes.indexOf(eventType) >= 0 &&
     typeof listenerFn === 'function'
   )
@@ -121,7 +124,6 @@ export function patchEventTarget(callback) {
 
     let task = {
       source: EVENT_TARGET,
-      target,
       eventType,
       listenerFn,
       capture,
@@ -131,6 +133,13 @@ export function patchEventTarget(callback) {
     existingTasks.push(task)
 
     function wrappingFn() {
+      // To identify properly the element on which the event occurred we need to make sure we distinguish between currentTarget and target
+      // currentTarget always refers to the element to which the event handler has been attached
+      // target identifies the element on which the element occurred
+      const [event] = arguments
+      task.currentTarget = event.currentTarget
+      task.target = event.target
+
       callback(SCHEDULE, task)
       let result
       try {

--- a/packages/rum-core/test/common/event-target-patch.spec.js
+++ b/packages/rum-core/test/common/event-target-patch.spec.js
@@ -151,26 +151,6 @@ describe('EventTargetPatch', function () {
         expect(count).toBe(4)
         expect(events.length).toBe(8)
       })
-
-      it('should not instrument non-Element targets', () => {
-        let count = 0
-        const eventType = 'click'
-        const listener = e => {
-          expect(e.type).toBe(eventType)
-          count++
-        }
-
-        let event = createCustomEvent(eventType)
-        window.addEventListener(eventType, listener)
-        window.dispatchEvent(event)
-        expect(count).toBe(1)
-        expect(events.length).toBe(0)
-
-        window.addEventListener.apply(undefined, [eventType, listener, true])
-        window.dispatchEvent(event)
-        expect(count).toBe(3)
-        expect(events.length).toBe(0)
-      })
     },
     !!window.EventTarget
   )

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -761,37 +761,6 @@ describe('PerformanceMonitoring', function () {
           etsub(event, task)
         }
       )
-      // element.setAttribute('class', 'cool-button purchase-style')
-
-      // We set an event listener in document
-      // in order to exemplify a situation where the application relies
-      // on event delegation to handle all the clicks
-      const listener = e => {
-        expect(e.type).toBe('click')
-      }
-      document.addEventListener('click', listener)
-
-      // Element on which the event will occur
-      let element = document.createElement('button')
-      document.body.appendChild(element)
-      element.click()
-
-      let tr = transactionService.getCurrentTransaction()
-      expect(tr).toBeDefined()
-      expect(tr.name).toBe('Click - button')
-      expect(tr.type).toBe('user-interaction')
-      cancelEventTargetSub()
-    })
-
-    it('should create click transactions on window', () => {
-      const transactionService = performanceMonitoring._transactionService
-      let etsub = performanceMonitoring.getEventTargetSub()
-      const cancelEventTargetSub = patchEventHandler.observe(
-        EVENT_TARGET,
-        (event, task) => {
-          etsub(event, task)
-        }
-      )
 
       const listener = e => {
         expect(e.type).toBe('click')

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -752,6 +752,95 @@ describe('PerformanceMonitoring', function () {
       cancelEventTargetSub()
     })
 
+    it('should create click transactions on window', () => {
+      const transactionService = performanceMonitoring._transactionService
+      let etsub = performanceMonitoring.getEventTargetSub()
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
+      // element.setAttribute('class', 'cool-button purchase-style')
+
+      // We set an event listener in document
+      // in order to exemplify a situation where the application relies
+      // on event delegation to handle all the clicks
+      const listener = e => {
+        expect(e.type).toBe('click')
+      }
+      document.addEventListener('click', listener)
+
+      // Element on which the event will occur
+      let element = document.createElement('button')
+      document.body.appendChild(element)
+      element.click()
+
+      let tr = transactionService.getCurrentTransaction()
+      expect(tr).toBeDefined()
+      expect(tr.name).toBe('Click - button')
+      expect(tr.type).toBe('user-interaction')
+      cancelEventTargetSub()
+    })
+
+    it('should create click transactions on window', () => {
+      const transactionService = performanceMonitoring._transactionService
+      let etsub = performanceMonitoring.getEventTargetSub()
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
+
+      const listener = e => {
+        expect(e.type).toBe('click')
+      }
+      window.addEventListener('click', listener)
+
+      let element = document.createElement('button')
+      element.setAttribute('name', 'window-listener-will-handle-me')
+      document.body.appendChild(element)
+
+      element.click()
+
+      let tr = transactionService.getCurrentTransaction()
+      expect(tr).toBeDefined()
+      expect(tr.name).toBe('Click - button["window-listener-will-handle-me"]')
+      expect(tr.type).toBe('user-interaction')
+      cancelEventTargetSub()
+      document.body.removeChild(element)
+    })
+
+    it('should create click transactions on document', () => {
+      const transactionService = performanceMonitoring._transactionService
+      let etsub = performanceMonitoring.getEventTargetSub()
+      const cancelEventTargetSub = patchEventHandler.observe(
+        EVENT_TARGET,
+        (event, task) => {
+          etsub(event, task)
+        }
+      )
+
+      const listener = e => {
+        expect(e.type).toBe('click')
+      }
+      document.addEventListener('click', listener)
+
+      let element = document.createElement('button')
+      element.setAttribute('name', 'document-listener-will-handle-me')
+      document.body.appendChild(element)
+
+      element.click()
+
+      let tr = transactionService.getCurrentTransaction()
+      expect(tr).toBeDefined()
+      expect(tr.name).toBe('Click - button["document-listener-will-handle-me"]')
+      expect(tr.type).toBe('user-interaction')
+      cancelEventTargetSub()
+      document.body.removeChild(element)
+    })
+
     it('should respect the transaction type priority order', function () {
       const historySubFn = performanceMonitoring.getHistorySub()
       const cancelHistorySub = patchEventHandler.observe(HISTORY, historySubFn)


### PR DESCRIPTION
# Context

Web applications which rely on event delegation tend to declare click events through these ways:

```
window.addEventListener('click', //...)
document.addEventListener('click', //...)
document.querySelector("div.root").addEventListener('click', //...)

// more strategies ...

```

The agent is not handling  properly these cases. In our instrumentation we are not using the [target](https://developer.mozilla.org/en-US/docs/Web/API/Event/target) to build the user interaction transaction. Instead what we are doing is to use the equivalent to [currentTarget](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)
since we define the target as the element where the listener is being attached

# Summary 

The fix consists in capture the event generated by the browser and pick the target property from it, which from now on it will be the one that we will use to build the user-interaction transaction.

