### PR TITLE
feat: allow requests to be sent with credentials

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -396,3 +396,13 @@ apm.init({
   }
 })
 ----
+
+
+[float]
+[[send-credentials]]
+==== `sendCredentials`
+
+* *Type:* Boolean
+* *Default:* `false`
+
+Instructs the agent to send credentials when making requests to the APM server.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -405,4 +405,8 @@ apm.init({
 * *Type:* Boolean
 * *Default:* `false`
 
-Instructs the agent to send credentials when making requests to the APM server.
+This allows the agent to send cookies when making requests to the APM server.
+This is useful on scenarios where the APM server is behind a reverse proxy that requires requests to be authenticated.
+
+NOTE: If APM Server is deployed in an origin different than the page’s origin, you will need to
+<<configuring-cors, configure Cross-Origin Resource Sharing (CORS)>>.

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -93,7 +93,8 @@ class Config {
       apiVersion: 2,
       context: {},
       session: false,
-      apmRequest: null
+      apmRequest: null,
+      sendCredentials: false
     }
 
     this.events = new EventHandler()

--- a/packages/rum-core/src/common/http/fetch.js
+++ b/packages/rum-core/src/common/http/fetch.js
@@ -48,7 +48,13 @@ export function shouldUseFetchWithKeepAlive(method, payload) {
 export function sendFetchRequest(
   method,
   url,
-  { keepalive = false, timeout = HTTP_REQUEST_TIMEOUT, payload, headers }
+  {
+    keepalive = false,
+    timeout = HTTP_REQUEST_TIMEOUT,
+    payload,
+    headers,
+    sendCredentials
+  }
 ) {
   let timeoutConfig = {}
   if (typeof AbortController === 'function') {
@@ -64,7 +70,7 @@ export function sendFetchRequest(
       headers,
       method,
       keepalive, // used to allow the request to outlive the page.
-      credentials: 'omit',
+      credentials: sendCredentials ? 'include' : 'omit',
       ...timeoutConfig
     })
     .then(response => {

--- a/packages/rum-core/src/common/http/xhr.js
+++ b/packages/rum-core/src/common/http/xhr.js
@@ -30,13 +30,20 @@ import { Promise } from '../polyfills'
 export function sendXHR(
   method,
   url,
-  { timeout = HTTP_REQUEST_TIMEOUT, payload, headers, beforeSend }
+  {
+    timeout = HTTP_REQUEST_TIMEOUT,
+    payload,
+    headers,
+    beforeSend,
+    sendCredentials
+  }
 ) {
   return new Promise(function (resolve, reject) {
     var xhr = new window.XMLHttpRequest()
     xhr[XHR_IGNORE] = true
     xhr.open(method, url, true)
     xhr.timeout = timeout
+    xhr.withCredentials = sendCredentials
 
     if (headers) {
       for (var header in headers) {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -478,9 +478,11 @@ describe('ApmServer', function () {
       spyOnFunction(xhrSender, 'sendXHR')
       const serverUrl = 'http://localhost'
       const serverUrlPrefix = '/prefix'
+      const sendCredentials = true
       configService.setConfig({
         serverUrl,
-        serverUrlPrefix
+        serverUrlPrefix,
+        sendCredentials
       })
 
       await apmServer.sendEvents([{ [TRANSACTIONS]: { test: 'test' } }])
@@ -496,7 +498,8 @@ describe('ApmServer', function () {
             '{"metadata":{"service":{"name":"test","agent":{"name":"rum-js","version":"N/A"},"language":{"name":"javascript"}}}}\n{"transaction":{"test":"test"}}\n',
           headers: {
             'Content-Type': 'application/x-ndjson'
-          }
+          },
+          sendCredentials: true
         }
       )
       expect(xhrSender.sendXHR).toHaveBeenCalledTimes(0)
@@ -512,10 +515,12 @@ describe('ApmServer', function () {
 
       const serverUrl = 'http://localhost'
       const serverUrlPrefix = '/prefix'
+      const sendCredentials = true
       configService.setConfig({
         serverUrl,
         serverUrlPrefix,
-        apmRequest: beforeSend
+        apmRequest: beforeSend,
+        sendCredentials
       })
 
       await apmServer.sendEvents([{ [TRANSACTIONS]: { test: 'test' } }])
@@ -534,7 +539,8 @@ describe('ApmServer', function () {
           headers: {
             'Content-Type': 'application/x-ndjson'
           },
-          beforeSend
+          beforeSend,
+          sendCredentials
         }
       )
     })
@@ -549,9 +555,11 @@ describe('ApmServer', function () {
       spyOnFunction(xhrSender, 'sendXHR').and.resolveTo({})
       const serverUrl = 'http://localhost'
       const serverUrlPrefix = '/prefix'
+      const sendCredentials = true
       configService.setConfig({
         serverUrl,
-        serverUrlPrefix
+        serverUrlPrefix,
+        sendCredentials
       })
 
       await apmServer.sendEvents([{ [TRANSACTIONS]: { test: 'test' } }])
@@ -570,7 +578,8 @@ describe('ApmServer', function () {
           headers: {
             'Content-Type': 'application/x-ndjson'
           },
-          beforeSend: null
+          beforeSend: null,
+          sendCredentials: true
         }
       )
     })

--- a/packages/rum-core/test/common/http/fetch.spec.js
+++ b/packages/rum-core/test/common/http/fetch.spec.js
@@ -134,7 +134,8 @@ describeIf(
       await sendFetchRequest('POST', 'anyUrl', {
         payload: 'anyPayload',
         keepalive: true,
-        headers: {}
+        headers: {},
+        sendCredentials: false
       })
 
       expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -146,6 +147,35 @@ describeIf(
           body: 'anyPayload',
           method: 'POST',
           credentials: 'omit'
+        })
+      )
+    })
+
+    it('should send credentials if requested', async () => {
+      const response = {
+        status: 200,
+        text() {
+          return Promise.resolve({})
+        }
+      }
+      const fetchSpy = spyOn(window, 'fetch').and.resolveTo(response)
+
+      await sendFetchRequest('POST', 'anyUrl', {
+        payload: 'anyPayload',
+        keepalive: true,
+        headers: {},
+        sendCredentials: true
+      })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'anyUrl',
+        jasmine.objectContaining({
+          keepalive: true,
+          headers: {},
+          body: 'anyPayload',
+          method: 'POST',
+          credentials: 'include'
         })
       )
     })


### PR DESCRIPTION
fix #1237 

This allows RUM clients to send cookies to APM servers that are behind reverse proxies that require requests to be authenticated.