### PR TITLE
docs: amend release 5.11.0 notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,9 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 [float]
 ===== Features
 * Events are now beaconed when the user abandons or backgrounds the page, this makes sure the agent never miss an event. Before this change it was only sending them every interval configurable via `flushInterval`. Unsupported browsers: Firefox, IE11: {pull}1146[#1146]
+
+NOTE: Transactions based on the <<supported-technologies,supported technologies>> and <<custom-managed-transactions, custom managed transactions>> are the only ones taken into account.
+
 * **rum-vue:** Introduce script setup syntax support: {issue}1194[#1194]
 * Override reuse threshold when redefining a transaction. This will permit the agent not to miss data on slow network connections: {issue}1196[#1196]
 


### PR DESCRIPTION
# Context

In the 5.11.0 release notes we explained that the [new beaconing feature ](https://www.elastic.co/guide/en/apm/agent/rum-js/current/release-notes-5.x.html#_features_2) was sending all events. Nevertheless, there is a nuance that we didn't include in the description. [Custom unmanaged transactions](https://github.com/elastic/apm-agent-rum-js/issues/1231) are not handled by that feature.

# Summary

This PR updates the release notes to highlight that only managed transactions are considered.

