### PR TITLE
hotfix: change event capture timing

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -165,7 +165,7 @@ class ErrorLogging {
   registerListeners() {
     window.addEventListener('error', errorEvent =>
       this.logErrorEvent(errorEvent)
-    )
+    , true)
     window.addEventListener('unhandledrejection', promiseRejectionEvent =>
       this.logPromiseEvent(promiseRejectionEvent)
     )


### PR DESCRIPTION
The error messages of http requests (such as js files, css files, img) cannot be captured at present, and the event monitoring timing should be changed to the capture stage.