### PR TITLE
chore: saucelabs firefox update

### DIFF
--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -167,7 +167,10 @@ function getBrowserList(pkg = 'default') {
       {
         browserName: 'firefox',
         browserVersion: 'latest',
-        platformName: 'Windows 10'
+        platformName: 'Windows 10',
+        'sauce:options': {
+          geckodriverVersion: '0.30.0' // reason: https://github.com/karma-runner/karma-sauce-launcher/issues/275
+        }
       }
     ]
   }


### PR DESCRIPTION
# Context

The **apm-rum-vue** e2e tests were failing because of the following combination:

_Mozilla recently [removed the ability](https://github.com/mozilla/geckodriver/issues/2011) to pass the capability --remote-debugging-port in Firefox GeckoDriver version 0.31.0._


and

_On October 4, 2022, Sauce Labs updated the supported Firefox GeckoDriver to version 0.31.0 for tests on Firefox versions 90 and later. If you use the –remote-debugging-port capability, your tests will fail if you do not take action before October 4, 2022._

More info [here](https://saucelabs.com/blog/update-firefox-tests-before-oct-4-2022)

# Fix

The cleanest fix for this would be to update to a new version of karma-sauce-launcher. Unfortunately, a new version available with the updated [webdriverio](https://github.com/webdriverio/webdriverio/pull/8211) dependency is not yet [available](https://github.com/karma-runner/karma-sauce-launcher/issues/275).

The solution proposed by saucelabs is to set the geckodriverVersion config option to **0.30.0**. This is the solution that we have applied. 

Once the new version of karma-sauce-launcher is available we will update it and remove the 0.30.0 config option.

