### PR TITLE
ci: use withNode and use retryWithSleep

### DIFF
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
-${SED} -E -e "s#(values '8.0.0-SNAPSHOT',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
+${SED} -E -e "s#(values '8.1.0-SNAPSHOT',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
 ${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" Jenkinsfile
 git add Jenkinsfile
 for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/scripts/test.sh dev-utils/docker-compose.yml ; do

--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
-${SED} -E -e "s#(values '8.0.0-SNAPSHOT', '7.x',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
+${SED} -E -e "s#(values '8.0.0-SNAPSHOT',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
 ${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" Jenkinsfile
 git add Jenkinsfile
 for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/scripts/test.sh dev-utils/docker-compose.yml ; do

--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
-${SED} -E -e "s#(values '8.1.0-SNAPSHOT',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
+${SED} -E -e "s#(values '.+-SNAPSHOT',) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_DEV}'#g" Jenkinsfile
 ${SED} -E -e "s#(defaultValue:) '[0-9]+\.[0-9]+\.[0-9]+'#\1 '${VERSION_RELEASE}'#g" Jenkinsfile
 git add Jenkinsfile
 for FILE in .ci/scripts/load-testing.sh .ci/scripts/pull_and_build.sh .ci/scripts/test.sh dev-utils/docker-compose.yml ; do

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,23 +120,23 @@ pipeline {
           matrix {
             agent { label 'linux && immutable' }
             axes {
-                axis {
-                  name 'ELASTIC_STACK_VERSION'
-                  // The below line is part of the bump release automation
-                  // if you change anything please modifies the file
-                  // .ci/bump-stack-release-version.sh
-                  values '8.1.0-SNAPSHOT', '7.16.0'
-                }
-                axis {
-                  name 'SCOPE'
-                  values (
-                    '@elastic/apm-rum',
-                    '@elastic/apm-rum-core',
-                    '@elastic/apm-rum-react',
-                    '@elastic/apm-rum-angular',
-                    '@elastic/apm-rum-vue',
-                  )
-                }
+              axis {
+                name 'ELASTIC_STACK_VERSION'
+                // The below line is part of the bump release automation
+                // if you change anything please modifies the file
+                // .ci/bump-stack-release-version.sh
+                values '8.1.0-SNAPSHOT', '7.16.0'
+              }
+              axis {
+                name 'SCOPE'
+                values (
+                  '@elastic/apm-rum',
+                  '@elastic/apm-rum-core',
+                  '@elastic/apm-rum-react',
+                  '@elastic/apm-rum-angular',
+                  '@elastic/apm-rum-vue',
+                )
+              }
             }
             stages {
               stage('Scope Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -485,14 +485,12 @@ def runScript(Map args = [:]){
       "APM_SERVER_URL=http://apm-server:8200",
       "APM_SERVER_PORT=8200",
       "GOAL=${goal}"]) {
-      retry(2) {
-        sleep randomNumber(min: 5, max: 10)
+      retryWithSleep(retries: 2, seconds: 5, sleepFirst: true) {
         sh(label: 'Pull and build docker infra', script: '.ci/scripts/pull_and_build.sh')
       }
       try {
         // Another retry in case there are any environmental issues
-        retry(3) {
-          sleep randomNumber(min: 5, max: 10)
+        retryWithSleep(retries: 3, seconds: 5, sleepFirst: true) {
           if(env.MODE == 'saucelabs'){
             withSaucelabsEnv(){
               sh(label: "Run tests: Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
@@ -501,8 +499,6 @@ def runScript(Map args = [:]){
             sh(label: "Run tests: Elastic Stack ${stack} - ${scope} - ${env.MODE}", script: '.ci/scripts/test.sh')
           }
         }
-      } catch(e) {
-        throw e
       } finally {
         dockerLogs(step: "${label}-${stack}", failNever: true)
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
                 // The below line is part of the bump release automation
                 // if you change anything please modifies the file
                 // .ci/bump-stack-release-version.sh
-                values '8.1.0-SNAPSHOT', '7.16.0'
+                values '8.0.0-SNAPSHOT', '7.16.0'
               }
               axis {
                 name 'SCOPE'
@@ -151,7 +151,7 @@ pipeline {
             }
           }
         }
-        stage('Stack 8.1.0-SNAPSHOT SauceLabs') {
+        stage('Stack 8.0.0-SNAPSHOT SauceLabs') {
           agent { label 'linux && immutable' }
           environment {
             MODE = "saucelabs"
@@ -174,7 +174,7 @@ pipeline {
             }
           }
           steps {
-            runAllScopes(stack: "8.1.0-SNAPSHOT")
+            runAllScopes(stack: "8.0.0-SNAPSHOT")
           }
           post {
             cleanup {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
                   // The below line is part of the bump release automation
                   // if you change anything please modifies the file
                   // .ci/bump-stack-release-version.sh
-                  values '8.0.0-SNAPSHOT', '7.16.0'
+                  values '8.1.0-SNAPSHOT', '7.16.0'
                 }
                 axis {
                   name 'SCOPE'
@@ -152,7 +152,7 @@ pipeline {
             }
           }
         }
-        stage('Stack 8.0.0-SNAPSHOT SauceLabs') {
+        stage('Stack 8.1.0-SNAPSHOT SauceLabs') {
           agent { label 'linux && immutable' }
           environment {
             MODE = "saucelabs"
@@ -175,7 +175,7 @@ pipeline {
             }
           }
           steps {
-            runAllScopes(stack: "8.0.0-SNAPSHOT")
+            runAllScopes(stack: "8.1.0-SNAPSHOT")
           }
           post {
             cleanup {


### PR DESCRIPTION
### What

- ~~Bump versions to `8.1` and `7.17`~~ requires https://github.com/elastic/apm-agent-rum-js/pull/1193
- Fix version bump (since `7.x` is not anymore a pattern to be searched)
- Use [`retryWithSleep`](https://github.com/elastic/apm-pipeline-library/blob/main/vars/retryWithSleep.groovy) to simplify the pipeline
- Use [`withNode`](https://github.com/elastic/apm-pipeline-library/blob/main/vars/withNode.groovy) to assign unique agents.

### Why

Trying to solve the issue with the `Test Puppeteer` when the subsequent reattempts triggered by the test command fail. I'm still confused since `Test Puppeteer` does not cache anything in the CI workers, and the `Gobld Jenkins plugin` ensures the workers are not reused.