### PR TITLE
chore: remove _type from benchmark document

### DIFF
--- a/scripts/apm-server-load-test.js
+++ b/scripts/apm-server-load-test.js
@@ -347,8 +347,7 @@ const iterations = 10
   if (outputFile) {
     const outputPath = join(__dirname, '../', outputFile)
     let ndJSONOutput =
-      '{"index": { "_index": "benchmarks-rum-load-test", "_type": "_doc"}}' +
-      '\n'
+      '{"index": { "_index": "benchmarks-rum-load-test" }}' + '\n'
     ndJSONOutput += JSON.stringify(results)
     await writeFile(outputPath, ndJSONOutput)
   } else {

--- a/scripts/benchmarks.js
+++ b/scripts/benchmarks.js
@@ -154,8 +154,7 @@ function runBenchmarks() {
       /**
        * NDJSON format for uploading to ES
        */
-      let ndJSONOutput =
-        '{"index": { "_index": "benchmarks-rum-js", "_type": "_doc"}}' + '\n'
+      let ndJSONOutput = '{"index": { "_index": "benchmarks-rum-js" }}' + '\n'
       ndJSONOutput += JSON.stringify(output)
 
       const outputPath = join(PKG_DIR, outputFile)


### PR DESCRIPTION
# Context

[Recently](https://elastic.slack.com/archives/C5L79P420/p1658250637879769) the deployment of our benchmarks deployment was upgraded from 7.x to 8.x. The new version does not support mapping [types](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html) and since we were including a "_type" property on our document the benchmark process was not ending properly

# Fix 

The "_type" field will not be stored anymore


Thanks @trentm for the heads up