### PR TITLE
docs: add release notes for 5.11.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,18 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 [[release-notes-5.x]]
 === RUM JS Agent version 5.x
 
+[[release-notes-5.11.1]]
+==== 5.11.1 (2022-05-16)
+[float]
+===== Features
+* Span's outcome is now set to ```Unknown``` when a Fetch/XHR request is aborted. The outcome can be found in the metadata information of the span details in APM UI: {pull}1211[#1211]
+* Allow users the ability to [disable compression](https://www.elastic.co/guide/en/apm/agent/rum-js/current/troubleshooting.html#disable-events-payload-compression) for the events sent to APM server. This is helpful for debugging purposes while inspecting via
+Devtools and also for generating HAR file: {pull}1214[#1214]
+
+===== Bug fixes
+* The instrumentation of fetch API consumes a response as a readable stream properly. Before this fix the related span was being ended on the start of the response rather than on the end of it: {pull}1213[#1213]
+* Agent now can listen to all click events on the page. Users can enable/disable click instrumentation via `disableInstrumentation: ["click"]`. ```eventtarget``` instrumentation flag will be deprecated in favor of ```click``` and will be removed in the future releases: {pull}1219[#1219]
+
 [[release-notes-5.11.0]]
 ==== 5.11.0 (2022-04-20)
 [float]


### PR DESCRIPTION
- Release notes for 5.11.1


When updating 5.x branch docs, I will make sure of adding:

- the changes of this PR
- the changes done in [troubleshooting docs](https://github.com/elastic/apm-agent-rum-js/pull/1214/files?short_path=92b8b79#diff-92b8b7986e2fd45aa4cb15ef8868e24f3470b2f0f17a9ab88c1b95f1357e0b6c).  (**DONE**)
- the changes done in [disableInstrumentation docs](https://github.com/elastic/apm-agent-rum-js/pull/1219/files?short_path=df7480c#diff-df7480cd30746f32771991c28c14e275c3d46e989be2be5da8cfc6f9a1b02eb7) (**DONE**)