### PR TITLE
chore: increase bundle size limit

### DIFF
--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -51,11 +51,11 @@
   "bundlesize": [
     {
       "path": "./dist/bundles/elastic-apm-rum*.min.js",
-      "maxSize": "19 kB"
+      "maxSize": "19.6 kB"
     },
     {
       "path": "./dist/bundles/elastic-apm-opentracing*.min.js",
-      "maxSize": "20.5 kB"
+      "maxSize": "21 kB"
     }
   ],
   "browserslist": [


### PR DESCRIPTION
Otherwise, there are failures in the CI pipeline:


```
[2022-04-11T10:05:14.386Z] @elastic/apm-rum:  FAIL  ./dist/bundles/elastic-apm-rum.umd.min.js: 19.4KB > maxSize 19KB (gzip) 
[2022-04-11T10:05:14.386Z] @elastic/apm-rum:  FAIL  ./dist/bundles/elastic-apm-opentracing.umd.min.js: 20.95KB > maxSize 20.5KB (gzip)
```

<img width="659" alt="image" src="https://user-images.githubusercontent.com/2871786/163807128-0c74eda0-28aa-4cc3-910f-a61da18c89f9.png">
