### PR TITLE
fix(rum-core): capture stack trace from syntax errors properly

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -27,6 +27,7 @@ import { createStackTraces, filterInvalidFrames } from './stack-trace'
 import { generateRandomId, merge, extend } from '../common/utils'
 import { getPageContext } from '../common/context'
 import { truncateModel, ERROR_MODEL } from '../common/truncate'
+import stackParser from 'error-stack-parser'
 
 /**
  * List of keys to be ignored from getting added to custom error properties
@@ -76,7 +77,7 @@ class ErrorLogging {
    * errorEvent = { message, filename, lineno, colno, error }
    */
   createErrorDataModel(errorEvent) {
-    const frames = createStackTraces(errorEvent)
+    const frames = createStackTraces(stackParser, errorEvent)
     const filteredFrames = filterInvalidFrames(frames)
 
     // If filename empty, assume inline script


### PR DESCRIPTION
# Context

The RUM agent was capturing errors thrown in [inline scripts](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#examples) with an **empty stack trace**.  There is a nuance to highlight, though.

This **only** affects to errors whose type is [SyntaxError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) and have been triggered because of a malformed JavaScript code. This tend to occur when the browser is parsing the document.

The following two examples will help to understand that nuance:

Example 1 (**KO**): SyntaxError because of malformed JavaScript while parsing the document:

```
<html>
  <head>Example 1: SyntaxError because of malformed JavaScript while parsing the document </head>
  <body>
     Hello, I am Example 1 page.
    <script>
         var a:      // This throws a Syntax Error
    </script>
  </body>
</html>
```

As we can see on the screenshot below the **stacktrace** was empty:

<img width="429" alt="Screenshot 2022-06-07 at 16 20 22" src="https://user-images.githubusercontent.com/15065076/172404117-817599c6-f3bb-4d00-9fe3-586375ac315a.png">


Example 2 (**OK**): SyntaxError because of bad usage of JSON.parse


```
<html>
  <head>Example 2: SyntaxError because of bad usage of JSON.parse </head>
  <body>
     Hello, I am Example 2 page.
    <script>
         JSON.parse("bad json") // this will throw a SyntaxError too
    </script>
  </body>
</html>
```

As we can see on the screenshot below the stack trace was **not** empty, since this kind of SyntaxError was being handled properly:

<img width="1085" alt="Screenshot 2022-06-07 at 16 26 53" src="https://user-images.githubusercontent.com/15065076/172405593-14f4ffe1-8306-4da5-9385-316e0a8289df.png">

## How are we generating stacktraces?

One of the steps of the error capturing flow is the one that generates the stacktrace from an [error event](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent). Given the complexity that some cases have (cross browsing support for instance) we rely on a third-party library named [error-stack-parser](https://github.com/stacktracejs/error-stack-parser). Unfortunately, that case is not being handled as expected.


## Fix

The ErrorEvent that the browser dispatches when an uncaught error takes place contains all the information we need to generate the **stacktrace**.  So, that's what we do now, we create a stack trace of a single element which contains the missing information.

After the fix, the **stacktrace** of **example 1** looks this way: 🎉 


<img width="1081" alt="Screenshot 2022-06-07 at 16 48 43" src="https://user-images.githubusercontent.com/15065076/172410744-d16d8b4c-f395-4776-8f47-3554b9985218.png">

## Next

We are going to create an issue in the third-party library to report the unexpected behaviour.

