### PR TITLE
docs: update cors documentation

### DIFF
--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -182,5 +182,12 @@ Access-Control-Allow-Methods: POST, OPTIONS
 Access-Control-Allow-Origin: [request-origin]
 ----
 
+If you enable the <<send-credentials, sendCredentials>> configuration option you will need to make sure that your proxy's response include the header `Access-Control-Allow-Origin` with the page's origin as a value and that the following header is also included:
+
+[source,js]
+----
+Access-Control-Allow-Credentials: true
+----
+
 TIP: To learn more about CORS, see the MDN page on
 https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[Cross-Origin Resource Sharing].

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -182,7 +182,7 @@ Access-Control-Allow-Methods: POST, OPTIONS
 Access-Control-Allow-Origin: [request-origin]
 ----
 
-If you enable the <<send-credentials, sendCredentials>> configuration option you will need to make sure that your proxy's response include the header `Access-Control-Allow-Origin` with the page's origin as a value and that the following header is also included:
+If you enable the <<send-credentials, `sendCredentials`>> configuration option, your proxy's response must include the header `Access-Control-Allow-Origin` with the page's origin as a value, and the following header:
 
 [source,js]
 ----


### PR DESCRIPTION
# Summary

This PR follows up the [one](https://github.com/elastic/apm-agent-rum-js/pull/1238) which added the new config for sending credentials.

The added changes would look like the screenshot below:

<img width="765" alt="Screenshot 2022-06-13 at 19 14 53" src="https://user-images.githubusercontent.com/15065076/173408574-b400a6ff-d208-44a9-8630-740ff63c164d.png">


The current version is available in this [link](https://www.elastic.co/guide/en/apm/agent/rum-js/5.x/configuring-cors.html)
