### PR TITLE
chore: remove script to lock dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -522,7 +522,7 @@
             "cli-width": "^3.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.21",
             "mute-stream": "0.0.8",
             "run-async": "^2.4.0",
             "rxjs": "^6.6.6",
@@ -1228,7 +1228,7 @@
             "cli-width": "^3.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.21",
             "mute-stream": "0.0.8",
             "run-async": "^2.4.0",
             "rxjs": "^6.6.6",
@@ -2006,7 +2006,7 @@
       "requires": {
         "@babel/types": "^7.3.4",
         "jsesc": "^2.5.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -4924,7 +4924,7 @@
         "@babel/types": "^7.3.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "4.17.21"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -4942,7 +4942,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -4968,7 +4968,7 @@
         "chalk": "4.1.0",
         "core-js": "^3.6.1",
         "get-stdin": "8.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^15.1.0"
@@ -5066,7 +5066,7 @@
       "dev": true,
       "requires": {
         "@commitlint/types": "^10.0.0",
-        "lodash": "4.17.21"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
@@ -5186,7 +5186,7 @@
         "@commitlint/types": "^10.0.0",
         "chalk": "4.1.0",
         "cosmiconfig": "^7.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -5373,7 +5373,7 @@
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
@@ -11100,7 +11100,7 @@
         "@typescript-eslint/scope-manager": "4.17.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
@@ -11816,7 +11816,7 @@
             "cli-width": "^3.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.21",
             "mute-stream": "0.0.8",
             "ora": "^5.4.1",
             "run-async": "^2.4.0",
@@ -14356,7 +14356,7 @@
       "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21",
+        "lodash": "^4.17.4",
         "platform": "^1.3.3"
       },
       "dependencies": {
@@ -16072,7 +16072,7 @@
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       },
       "dependencies": {
@@ -16123,7 +16123,7 @@
         "git-raw-commits": "^2.0.8",
         "git-remote-origin-url": "^2.0.0",
         "git-semver-tags": "^4.1.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "normalize-package-data": "^3.0.0",
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
@@ -16139,7 +16139,7 @@
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.1",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.15",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -16378,7 +16378,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -16431,7 +16431,7 @@
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "meow": "^7.0.0",
         "split2": "^2.0.0",
         "through2": "^3.0.0",
@@ -16695,7 +16695,7 @@
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.1",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.15",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -16917,7 +16917,7 @@
       "dev": true,
       "requires": {
         "json5": "^0.5.1",
-        "lodash": "4.17.21"
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "json5": {
@@ -18772,7 +18772,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -20037,15 +20037,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "dev": true,
       "requires": {
-        "semver-regex": "4.0.2"
-      },
-      "dependencies": {
-        "semver-regex": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.2.tgz",
-          "integrity": "sha512-xyuBZk1XYqQkB687hMQqrCP+J9bdJSjPpZwdmmNjyxKW1K3LDXxqxw91Egaqkh/yheBIVtKPt4/1eybKVdCx3g==",
-          "dev": true
-        }
+        "semver-regex": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -20469,7 +20461,7 @@
       "dev": true,
       "requires": {
         "dargs": "^7.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -20993,7 +20985,7 @@
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "4.17.21",
+        "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
       },
       "dependencies": {
@@ -21526,7 +21518,7 @@
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",
         "html-minifier-terser": "^5.0.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.20",
         "pretty-error": "^2.1.1",
         "tapable": "^2.0.0"
       },
@@ -21619,7 +21611,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
@@ -22109,7 +22101,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -22884,7 +22876,7 @@
           "requires": {
             "@babel/types": "^7.7.2",
             "jsesc": "^2.5.1",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
@@ -22956,7 +22948,7 @@
             "@babel/types": "^7.7.2",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "4.17.21"
+            "lodash": "^4.17.13"
           },
           "dependencies": {
             "@babel/code-frame": {
@@ -22983,7 +22975,7 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "4.17.21",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -23794,14 +23786,14 @@
       "integrity": "sha512-e9YmWrX3xk7BSosBaL/7lg0ZKSOpwQySKlLb1xa2m5VbwMVFffS29QB9f2UCT7+aMCnJlNRWjcKym4Ch/60OsA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21",
+        "lodash": "4.17.15",
         "platform": "1.3.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -24625,7 +24617,7 @@
           "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.21"
+            "lodash": "^4.17.15"
           },
           "dependencies": {
             "lodash": {
@@ -29202,7 +29194,7 @@
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.21"
+            "lodash": "^4.17.14"
           },
           "dependencies": {
             "lodash": {
@@ -30911,7 +30903,7 @@
       "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21",
+        "lodash": "^4.17.20",
         "renderkid": "^2.0.4"
       },
       "dependencies": {
@@ -32121,7 +32113,7 @@
         "css-select": "^4.1.3",
         "dom-converter": "^0.2.0",
         "htmlparser2": "^6.1.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.21",
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
@@ -32731,7 +32723,7 @@
         "adm-zip": "~0.4.3",
         "async": "^2.1.2",
         "https-proxy-agent": "^5.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.16.6",
         "rimraf": "^2.5.4"
       },
       "dependencies": {
@@ -32750,7 +32742,7 @@
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.21"
+            "lodash": "^4.17.14"
           },
           "dependencies": {
             "lodash": {
@@ -33011,6 +33003,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "dev": true
     },
     "semver-truncate": {
@@ -34549,7 +34547,7 @@
       "dev": true,
       "requires": {
         "ajv": "^7.0.2",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.20",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
       },
@@ -36832,7 +36830,7 @@
         "chalk": "^4.1.0",
         "commander": "^6.2.0",
         "gzip-size": "^6.0.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.17.20",
         "opener": "^1.5.2",
         "sirv": "^1.0.7",
         "ws": "^7.3.1"
@@ -37561,7 +37559,7 @@
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21",
+        "lodash": "^4.7.0",
         "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "scripts": {
     "version": "node scripts/prompt-release",
-    "lock-dependencies": "npx npm-force-resolutions@0.0.10",
     "prerelease": "npm test && npm run clean",
     "release": "lerna publish && npm run github-release",
     "release-package": "node scripts/publish-package",
@@ -59,7 +58,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lock-dependencies && lint-staged",
+      "pre-commit": "lint-staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/package.json
+++ b/package.json
@@ -195,9 +195,5 @@
   "engines": {
     "node": ">=12 <=16",
     "npm": "6"
-  },
-  "resolutions": {
-    "semver-regex": "4.0.2",
-    "lodash": "4.17.21"
   }
 }


### PR DESCRIPTION
# Summary

**Agent maintenance:**

A few months ago, in this [PR](https://github.com/elastic/apm-agent-rum-js/pull/1131), we introduced [npm-force-resolutions](https://github.com/rogeriochaves/npm-force-resolutions) to the project.

We did to force some downstream dependencies to resolve to particular versions, such as lodash and semver-regex.

**Why removing this now?**

1. The developer experience when doing commits (including amends) is not good. The process is quite slow and feels intrusive. 
2. Apart from that, none of the dependencies locked end up on the bundle used by our users/customers, all the locked versions are devDependencies.
3. It requires from us to keep track of **two** kind of versions: the ones of the installed packages and the ones related to the resolution.

Those are the main reasons to remove it.


