### PR TITLE
feat(rum): set unknown outcome for aborted http requests

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -92,7 +92,6 @@ const OUTCOME_SUCCESS = 'success'
 const OUTCOME_FAILURE = 'failure'
 const OUTCOME_UNKNOWN = 'unknown'
 
-
 /**
  * Check only for long tasks that are more than 60ms
  */

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -90,6 +90,8 @@ const TRANSACTION_TYPE_ORDER = [
 
 const OUTCOME_SUCCESS = 'success'
 const OUTCOME_FAILURE = 'failure'
+const OUTCOME_UNKNOWN = 'unknown'
+
 
 /**
  * Check only for long tasks that are more than 60ms
@@ -227,6 +229,7 @@ export {
   LAYOUT_SHIFT,
   OUTCOME_SUCCESS,
   OUTCOME_FAILURE,
+  OUTCOME_UNKNOWN,
   SESSION_TIMEOUT,
   HTTP_REQUEST_TIMEOUT
 }

--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -97,6 +97,7 @@ export function patchFetch(callback) {
         error => {
           reject(error)
           scheduleMicroTask(() => {
+            task.data.aborted = isAbortError(error)
             task.data.error = error
             invokeTask(task)
           })
@@ -105,4 +106,8 @@ export function patchFetch(callback) {
       globalState.fetchInProgress = false
     })
   }
+}
+
+function isAbortError(error) {
+  return error && error.name === 'AbortError'
 }

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -48,6 +48,7 @@ import {
   USER_INTERACTION,
   OUTCOME_FAILURE,
   OUTCOME_SUCCESS,
+  OUTCOME_UNKNOWN,
   QUEUE_ADD_TRANSACTION
 } from '../common/constants'
 import {
@@ -337,12 +338,14 @@ export default class PerformanceMonitoring {
         }
 
         let outcome
-        if (data.status != 'abort') {
+        if (data.status != 'abort' && !data.aborted) {
           if (status >= 400 || status == 0) {
             outcome = OUTCOME_FAILURE
           } else {
             outcome = OUTCOME_SUCCESS
           }
+        } else {
+          outcome = OUTCOME_UNKNOWN
         }
         span.outcome = outcome
         const tr = transactionService.getCurrentTransaction()

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -116,6 +116,23 @@ describe('fetchPatch', function () {
         })
       })
     })
+
+    it('should set invoke task as aborted when fetch request aborts', function (done) {
+      const abortController = new AbortController()
+      var promise = window.fetch('/', { signal: abortController.signal })
+      abortController.abort()
+
+      promise.catch(function (resp) {
+        expect(resp).toBeDefined()
+        Promise.resolve().then(function () {
+          expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
+          const invokeTask = events[1].task
+          expect(invokeTask.data.aborted).toBe(true)
+          done()
+        })
+      })
+    })
+
     it('should reset fetchInProgress global state', function (done) {
       expect(globalState.fetchInProgress).toBe(false)
       window.fetch('http://localhost:54321/').then(done, () => done())


### PR DESCRIPTION
# Summary

Relates to: https://github.com/elastic/apm-agent-rum-js/issues/1210

The goal of this change is to set the outcome of transactions/spans with aborted requests to **unknown**

@vigneshshanmugam:

There is some **drawback** that I would like to highlight related to Fetch API: 

At present, it's not possible to tell if the request has aborted with a timeout or not. It means, that we would be treating as "unknown" (rather than a failure) the ones that are caused by a timeout. Although, the agent currently consider them as a **successful** ones, so we could consider this as an improvement? (thinking out loud  🤔 )

There are upcoming browser APIs that will address that, such as: [AbortSignal.timeout](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout). For instance, it will be available in [Chrome 103](https://chromestatus.com/feature/5768400507764736)

WDYT about this drawback?


**Note**: As explained in the issue's description, we will need to make a change in Kibana UI, since the unknown badge is not created. But at least the information will be visible in the metadata

**Note 2**: I ended up creating the ticket as an enhancement and not as a bug. Let me know if you disagree with that. 
I created this as an enhancement, because I feel that this is something that was discussed but not developed rather than something that is happening "accidentally"