### PR TITLE
chore: update elastic stack release version 7.17.0 7.17.1

### DIFF
--- a/.ci/scripts/load-testing.sh
+++ b/.ci/scripts/load-testing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-STACK_VERSION=${1:-7.16.3}
+STACK_VERSION=${1:-7.17.0}
 USER_ID="$(id -u):$(id -g)"
 NODEJS_VERSION=$(cat ./dev-utils/.node-version)
 

--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -6,7 +6,7 @@ STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures
 
 # We are building the images here even though the Docker images are already cached in Packer.
-# This is because there could be changes in the PR affecting the files copied to the Docker image,
+# This is because there could be changes in the PR affecting the files copied to the Docker image, 
 # which we want to test in the current build.
 NODEJS_VERSION="${NODEJS_VERSION}" \
 STACK_VERSION=${STACK_VERSION} \

--- a/.ci/scripts/pull_and_build.sh
+++ b/.ci/scripts/pull_and_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export NODEJS_VERSION=$(cat ./dev-utils/.node-version)
-export STACK_VERSION=${STACK_VERSION:-7.16.3}
+export STACK_VERSION=${STACK_VERSION:-7.17.0}
 
 STACK_VERSION=${STACK_VERSION} \
 docker-compose -f ./dev-utils/docker-compose.yml --log-level INFO pull --quiet --ignore-pull-failures

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -xeo pipefail
-STACK_VERSION=${STACK_VERSION:-7.16.3}
+STACK_VERSION=${STACK_VERSION:-7.17.0}
 
 pip install docker-compose>=1.25.4
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     booleanParam(name: 'saucelab_test', defaultValue: "true", description: "Enable run a Sauce lab test")
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from main.')
-    string(name: 'stack_version', defaultValue: '7.16.3', description: "What's the Stack Version to be used for the load testing?")
+    string(name: 'stack_version', defaultValue: '7.17.0', description: "What's the Stack Version to be used for the load testing?")
   }
   stages {
     stage('Initializing'){

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.16.3}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.17.0}
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
@@ -34,7 +34,7 @@ services:
 
   apm-server:
     container_name: apm-server
-    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.16.3}
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.17.0}
     ports:
       - "127.0.0.1:${APM_SERVER_PORT:-8200}:8200"
     environment:
@@ -85,7 +85,7 @@ services:
 
   kibana:
     container_name: kibana
-    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.16.3}
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.17.0}
     environment:
       SERVER_NAME: kibana.example.org
       ELASTICSEARCH_URL: http://elasticsearch:9200


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 7.17.0 7.17.1