### PR TITLE
feat(rum): add sendCredentials config to TypeScript typings

### DIFF
--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -100,6 +100,7 @@ declare module '@elastic/apm-rum' {
     propagateTracestate?: boolean
     eventsLimit?: number
     queueLimit?: number
+    sendCredentials?: boolean
   }
 
   type Init = (options?: AgentConfigOptions) => ApmBase


### PR DESCRIPTION
elastic/apm-agent-rum-js#1238 added the `sendCredentials` option, but it didn't add it to the Typescript definitions file. This fixes that oversight.