### PR TITLE
chore: test for partial page-load transaction

### DIFF
--- a/packages/rum-core/test/common/page-visibility.spec.js
+++ b/packages/rum-core/test/common/page-visibility.spec.js
@@ -32,7 +32,11 @@ import {
   CONFIG_SERVICE
 } from '../../src/common/constants'
 import * as utils from '../../src/common/utils'
-import { createCustomEvent } from '../../test/'
+import {
+  hidePageSynthetically,
+  dispatchBrowserEvent,
+  setDocumentVisibilityState
+} from '../../test/'
 import { spyOnFunction, waitFor } from '../../../../dev-utils/jasmine'
 
 describe('observePageVisibility', () => {
@@ -41,26 +45,6 @@ describe('observePageVisibility', () => {
   let transactionService
   let unobservePageVisibility
   let originalLastHiddenStart
-
-  function hidePageSynthetically(eventName) {
-    if (eventName === 'visibilitychange') {
-      setDocumentVisibilityState('hidden')
-    }
-
-    dispatchBrowserEvent(eventName)
-  }
-
-  function dispatchBrowserEvent(eventName) {
-    document.dispatchEvent(createCustomEvent(eventName))
-  }
-
-  function setDocumentVisibilityState(visibilityState) {
-    Object.defineProperty(document, 'visibilityState', {
-      get() {
-        return visibilityState
-      }
-    })
-  }
 
   beforeEach(() => {
     serviceFactory = createServiceFactory()

--- a/packages/rum-core/test/index.js
+++ b/packages/rum-core/test/index.js
@@ -57,6 +57,27 @@ export function createCustomEvent(
   return evt
 }
 
+export function dispatchBrowserEvent(eventName) {
+  document.dispatchEvent(createCustomEvent(eventName))
+}
+
+// Possible eventName values: visibilitychange, pagehide
+export function hidePageSynthetically(eventName = 'visibilitychange') {
+  if (eventName === 'visibilitychange') {
+    setDocumentVisibilityState('hidden')
+  }
+
+  dispatchBrowserEvent(eventName)
+}
+
+export function setDocumentVisibilityState(visibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    get() {
+      return visibilityState
+    }
+  })
+}
+
 export function generateTransaction(count, breakdown = false) {
   const result = []
   for (var i = 0; i < count; i++) {


### PR DESCRIPTION
# Summary

Test that demonstrates that if a page becomes backgrounded all the data gathered until that moment will be sent even when the load event from the browser has not been triggered.