### PR TITLE
ci: use the microbenchmarks-pool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,7 +227,7 @@ pipeline {
           }
           parallel {
             stage('Benchmarks') {
-              agent { label 'metal' }
+              agent { label 'microbenchmarks-pool' }
               environment {
                 REPORT_FILE = 'apm-agent-benchmark-results.json'
               }
@@ -258,7 +258,7 @@ pipeline {
               }
             }
             stage('Load testing') {
-              agent { label 'metal' }
+              agent { label 'microbenchmarks-pool' }
               options {
                 warnError('load testing failed')
               }


### PR DESCRIPTION
### What

From now on we will use the same CI workers for the benchmarking

