### PR TITLE
fix(rum): end fetch span when response stream ends

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -44,6 +44,27 @@ export function patchFetch(callback) {
     callback(INVOKE, task)
   }
 
+  function readStream(stream, task) {
+    const reader = stream.getReader()
+    const read = () => {
+      reader.read().then(
+        ({ done }) => {
+          if (done) {
+            invokeTask(task)
+          } else {
+            read()
+          }
+        },
+        error => {
+          task.data.aborted = isAbortError(error)
+          task.data.error = error
+          invokeTask(task)
+        }
+      )
+    }
+    read()
+  }
+
   var nativeFetch = window.fetch
   window.fetch = function (input, init) {
     var fetchSelf = this
@@ -87,11 +108,17 @@ export function patchFetch(callback) {
 
       promise.then(
         response => {
+          let clonedResponse = response.clone ? response.clone() : {}
           resolve(response)
           // invokeTask in the next execution cycle to let the promise resolution complete
           scheduleMicroTask(() => {
             task.data.response = response
-            invokeTask(task)
+            const { body } = clonedResponse
+            if (body) {
+              readStream(body, task)
+            } else {
+              invokeTask(task)
+            }
           })
         },
         error => {

--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -44,6 +44,12 @@ export function patchFetch(callback) {
     callback(INVOKE, task)
   }
 
+  function handleResponseError(task, error) {
+    task.data.aborted = isAbortError(error)
+    task.data.error = error
+    invokeTask(task)
+  }
+
   function readStream(stream, task) {
     const reader = stream.getReader()
     const read = () => {
@@ -56,9 +62,7 @@ export function patchFetch(callback) {
           }
         },
         error => {
-          task.data.aborted = isAbortError(error)
-          task.data.error = error
-          invokeTask(task)
+          handleResponseError(task, error)
         }
       )
     }
@@ -124,9 +128,7 @@ export function patchFetch(callback) {
         error => {
           reject(error)
           scheduleMicroTask(() => {
-            task.data.aborted = isAbortError(error)
-            task.data.error = error
-            invokeTask(task)
+            handleResponseError(task, error)
           })
         }
       )


### PR DESCRIPTION
# Summary

From now on, fetch spans will be ended once the response stream is completely consumed.
- Browser not supporting [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) will keep working as they were already doing.
- If the server triggers an error while emitting chunks of data, the logic in charge of reading the stream will notice and then the transaction/span outcome will be set as a **failure**
- If the request is aborted while reading the stream, the transaction/span outcome will be set as a **unknown** (following the strategy started in a [previous PR](https://github.com/elastic/apm-agent-rum-js/pull/1211))


The memory analysis have not reported anything grave. A local website (always in incognito, without extensions) have been tested in the following situations. (btw, the test consisted in generate a **fetch** request every time I clicked in the text)

**1.  before applying the changes**

<ins>**Allocation timeline analysis**</ins>


https://user-images.githubusercontent.com/15065076/166743933-8b168437-d264-495a-9ff1-244fe9339190.mov


<ins>**Heap snapshots**</ins>


https://user-images.githubusercontent.com/15065076/166745774-41784d0d-7325-4eb6-9e5a-ea5aed57ca22.mov




**2.  after applying the changes**

<ins>**Allocation timeline analysis**</ins>


https://user-images.githubusercontent.com/15065076/166744224-91c134e3-aeca-4bec-832c-d5d5b8daa778.mov


<ins>**Heap snapshots**</ins>


https://user-images.githubusercontent.com/15065076/166744283-95c30b80-af41-47a2-abe1-36da06a9b82c.mov

**My high level thoughts about the memory analysis:**

The changes in memory after adding the change are negligible. As you can see in the comparison of the snapshots and when seeing the statistics chart.

What I have seen is that we might have **smalls** leaks of memory in the agent. (before and after the change). It might be interesting to check thoroughly in a separated task/issue.


