### PR TITLE
feat: add pageLoadParentId configuration

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -183,6 +183,15 @@ NOTE: After each flush of the queue, the next flush isn't scheduled until an ite
 
 This option overrides the page load transactions trace ID.
 
+[float]
+[[page-load-parent-id]]
+=== `pageLoadParentId`
+
+* *Type:* String
+
+This option allows the creation of the page load transaction as child of an existing one. By default,
+the agent treats it as the root transaction.
+
 
 [float]
 [[page-load-sampled]]

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -231,6 +231,7 @@ export function compressTransaction(transaction) {
 
   const tr = {
     id: transaction.id,
+    pid: transaction.parent_id,
     tid: transaction.trace_id,
     n: transaction.name,
     t: transaction.type,

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -447,6 +447,7 @@ export default class PerformanceMonitoring {
 
     const transactionData = {
       id: transaction.id,
+      parent_id: transaction.parentId,
       trace_id: transaction.traceId,
       session: transaction.session,
       name: transaction.name,

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -106,7 +106,8 @@ class TransactionService {
           pageLoadTraceId: config.pageLoadTraceId,
           pageLoadSampled: config.pageLoadSampled,
           pageLoadSpanId: config.pageLoadSpanId,
-          pageLoadTransactionName: config.pageLoadTransactionName
+          pageLoadTransactionName: config.pageLoadTransactionName,
+          pageLoadParentId: config.pageLoadParentId
         },
         perfOptions
       )
@@ -279,6 +280,9 @@ class TransactionService {
           if (name === NAME_UNKNOWN && pageLoadTransactionName) {
             tr.name = pageLoadTransactionName
           }
+
+          tr.parentId = tr.options.pageLoadParentId
+
           /**
            * Capture the TBT as span after observing for all long task entries
            * and once performance observer is disconnected

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -298,9 +298,10 @@ describe('ApmServer', function () {
     clock.install()
     apmServer.init()
     spyOn(apmServer, '_postJson')
-    const trs = generateTransaction(2).map(tr =>
-      performanceMonitoring.createTransactionDataModel(tr)
-    )
+    const trs = generateTransaction(2).map((tr, i) => {
+      tr.parentId = 'parent-transaction-id-' + i
+      return performanceMonitoring.createTransactionDataModel(tr)
+    })
     const errors = generateErrors(2).map(err => ({
       name: err.name,
       message: err.message
@@ -318,9 +319,9 @@ describe('ApmServer', function () {
       '{"metadata":{"service":{"name":"test","agent":{"name":"rum-js","version":"N/A"},"language":{"name":"javascript"}}}}',
       '{"error":{"name":"Error","message":"error #0"}}',
       '{"error":{"name":"Error","message":"error #1"}}',
-      '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
+      '{"transaction":{"id":"transaction-id-0","parent_id":"parent-transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}',
-      '{"transaction":{"id":"transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
+      '{"transaction":{"id":"transaction-id-1","parent_id":"parent-transaction-id-1","trace_id":"trace-id-1","name":"transaction #1","type":"transaction","duration":990,"span_count":{"started":1},"sampled":false}}',
       '{"span":{"id":"span-id-1-1","transaction_id":"transaction-id-1","parent_id":"transaction-id-1","trace_id":"trace-id-1","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10}}'
     ]
 
@@ -334,9 +335,10 @@ describe('ApmServer', function () {
     configService.setConfig({ apiVersion: 3 })
     apmServer.init()
     spyOn(apmServer, '_postJson')
-    const trs = generateTransaction(1, true).map(tr =>
-      performanceMonitoring.createTransactionDataModel(tr)
-    )
+    const trs = generateTransaction(1, true).map((tr, i) => {
+      tr.parentId = 'parent-transaction-id-' + i
+      return performanceMonitoring.createTransactionDataModel(tr)
+    })
     const errors = generateErrors(1).map((err, i) => {
       let model = errorLogging.createErrorDataModel(err)
       model.id = 'error-id-' + i
@@ -354,7 +356,7 @@ describe('ApmServer', function () {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
+      '{"x":{"id":"transaction-id-0","pid":"parent-transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -257,6 +257,28 @@ describe('TransactionService', function () {
     })
   })
 
+  it('should set page load parentId before ending the transaction', function (done) {
+    config.setConfig({
+      pageLoadParentId: 'test-page-load-parent-id'
+    })
+    transactionService = new TransactionService(logger, config)
+
+    const tr = transactionService.startTransaction(undefined, 'page-load', {
+      managed: true
+    })
+
+    tr.detectFinish()
+
+    /**
+     * For page load transaction we set the transaction parentId using
+     * transaction.onEnd
+     */
+    config.events.observe(TRANSACTION_END, tr => {
+      expect(tr.parentId).toBe('test-page-load-parent-id')
+      done()
+    })
+  })
+
   it('should capture resources from navigation timing', function (done) {
     const unMock = mockGetEntriesByType()
 
@@ -356,6 +378,16 @@ describe('TransactionService', function () {
       unMock()
       done()
     })
+  })
+
+  it('should consider page load parentId', function () {
+    config.setConfig({
+      pageLoadParentId: 'test-page-load-parent-id'
+    })
+
+    transactionService = new TransactionService(logger, config)
+    const tr = sendPageLoadMetrics()
+    expect(tr.options.pageLoadParentId).toBe('test-page-load-parent-id')
   })
 
   it('should call createCurrentTransaction once per startTransaction', function () {


### PR DESCRIPTION
# Context

One of the requirements for [Crosslinking Synthetics with APM](https://github.com/elastic/synthetics/issues/265) issue was to allow the RUM agent the creation of the `page-load` transaction as child of the one created in Synthetics.

The main goal of that is to provide visibility into how the synthetic journeys are executed and what actions are happening inside every step. This [image](https://user-images.githubusercontent.com/3902525/116486823-ccd0f200-a88e-11eb-95da-527940a74081.png) extracted from the issue linked above it's a great example.


# Summary

We expose a new [agent configuration](https://www.elastic.co/guide/en/apm/agent/rum-js/current/configuration.html) option named `pageLoadParentId` whose value will be the id of the transaction that we want to establish as **parent** of the `page-load` transaction.  Before this PR `page-load` transaction was always treated as the **root** transaction, now it will be possible to set a parent if needed thanks to this new config.

