### PR TITLE
docs: add cross-origin script error details

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -39,6 +39,9 @@ Access-Control-Allow-Origin: *
 Access-Control-Allow-Origin: your page's origin
 ----
 
+TIP: To learn more about how browsers handle script errors, see the MDN page on the https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#notes[onerror] event.
+
+
 [float]
 [[no-stack-trace-available]]
 === No stack trace available in the Span detail view

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -14,6 +14,30 @@ further to identify the offending code.
 Of course, there are errors that might have been caused by the agent itself and we appreciate it if
 you <<get-in-touch, report them back to us>>.
 
+[float]
+[[cross-origin-script-error]]
+=== Some errors in the application only show `script error`
+In some cases when you look at the details of an error, the only information you can see is the message `Script error`.
+This happens when an error originates from a JavaScript file served from a different origin than the page's origin.
+
+In order to get visibility of the error's detail, you must do two things.
+
+1. Add the attribute `crossorigin` to the `<script>` element:
++
+[source,js]
+----
+<script src="https://example.com/example.js" crossorigin>
+----
+
+2. Make sure that the server response includes the `Access-Control-Allow-Origin` header when serving the JavaScript file.
++
+[source,js]
+----
+// Either of the two values is valid:
+
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Origin: your page's origin
+----
 
 [float]
 [[no-stack-trace-available]]


### PR DESCRIPTION
# Summary

To improve the guidance we provide to our users and customers we are updating the [troubleshooting](https://www.elastic.co/guide/en/apm/agent/rum-js/master/troubleshooting.html) page explaining why sometimes the only information available for a JavaScript error is "Script error". The new docs also include the steps needed to fix the situation.

The most recent example of this issue can be seen at [this](https://elastic.slack.com/archives/C0D1XEXEZ/p1655216496061709?thread_ts=1648034147.903139&cid=C0D1XEXEZ) slack conversation with @jstrassb 
<img width="772" alt="Screenshot 2022-06-20 at 16 37 20" src="https://user-images.githubusercontent.com/15065076/174625666-c0a784c6-06bd-46c7-b8d4-45132419cd2b.png">

