### PR TITLE
ci: simpler builds for tag releases

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -34,7 +34,7 @@
         build-strategies:
         - tags:
             ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
+            ignore-tags-newer-than: 30
         - regular-branches: true
         ## This will avoid building the PRs when the target branch has changed
         ## when the MBP index scan happens. Since periodic-folder-trigger is disabled

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -34,7 +34,7 @@
         build-strategies:
         - tags:
             ignore-tags-older-than: -1
-            ignore-tags-newer-than: 30
+            ignore-tags-newer-than: -1
         - regular-branches: true
         ## This will avoid building the PRs when the target branch has changed
         ## when the MBP index scan happens. Since periodic-folder-trigger is disabled

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,12 @@ pipeline {
         Lint the code.
         */
         stage('Lint') {
+          when {
+            beforeAgent true
+            allOf {
+              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+            }
+          }
           steps {
             withGithubNotify(context: 'Lint') {
               deleteDir()
@@ -104,7 +110,10 @@ pipeline {
         stage('Test Puppeteer') {
           when {
             beforeAgent true
-            expression { return env.ONLY_DOCS == "false" }
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+            }
           }
           matrix {
             agent { label 'linux && immutable' }
@@ -203,7 +212,6 @@ pipeline {
             allOf {
               anyOf {
                 branch 'main'
-                tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return params.Run_As_Main_Branch }
                 expression { return env.BENCHMARK_UPDATED != "false" }
                 expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
@@ -294,7 +302,10 @@ pipeline {
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
-            expression { return env.ONLY_DOCS == "false" }
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+            }
           }
           steps {
             withGithubNotify(context: 'Coverage') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,8 @@ pipeline {
         stage('Lint') {
           when {
             beforeAgent true
-            allOf {
-              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+            not {
+              expression { return isTag() }
             }
           }
           steps {
@@ -112,7 +112,9 @@ pipeline {
             beforeAgent true
             allOf {
               expression { return env.ONLY_DOCS == "false" }
-              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+              not {
+                expression { return isTag() }
+              }
             }
           }
           matrix {
@@ -304,7 +306,9 @@ pipeline {
             beforeAgent true
             allOf {
               expression { return env.ONLY_DOCS == "false" }
-              not { tag pattern: '.*@\\d+\\.\\d+.*', comparator: 'REGEXP' }
+              not {
+                expression { return isTag() }
+              }
             }
           }
           steps {


### PR DESCRIPTION
### What

This proposal reduces:
* The builds for tags.
* Benchmark to run on `main` but no tags
* Tests to run for all but `main`

### Why

Tags are generated always from a particular merged commit, and merged-commits are validated always in the main branch, and previous to be merged on a PR basis.

Therefore there is no need to generate heavy builds in favour of simplifying the releases.

Opbeans are updated automatically at the very end of the release, so by making more reliable then the opbeans can benefit from the autoamtion in place.

### Issue

Relates to https://github.com/elastic/apm-agent-rum-js/issues/1191

### Actions

- [ ] Agree with the team