### PR TITLE
feat(rum): override threshold when redefining transaction

### DIFF
--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -84,6 +84,10 @@ class Transaction extends SpanBase {
     }
 
     if (options) {
+      // Makes sure the reuseThreshold is overridden too. This covers the case where the transaction
+      // is not setting explicitly the threshold and instead expecting to rely on the one by default.
+      this.options.reuseThreshold = options.reuseThreshold
+
       extend(this.options, options)
     }
   }

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -68,7 +68,7 @@ describe('Transaction', function () {
     expect(tr.options).toEqual({ test: 'test', reuseThreshold: 400 })
   })
 
-  it('should redefine transaction threshold to undefined even when it is not explicitly defined', function () {
+  it('should redefine transaction threshold to undefined when it is not explicitly defined', function () {
     var tr = new Transaction('/', 'transaction', { reuseThreshold: 300 })
     tr.redefine('name', 'type', { test: 'test' })
     expect(tr.name).toBe('name')

--- a/packages/rum-core/test/performance-monitoring/transaction.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction.spec.js
@@ -62,10 +62,18 @@ describe('Transaction', function () {
 
   it('should redefine transaction', function () {
     var tr = new Transaction('/', 'transaction')
+    tr.redefine('name', 'type', { test: 'test', reuseThreshold: 400 })
+    expect(tr.name).toBe('name')
+    expect(tr.type).toBe('type')
+    expect(tr.options).toEqual({ test: 'test', reuseThreshold: 400 })
+  })
+
+  it('should redefine transaction threshold to undefined even when it is not explicitly defined', function () {
+    var tr = new Transaction('/', 'transaction', { reuseThreshold: 300 })
     tr.redefine('name', 'type', { test: 'test' })
     expect(tr.name).toBe('name')
     expect(tr.type).toBe('type')
-    expect(tr.options).toEqual({ test: 'test' })
+    expect(tr.options).toEqual({ test: 'test', reuseThreshold: undefined })
   })
 
   it('should add and remove tasks', function () {


### PR DESCRIPTION
Relates to: https://github.com/elastic/apm-agent-rum-js/issues/1196

With this change we make sure that the reuseThreshold is overridden every time a transaction is redefined. This change will benefit users browsing with slow networks in cases like the one explained [here](https://github.com/elastic/apm-agent-rum-js/issues/1196#issuecomment-1097908486)


https://user-images.githubusercontent.com/15065076/164041735-b5299857-3959-4c04-aaf7-a495b3eca118.mov





@vigneshshanmugam I added feat(rum) in the commit. If you think that this should be a **"chore:"** instead let me know