### PR TITLE
feat(rum): disable beacon compression when flag is set

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -35,16 +35,16 @@ In order to debug the agent consider performing the following steps:
 [[disable-events-payload-compression]]
 === Disable events payload compression
 
-In browsers such as Chrome the payload of the events sent by the RUM JS agent is being compressed with gzip.
-Because of that, you will not see a readable content when inspecting the event with the Network panel of your browser developer tools.
+In browsers such as Chrome, the RUM agent event payload is compressed with gzip.
+Because of this compression, you will not see readable content when inspecting the event with the Network panel of your browser developer tools.
 
-There are situations where that can be an issue. For instance, HAR files will not show a readable information. Therefore, inspecting events
+There are situations where that can be an issue. For instance, HAR files will not show readable information. Therefore, inspecting events
 for debugging purposes will not be possible.
 
 There are two ways to disable the payload compression:
 
-1. Creating an item named `_elastic_inspect_beacon_` using the sessionStorage browser API.
-2. Loading the webpage including the query param `_elastic_inspect_beacon_` in the URL. E.g. `https://elastic.co?_elastic_inspect_beacon_`
+1. Create an item named `_elastic_inspect_beacon_` using the sessionStorage browser API.
+2. Load the webpage with the query param `_elastic_inspect_beacon_` in the URL. For example, `https://elastic.co?_elastic_inspect_beacon_=true`
 
 The effect of this will remain until the tab or browser is closed.
 

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -32,6 +32,23 @@ In order to debug the agent consider performing the following steps:
 4. Monitor the Console and Network panel in your browsers developer tools
 
 [float]
+[[disable-events-payload-compression]]
+=== Disable events payload compression
+
+In browsers such as Chrome the payload of the events sent by the RUM JS agent is being compressed with gzip.
+Because of that, you will not see a readable content when inspecting the event with the Network panel of your browser developer tools.
+
+There are situations where that can be an issue. For instance, HAR files will not show a readable information. Therefore, inspecting events
+for debugging purposes will not be possible.
+
+There are two ways to disable the payload compression:
+
+1. Creating an item named `_elastic_inspect_beacon_` using the sessionStorage browser API.
+2. Loading the webpage including the query param `_elastic_inspect_beacon_` in the URL. E.g. `https://elastic.co?_elastic_inspect_beacon_`
+
+The effect of this will remain until the tab or browser is closed.
+
+[float]
 [[disable-agent]]
 === Disable the Agent
 

--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -28,6 +28,7 @@ import {
   NAVIGATION_TIMING_MARKS,
   COMPRESSED_NAV_TIMING_MARKS
 } from '../performance-monitoring/capture-navigation'
+import { isBeaconInspectionEnabled } from './utils'
 
 /**
  * Compression of all the below schema is based on the v3 RUM Specification
@@ -334,6 +335,15 @@ export function compressPayload(params, type = 'gzip') {
     if (!isCompressionStreamSupported) {
       return resolve(params)
     }
+
+    /**
+     * Resolve with unmodified payload if the flag
+     * for inspecting beacons is enabled
+     */
+    if (isBeaconInspectionEnabled()) {
+      return resolve(params)
+    }
+
     const { payload, headers, beforeSend } = params
     /**
      * create a blob with the original payload data and convert it

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -401,6 +401,36 @@ function isPerfTypeSupported(type) {
   )
 }
 
+/**
+ * The goal of this is to make sure that HAR files
+ * can be created containing beacons with the payload readable
+ */
+function isBeaconInspectionEnabled() {
+  const flagName = '_elastic_inspect_beacon_'
+
+  if (sessionStorage.getItem(flagName) !== null) {
+    return true
+  }
+
+  if (!window.URL || !window.URLSearchParams) {
+    return false
+  }
+
+  try {
+    const parsedUrl = new URL(window.location.href)
+    const isFlagSet = parsedUrl.searchParams.has(flagName)
+    if (isFlagSet) {
+      sessionStorage.setItem(flagName, '')
+    }
+
+    return isFlagSet
+  } catch (e) {
+    // Ignore error since this is not intended to be used by users
+  }
+
+  return false
+}
+
 export {
   extend,
   merge,
@@ -439,5 +469,6 @@ export {
   PERF,
   isPerfTimelineSupported,
   isBrowser,
-  isPerfTypeSupported
+  isPerfTypeSupported,
+  isBeaconInspectionEnabled
 }

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -408,7 +408,7 @@ function isPerfTypeSupported(type) {
 function isBeaconInspectionEnabled() {
   const flagName = '_elastic_inspect_beacon_'
 
-  if (sessionStorage.getItem(flagName) !== null) {
+  if (sessionStorage.getItem(flagName) != null) {
     return true
   }
 
@@ -420,7 +420,7 @@ function isBeaconInspectionEnabled() {
     const parsedUrl = new URL(window.location.href)
     const isFlagSet = parsedUrl.searchParams.has(flagName)
     if (isFlagSet) {
-      sessionStorage.setItem(flagName, '')
+      sessionStorage.setItem(flagName, true)
     }
 
     return isFlagSet

--- a/packages/rum-core/test/common/utils.spec.js
+++ b/packages/rum-core/test/common/utils.spec.js
@@ -339,4 +339,50 @@ describe('lib/utils', function () {
       'cache;desc=Origin cache;dur=200, edge;desc=Edge cache;dur=20, miss, app;dur=50'
     )
   })
+
+  describe('isBeaconInspectionEnabled', () => {
+    beforeEach(() => {
+      sessionStorage.removeItem('_elastic_inspect_beacon_')
+    })
+
+    it('should return true if flag exists in session storage', () => {
+      sessionStorage.setItem('_elastic_inspect_beacon_', '')
+
+      expect(utils.isBeaconInspectionEnabled()).toBe(true)
+    })
+
+    it('should return false if flag does not exist in session storage', () => {
+      expect(utils.isBeaconInspectionEnabled()).toBe(false)
+    })
+
+    it('should return false if URL api not available', () => {
+      const originalURL = window.URL
+      window.URL = undefined
+      expect(utils.isBeaconInspectionEnabled()).toBe(false)
+      window.URL = originalURL
+    })
+
+    it('should return false if URLSearchParams api not available', () => {
+      const originalURLSearchParams = window.URLSearchParams
+      window.URLSearchParams = undefined
+      expect(utils.isBeaconInspectionEnabled()).toBe(false)
+      window.URLSearchParams = originalURLSearchParams
+    })
+
+    if (window.URL && window.URLSearchParams) {
+      it('should return false if href does not include the flag as a query param', () => {
+        window.history.pushState({}, 'elastic', '/')
+        expect(utils.isBeaconInspectionEnabled()).toBe(false)
+      })
+
+      it('should return true if href includes the flag as a query param', () => {
+        window.history.pushState({}, 'elastic', '/?_elastic_inspect_beacon_')
+
+        expect(utils.isBeaconInspectionEnabled()).toBe(true)
+        expect(sessionStorage.getItem('_elastic_inspect_beacon_')).not.toBe(
+          null
+        )
+      })
+    }
+  })
 })


### PR DESCRIPTION
# Context

In the past it has been common to find the situation where we needed a HAR file to investigate issues of a support case.

Most of the time the HAR files provided were not showing the payload of the events sent by the RUM agent. That was happening because they were generated in **Chrome**. That browser supports **Compression Streams API** which it is being used by the agent to compress events payload. Although it would be possible to generate them with a browser such as Firefox, we have found that in particular cases that wasn't a viable option for support.

Because of that, in a conversation with @vigneshshanmugam we agreed to provide a way of disabling payload compression for such scenarios.

# What the PR is doing

Disables the payload compression:

1.  if an item with the key `_elastic_inspect_beacon_` exists in `sessionStorage`.
2.  If the page is loaded including the url param `_elastic_inspect_beacon_`. E.g. `https://elastic.co?_elastic_inspect_beacon_` (this creates the item in sessionStorage automatically)

The scenario **2** covers the case where support is not directly creating the HAR and instead explaining to a customer how to do it. The way I see it, to add `?_elastic_inspect_beacon_` to a URL is much simpler than creating a sessionStorage item manually.


# demo 

- creating the sessionStorage item manually

https://user-images.githubusercontent.com/15065076/166950345-c52b426f-3ad1-470e-bb56-e4ec91eff595.mov

- accessing a website with the query param included

https://user-images.githubusercontent.com/15065076/166953487-f82b7473-5679-417f-9800-6f1b3e86bbde.mov


Pending task:

- [x] Update the troubleshooting section so as to add this 





