### PR TITLE
fix: check supportedEntryTypes when starting observer

### DIFF
--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -30,7 +30,7 @@ import {
   FIRST_INPUT,
   LAYOUT_SHIFT
 } from '../common/constants'
-import { noop, PERF } from '../common/utils'
+import { noop, PERF, isPerfTypeSupported } from '../common/utils'
 import Span from './span'
 
 export const metrics = {
@@ -318,9 +318,7 @@ export class PerfEntryRecorder {
 
   start(type) {
     try {
-      const supportedEntryTypes =
-        window.PerformanceObserver?.supportedEntryTypes || []
-      if (supportedEntryTypes.indexOf(type) === -1) {
+      if (!isPerfTypeSupported(type)) {
         return
       }
       /**

--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -317,12 +317,9 @@ export class PerfEntryRecorder {
   }
 
   start(type) {
-    /**
-     * Safari throws an error when PerformanceObserver is
-     * observed for unknown entry types as longtasks and lcp is
-     * not supported at the moment
-     */
-    try {
+    const supportedEntryTypes =
+      window.PerformanceObserver?.supportedEntryTypes || []
+    if (supportedEntryTypes.indexOf(type) !== -1) {
       /**
        * Start observing for different entry types depending on the transaction type
        * - `buffered`: true means we would be able to retrive all the events that happened
@@ -332,7 +329,7 @@ export class PerfEntryRecorder {
        *   buffered flag (https://w3c.github.io/performance-timeline/#observe-method)
        */
       this.po.observe({ type, buffered: true })
-    } catch (_) {}
+    }
   }
 
   stop() {

--- a/packages/rum-core/src/performance-monitoring/metrics.js
+++ b/packages/rum-core/src/performance-monitoring/metrics.js
@@ -317,9 +317,12 @@ export class PerfEntryRecorder {
   }
 
   start(type) {
-    const supportedEntryTypes =
-      window.PerformanceObserver?.supportedEntryTypes || []
-    if (supportedEntryTypes.indexOf(type) !== -1) {
+    try {
+      const supportedEntryTypes =
+        window.PerformanceObserver?.supportedEntryTypes || []
+      if (supportedEntryTypes.indexOf(type) === -1) {
+        return
+      }
       /**
        * Start observing for different entry types depending on the transaction type
        * - `buffered`: true means we would be able to retrive all the events that happened
@@ -329,6 +332,12 @@ export class PerfEntryRecorder {
        *   buffered flag (https://w3c.github.io/performance-timeline/#observe-method)
        */
       this.po.observe({ type, buffered: true })
+    } catch (_) {
+      /**
+       * Even though we check supportedEntryTypes before starting the observer,
+       * there are risks of exceptions according to the [spec](https://www.w3.org/TR/performance-timeline/#observe-method)
+       * But we ignore error since this is not intended to be seen by users
+       */
     }
   }
 

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -33,6 +33,7 @@ import {
   createLongTaskSpans
 } from '../../src/performance-monitoring/metrics'
 import { LARGEST_CONTENTFUL_PAINT, LONG_TASK } from '../../src/common/constants'
+import { isPerfTypeSupported } from '../../src/common/utils'
 import {
   mockObserverEntryTypes,
   mockObserverEntryNames
@@ -170,35 +171,32 @@ describe('Metrics', () => {
       ])
     })
 
-    it('should start recorder with correct type', () => {
+    it('should start recorder only when the type is supported', () => {
       const recorder = new PerfEntryRecorder(() => {})
       const onStartSpy = jasmine.createSpy()
       recorder.po = {
         observe: onStartSpy
       }
       recorder.start(LONG_TASK)
-
-      expect(onStartSpy).toHaveBeenCalledWith({
-        type: LONG_TASK,
-        buffered: true
-      })
+      if (isPerfTypeSupported(LONG_TASK)) {
+        expect(onStartSpy).toHaveBeenCalledWith({
+          type: LONG_TASK,
+          buffered: true
+        })
+      } else {
+        expect(onStartSpy).not.toHaveBeenCalled()
+      }
       onStartSpy.calls.reset()
 
       recorder.start(LARGEST_CONTENTFUL_PAINT)
-      expect(onStartSpy).toHaveBeenCalledWith({
-        type: LARGEST_CONTENTFUL_PAINT,
-        buffered: true
-      })
-    })
-
-    it('should not start observer with unsupported type', () => {
-      const recorder = new PerfEntryRecorder(() => {})
-      const onStartSpy = jasmine.createSpy()
-      recorder.po = {
-        observe: onStartSpy
+      if (isPerfTypeSupported(LARGEST_CONTENTFUL_PAINT)) {
+        expect(onStartSpy).toHaveBeenCalledWith({
+          type: LARGEST_CONTENTFUL_PAINT,
+          buffered: true
+        })
+      } else {
+        expect(onStartSpy).not.toHaveBeenCalled()
       }
-      recorder.start('unknown_entry_type')
-      expect(onStartSpy).not.toHaveBeenCalled()
     })
 
     describe('Total Blocking Time', () => {

--- a/packages/rum-core/test/performance-monitoring/metrics.spec.js
+++ b/packages/rum-core/test/performance-monitoring/metrics.spec.js
@@ -191,6 +191,16 @@ describe('Metrics', () => {
       })
     })
 
+    it('should not start observer with unsupported type', () => {
+      const recorder = new PerfEntryRecorder(() => {})
+      const onStartSpy = jasmine.createSpy()
+      recorder.po = {
+        observe: onStartSpy
+      }
+      recorder.start('unknown_entry_type')
+      expect(onStartSpy).not.toHaveBeenCalled()
+    })
+
     describe('Total Blocking Time', () => {
       it('should create total blocking time as span', () => {
         calculateTotalBlockingTime(longtaskEntries)


### PR DESCRIPTION
fixes #1245 

This PR checks `PerformanceObserver.supportedEntryTypes` before starting an observer for a certain entryType so that it doesn't print a warning on Firefox browser and doesn't trigger errors on Safari when it starts observer for unsupported types.

Before the change on Firefox (latest version):
[![Image from Gyazo](https://i.gyazo.com/86731cfbb03863cbb454a57400d1d8db.gif)](https://gyazo.com/86731cfbb03863cbb454a57400d1d8db)

After the change on Firefox (local build of this PR):
<a href="https://gyazo.com/8324a6d181070ed09d4933651597428a"><img src="https://i.gyazo.com/8324a6d181070ed09d4933651597428a.gif" alt="Image from Gyazo" width="986"/></a>


### Note
List of supported entry types:
- Chrome (102.0): 
`['element', 'event', 'first-input', 'largest-contentful-paint', 'layout-shift', 'longtask', 'mark', 'measure', 'navigation', 'paint', 'resource']`
- Firefox(101.0.1):  `[ "event", "first-input", "mark", "measure", "navigation", "paint", "resource"]`
- Safari(15.5): 
`["mark", "measure", "navigation", "paint", "resource"]` 