### PR TITLE
chore: update elastic stack release version 8.1.2 8.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
                 // The below line is part of the bump release automation
                 // if you change anything please modifies the file
                 // .ci/bump-stack-release-version.sh
-                values '8.0.0-SNAPSHOT', '7.16.0'
+                values '8.0.0-SNAPSHOT', '8.2.0'
               }
               axis {
                 name 'SCOPE'


### PR DESCRIPTION
### What 
 Bump stack version with the latest release. 
 ### Further details 
 8.1.2 8.2.0