### PR TITLE
chore: fix benchmark in the CI

### DIFF
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -186,7 +186,7 @@ services:
         cd /app
         export
         npm install
-        npm install playwright --unsafe-perm=true --allow-root
+        npm install playwright@1.18.1 --unsafe-perm=true --allow-root
         set -eo pipefail
         npx lerna run build:module
         node ./scripts/benchmarks.js ${REPORT_FILE}"


### PR DESCRIPTION
# Context

Since February 14th the benchmark step has been failing in the CI:

```
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ╔════════════════════════════════════════════════════════════╗
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║ Host system is missing a few dependencies to run browsers. ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║ Please install them with the following command:            ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║                                                            ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║     sudo npx playwright install-deps                       ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║                                                            ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ║ <3 Playwright Team                                         ║
[2022-02-14T19:56:00.919Z] �[36mnode-playwright        |�[0m @elastic/apm-rum: ╚════════════════════════════════════════════════════════════╝
```

It turns out that the issue is related to the playwright version being used in the CI. Before February 14th our CI was executing the benchmark with the version **1.8.1.**. The failing ones were using the version **1.9.1**.  

The new version needs an additional OS dependency named [libxtst6](https://github.com/microsoft/playwright-python/issues/1169) which is required for Firefox in this new version.

This issue has occurred all of a sudden because in the steps defined in the [docker-compose file](https://github.com/elastic/apm-agent-rum-js/blob/main/dev-utils/docker-compose.yml#L189) we are not setting the playwright version to use.


# Summary

- Setting 1.8.1 for playwright to avoid unexpected failures in our CI in the future
