### PR TITLE
feat: warn users when invalid config options provided when init

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -211,7 +211,7 @@ class Config {
         errors.missing.push(key)
       }
 
-      if (allKeys.indexOf(key) < 0) {
+      if (allKeys.indexOf(key) === -1) {
         errors.unknown.push(key)
       }
     })

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -95,7 +95,6 @@ class Config {
       session: false,
       apmRequest: null
     }
-
     this.events = new EventHandler()
     this.filters = []
     /**
@@ -198,16 +197,22 @@ class Config {
    */
   validate(properties = {}) {
     const requiredKeys = ['serviceName', 'serverUrl']
+    const allKeys = Object.keys(this.config)
     const errors = {
       missing: [],
-      invalid: []
+      invalid: [],
+      unknown: []
     }
     /**
-     * Check when required keys are missing
+     * Check when required keys are missing or unknown keys found
      */
     Object.keys(properties).forEach(key => {
       if (requiredKeys.indexOf(key) !== -1 && !properties[key]) {
         errors.missing.push(key)
+      }
+
+      if (allKeys.indexOf(key) < 0) {
+        errors.unknown.push(key)
       }
     })
     /**

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -95,6 +95,7 @@ class Config {
       session: false,
       apmRequest: null
     }
+
     this.events = new EventHandler()
     this.filters = []
     /**

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -138,14 +138,16 @@ describe('ConfigService', function () {
     const errors1 = configService.validate({ serviceName: 'name' })
     expect(errors1).toEqual({
       missing: [],
-      invalid: []
+      invalid: [],
+      unknown: []
     })
 
     // missing required key serviceName
     const errors2 = configService.validate({ serviceName: undefined })
     expect(errors2).toEqual({
       missing: ['serviceName'],
-      invalid: []
+      invalid: [],
+      unknown: []
     })
 
     // missing required key serviceName & serverUrl
@@ -155,7 +157,8 @@ describe('ConfigService', function () {
     })
     expect(errors3).toEqual({
       missing: ['serviceName', 'serverUrl'],
-      invalid: []
+      invalid: [],
+      unknown: []
     })
 
     // Invalid characters in serviceName
@@ -168,7 +171,8 @@ describe('ConfigService', function () {
           value: 'abc.def',
           allowed: 'a-z, A-Z, 0-9, _, -, <space>'
         }
-      ]
+      ],
+      unknown: []
     })
 
     // transactionSampleRate validation
@@ -207,6 +211,18 @@ describe('ConfigService', function () {
         allowed: 'Number between 0 and 1'
       }
     ])
+  })
+
+  it('should check unknown config options', () => {
+    const errors1 = configService.validate({
+      serviceName: 'name',
+      unknownOption: 'hello'
+    })
+    expect(errors1).toEqual({
+      missing: [],
+      invalid: [],
+      unknown: ['unknownOption']
+    })
   })
 
   it('should addLabels', function () {

--- a/packages/rum-core/test/common/config-service.spec.js
+++ b/packages/rum-core/test/common/config-service.spec.js
@@ -133,95 +133,104 @@ describe('ConfigService', function () {
     })
   })
 
-  it('should validate required config options', () => {
-    // Valid
-    const errors1 = configService.validate({ serviceName: 'name' })
-    expect(errors1).toEqual({
-      missing: [],
-      invalid: [],
-      unknown: []
+  describe('config options', () => {
+    it('should validate required config options', () => {
+      const errors = configService.validate({ serviceName: 'name' })
+      expect(errors).toEqual({
+        missing: [],
+        invalid: [],
+        unknown: []
+      })
     })
 
-    // missing required key serviceName
-    const errors2 = configService.validate({ serviceName: undefined })
-    expect(errors2).toEqual({
-      missing: ['serviceName'],
-      invalid: [],
-      unknown: []
+    it('should report missing required key serviceName', () => {
+      const errors = configService.validate({ serviceName: undefined })
+      expect(errors).toEqual({
+        missing: ['serviceName'],
+        invalid: [],
+        unknown: []
+      })
     })
 
-    // missing required key serviceName & serverUrl
-    const errors3 = configService.validate({
-      serviceName: undefined,
-      serverUrl: ''
-    })
-    expect(errors3).toEqual({
-      missing: ['serviceName', 'serverUrl'],
-      invalid: [],
-      unknown: []
+    it('should report missing required key serviceName & serverUrl', () => {
+      const errors = configService.validate({
+        serviceName: undefined,
+        serverUrl: ''
+      })
+      expect(errors).toEqual({
+        missing: ['serviceName', 'serverUrl'],
+        invalid: [],
+        unknown: []
+      })
     })
 
-    // Invalid characters in serviceName
-    const errors4 = configService.validate({ serviceName: 'abc.def' })
-    expect(errors4).toEqual({
-      missing: [],
-      invalid: [
+    it('should report invalid characters in serviceName', () => {
+      const errors = configService.validate({ serviceName: 'abc.def' })
+      expect(errors).toEqual({
+        missing: [],
+        invalid: [
+          {
+            key: 'serviceName',
+            value: 'abc.def',
+            allowed: 'a-z, A-Z, 0-9, _, -, <space>'
+          }
+        ],
+        unknown: []
+      })
+    })
+
+    it('should validate transactionSampleRate', () => {
+      var sampleRateErrors = configService.validate({
+        transactionSampleRate: 2
+      })
+      expect(sampleRateErrors.invalid).toEqual([
         {
-          key: 'serviceName',
-          value: 'abc.def',
-          allowed: 'a-z, A-Z, 0-9, _, -, <space>'
+          key: 'transactionSampleRate',
+          value: 2,
+          allowed: 'Number between 0 and 1'
         }
-      ],
-      unknown: []
+      ])
+
+      sampleRateErrors = configService.validate({
+        transactionSampleRate: 'test'
+      })
+      expect(sampleRateErrors.invalid).toEqual([
+        {
+          key: 'transactionSampleRate',
+          value: 'test',
+          allowed: 'Number between 0 and 1'
+        }
+      ])
+
+      sampleRateErrors = configService.validate({ transactionSampleRate: -1 })
+      expect(sampleRateErrors.invalid).toEqual([
+        {
+          key: 'transactionSampleRate',
+          value: -1,
+          allowed: 'Number between 0 and 1'
+        }
+      ])
+
+      sampleRateErrors = configService.validate({ transactionSampleRate: NaN })
+      expect(sampleRateErrors.invalid).toEqual([
+        {
+          key: 'transactionSampleRate',
+          value: NaN,
+          allowed: 'Number between 0 and 1'
+        }
+      ])
     })
 
-    // transactionSampleRate validation
-    var sampleRateErrors = configService.validate({ transactionSampleRate: 2 })
-    expect(sampleRateErrors.invalid).toEqual([
-      {
-        key: 'transactionSampleRate',
-        value: 2,
-        allowed: 'Number between 0 and 1'
-      }
-    ])
-
-    sampleRateErrors = configService.validate({ transactionSampleRate: 'test' })
-    expect(sampleRateErrors.invalid).toEqual([
-      {
-        key: 'transactionSampleRate',
-        value: 'test',
-        allowed: 'Number between 0 and 1'
-      }
-    ])
-
-    sampleRateErrors = configService.validate({ transactionSampleRate: -1 })
-    expect(sampleRateErrors.invalid).toEqual([
-      {
-        key: 'transactionSampleRate',
-        value: -1,
-        allowed: 'Number between 0 and 1'
-      }
-    ])
-
-    sampleRateErrors = configService.validate({ transactionSampleRate: NaN })
-    expect(sampleRateErrors.invalid).toEqual([
-      {
-        key: 'transactionSampleRate',
-        value: NaN,
-        allowed: 'Number between 0 and 1'
-      }
-    ])
-  })
-
-  it('should check unknown config options', () => {
-    const errors1 = configService.validate({
-      serviceName: 'name',
-      unknownOption: 'hello'
-    })
-    expect(errors1).toEqual({
-      missing: [],
-      invalid: [],
-      unknown: ['unknownOption']
+    it('should report unknown config options', () => {
+      const errors = configService.validate({
+        serviceName: 'name',
+        unknownOption: 'hello'
+      })
+      expect(errors).toEqual({
+        missing: [],
+        invalid: [],
+        unknown: ['unknownOption']
+      })
     })
   })
 

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -219,21 +219,31 @@ export default class ApmBase {
    *
    * validation error format
    * {
-   *  missing: [ 'key1', 'key2']
+   *  missing: [ 'key1', 'key2'],
    *  invalid: [{
    *    key: 'a',
    *    value: 'abcd',
    *    allowed: 'string'
-   *  }]
+   *  }],
+   *  unknown: ['key3', 'key4']
    * }
    */
   config(config) {
-    const configService = this.serviceFactory.getService(CONFIG_SERVICE)
-    const { missing, invalid } = configService.validate(config)
+    const [configService, loggingService] = this.serviceFactory.getService([
+      CONFIG_SERVICE,
+      LOGGING_SERVICE
+    ])
+    const { missing, invalid, unknown } = configService.validate(config)
+    if (unknown.length > 0) {
+      const message =
+        'Unknown config options are specified for RUM agent: ' +
+        unknown.join(', ')
+      loggingService.warn(message)
+    }
+
     if (missing.length === 0 && invalid.length === 0) {
       configService.setConfig(config)
     } else {
-      const loggingService = this.serviceFactory.getService(LOGGING_SERVICE)
       const separator = ', '
       let message = "RUM agent isn't correctly configured. "
 

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -387,15 +387,15 @@ describe('ApmBase', function () {
   })
 
   describe('invalid config', () => {
-    const logErrorSpy = spyOn(loggingService, 'error')
+    let loggingService
 
     beforeEach(() => {
-      logErrorSpy.calls.reset()
+      loggingService = serviceFactory.getService(LOGGING_SERVICE)
+      spyOn(loggingService, 'warn')
+      spyOn(loggingService, 'error')
     })
 
     it('should log errors when config is invalid', () => {
-      const loggingService = serviceFactory.getService(LOGGING_SERVICE)
-      spyOn(loggingService, 'warn')
       apmBase.init({
         serverUrl: undefined,
         serviceName: ''

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -416,6 +416,16 @@ describe('ApmBase', function () {
     expect(loggingService.error).toHaveBeenCalledWith(
       `RUM agent isn't correctly configured. serviceName "abc.def" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)`
     )
+
+    logErrorSpy.calls.reset()
+    apmBase.config({
+      serviceName: 'abc',
+      serverUrl: 'http://localhost:8000',
+      randomKey: 'boo'
+    })
+    expect(loggingService.warn).toHaveBeenCalledWith(
+      `Unknown config options are specified for RUM agent: randomKey`
+    )
   })
 
   it('should instrument sync xhr', function (done) {

--- a/packages/rum/test/specs/apm-base.spec.js
+++ b/packages/rum/test/specs/apm-base.spec.js
@@ -386,46 +386,56 @@ describe('ApmBase', function () {
     expect(loggingService.warn).toHaveBeenCalledWith('RUM agent is inactive')
   })
 
-  it('should log errors when config is invalid', () => {
-    const loggingService = serviceFactory.getService(LOGGING_SERVICE)
-    spyOn(loggingService, 'warn')
+  describe('invalid config', () => {
     const logErrorSpy = spyOn(loggingService, 'error')
-    apmBase.init({
-      serverUrl: undefined,
-      serviceName: ''
-    })
-    expect(loggingService.error).toHaveBeenCalledWith(
-      `RUM agent isn't correctly configured. serverUrl, serviceName is missing`
-    )
-    const configService = serviceFactory.getService(CONFIG_SERVICE)
-    expect(configService.get('active')).toEqual(false)
 
-    logErrorSpy.calls.reset()
-    apmBase.config({
-      serverUrl: '',
-      serviceName: 'abc.def'
+    beforeEach(() => {
+      logErrorSpy.calls.reset()
     })
-    expect(loggingService.error).toHaveBeenCalledWith(
-      `RUM agent isn't correctly configured. serverUrl is missing, serviceName "abc.def" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)`
-    )
 
-    logErrorSpy.calls.reset()
-    apmBase.config({
-      serviceName: 'abc.def'
+    it('should log errors when config is invalid', () => {
+      const loggingService = serviceFactory.getService(LOGGING_SERVICE)
+      spyOn(loggingService, 'warn')
+      apmBase.init({
+        serverUrl: undefined,
+        serviceName: ''
+      })
+      expect(loggingService.error).toHaveBeenCalledWith(
+        `RUM agent isn't correctly configured. serverUrl, serviceName is missing`
+      )
+      const configService = serviceFactory.getService(CONFIG_SERVICE)
+      expect(configService.get('active')).toEqual(false)
     })
-    expect(loggingService.error).toHaveBeenCalledWith(
-      `RUM agent isn't correctly configured. serviceName "abc.def" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)`
-    )
 
-    logErrorSpy.calls.reset()
-    apmBase.config({
-      serviceName: 'abc',
-      serverUrl: 'http://localhost:8000',
-      randomKey: 'boo'
+    it('should log missing required key and invalid config', () => {
+      apmBase.config({
+        serverUrl: '',
+        serviceName: 'abc.def'
+      })
+      expect(loggingService.error).toHaveBeenCalledWith(
+        `RUM agent isn't correctly configured. serverUrl is missing, serviceName "abc.def" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)`
+      )
     })
-    expect(loggingService.warn).toHaveBeenCalledWith(
-      `Unknown config options are specified for RUM agent: randomKey`
-    )
+
+    it('should log errors when invalid chars in serviceName', () => {
+      apmBase.config({
+        serviceName: 'abc.def'
+      })
+      expect(loggingService.error).toHaveBeenCalledWith(
+        `RUM agent isn't correctly configured. serviceName "abc.def" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)`
+      )
+    })
+
+    it('should warn users unknown config keys', () => {
+      apmBase.config({
+        serviceName: 'abc',
+        serverUrl: 'http://localhost:8000',
+        randomKey: 'boo'
+      })
+      expect(loggingService.warn).toHaveBeenCalledWith(
+        `Unknown config options are specified for RUM agent: randomKey`
+      )
+    })
   })
 
   it('should instrument sync xhr', function (done) {


### PR DESCRIPTION
closes #1228 

Check the config options and print warnings when unknown config options are specified. 
As mentioned in the ticket, we won't affect any initiation logic but keep permitting the agent to be activated.
