### PR TITLE
use chrome stable to execute benchmarks

### DIFF
--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -110,4 +110,5 @@ RUN apt-get -qq install -y wget --no-install-recommends \
         fonts-wqy-zenhei \
         fonts-thai-tlwg \
         fonts-kacst \
+        fonts-freefont-ttf \
         --no-install-recommends

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get -qq install -y wget --no-install-recommends \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get -qq update  \
     && apt-get -qq install -y \
-        google-chrome-unstable \
+        google-chrome-stable \
         fonts-ipafont-gothic \
         fonts-wqy-zenhei \
         fonts-thai-tlwg \

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -10,7 +10,7 @@ ARG NODEJS_VERSION
 
 # 1. Install node
 RUN apt-get -qq update && apt-get -qq install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get -qq install -y nodejs
 
 # 2. Install git (used to tag commit in benchmark runner)

--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -10,7 +10,7 @@ ARG NODEJS_VERSION
 
 # 1. Install node
 RUN apt-get -qq update && apt-get -qq install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get -qq install -y nodejs
 
 # 2. Install git (used to tag commit in benchmark runner)

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -144,36 +144,15 @@ services:
       - STACK_VERSION=${STACK_VERSION}
       - APM_SERVER_URL=${APM_SERVER_URL}
       - KIBANA_URL=${KIBANA_URL}
-      - BUILD_NUMBER=${BUILD_NUMBER}
-      - BRANCH_NAME=${BRANCH_NAME}
-      - JENKINS_URL=${JENKINS_URL}
-      - SAUCE_USERNAME=${SAUCE_USERNAME}
-      - SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}
-      - MODE=${MODE}
-      - GOAL=${GOAL}
-      - WORKSPACE=${WORKSPACE}
-      - BASE_DIR=${BASE_DIR}
-    command: /run-test.sh
-    mem_limit: 2000m
-#    cpus: 0.5
-    depends_on:
-      fleet-server:
-        condition: service_healthy
-    volumes:
-      - ..:/app
-    networks:
-      apm:
-        aliases:
-          - node-puppeteer
-    user: ${USER_ID}
+
 
   node-benchmark:
     build:
       context: ../.ci/docker/node-playwright
       args:
-        - NODEJS_VERSION=${NODEJS_VERSION}
+        - NODEJS_VERSION=12
     container_name: node-playwright
-    image: docker.elastic.co/observability-ci/node-playwright:${NODEJS_VERSION}
+    image: docker.elastic.co/observability-ci/node-playwright:12
     environment:
       - HOME=/app
       - BUILD_NUMBER=${BUILD_NUMBER}

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -150,9 +150,9 @@ services:
     build:
       context: ../.ci/docker/node-playwright
       args:
-        - NODEJS_VERSION=12
+        - NODEJS_VERSION=${NODEJS_VERSION}
     container_name: node-playwright
-    image: docker.elastic.co/observability-ci/node-playwright:12
+    image: docker.elastic.co/observability-ci/node-playwright:${NODEJS_VERSION}
     environment:
       - HOME=/app
       - BUILD_NUMBER=${BUILD_NUMBER}

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -130,14 +130,20 @@ function prepareConfig(config, packageName) {
     config.plugins.push('karma-chrome-launcher')
 
     if (!isSauce) {
-      config.browsers = ['ChromeHeadlessNoSandbox']
+      config.browsers = ['HeadlessChromium']
       config.customLaunchers = {
-        ChromeHeadlessNoSandbox: {
-          base: 'ChromeHeadless',
+        HeadlessChromium: {
+          base: 'ChromiumHeadless',
           flags: [
             '--no-sandbox', // required to run without privileges in docker
+            '--remote-debugging-port=9222',
+            '--enable-logging',
             '--user-data-dir=/tmp/chrome-test-profile',
-            '--disable-web-security'
+            '--disable-web-security',
+            '--disable-background-timer-throttling',
+            '--disable-renderer-backgrounding',
+            '--proxy-bypass-list=*',
+            "--proxy-server='direct://'"
           ]
         }
       }

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -81,8 +81,11 @@ const baseConfig = {
   webpackMiddleware: {
     logLevel: 'error'
   },
+  logLevel: 'debug',
   autoWatch: false,
   browserNoActivityTimeout: 120000,
+  browserDisconnectTimeout: 120000,
+  browserDisconnectTolerance: 3,
   customLaunchers: [...getBrowserList(), ...getAppiumBrowsersForKarma()].map(
     launcher => ({
       ...launcher,
@@ -136,14 +139,8 @@ function prepareConfig(config, packageName) {
           base: 'ChromeHeadless',
           flags: [
             '--no-sandbox', // required to run without privileges in docker
-            '--remote-debugging-port=9222',
-            '--enable-logging',
             '--user-data-dir=/tmp/chrome-test-profile',
-            '--disable-web-security',
-            '--disable-background-timer-throttling',
-            '--disable-renderer-backgrounding',
-            '--proxy-bypass-list=*',
-            "--proxy-server='direct://'"
+            '--disable-web-security'
           ]
         }
       }

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -188,8 +188,11 @@ function prepareConfig(config, packageName) {
     config.transports = ['polling']
   }
 
-  console.log('prepareConfig ------', config)
-  return config.customLaunchers.flags
+  console.log(
+    'prepareConfig ------',
+    JSON.stringify(config.customLaunchers, null, 2)
+  )
+  return config
 }
 
 module.exports = {

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -130,10 +130,10 @@ function prepareConfig(config, packageName) {
     config.plugins.push('karma-chrome-launcher')
 
     if (!isSauce) {
-      config.browsers = ['HeadlessChromium']
+      config.browsers = ['ChromeHeadlessNoSandbox']
       config.customLaunchers = {
-        HeadlessChromium: {
-          base: 'ChromiumHeadless',
+        ChromeHeadlessNoSandbox: {
+          base: 'ChromeHeadless',
           flags: [
             '--no-sandbox', // required to run without privileges in docker
             '--remote-debugging-port=9222',

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -188,6 +188,7 @@ function prepareConfig(config, packageName) {
     config.transports = ['polling']
   }
 
+  console.log('prepareConfig ------', config)
   return config
 }
 

--- a/dev-utils/karma.js
+++ b/dev-utils/karma.js
@@ -189,7 +189,7 @@ function prepareConfig(config, packageName) {
   }
 
   console.log('prepareConfig ------', config)
-  return config
+  return config.customLaunchers.flags
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4954,12 +4954,6 @@
         }
       }
     },
-    "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true
-    },
     "@commitlint/cli": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-10.0.0.tgz",
@@ -14869,7 +14863,7 @@
     "cac": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/cac/-/cac-3.0.4.tgz",
-      "integrity": "sha512-hq4rxE3NT5PlaEiVV39Z45d6MoFcQZG5dsgJqtAUeOz3408LEQAElToDkf9i5IYSCOmK0If/81dLg7nKxqPR0w==",
+      "integrity": "sha1-bSTO7Dcu/lybeYgIvH9JtHJCpO8=",
       "dev": true,
       "requires": {
         "camelcase-keys": "^3.0.0",
@@ -14884,19 +14878,19 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "camelcase-keys": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-3.0.0.tgz",
-          "integrity": "sha512-U4E6A6aFyYnNW+tDt5/yIUKQURKXe3WMFPfX4FxrQFcwZ/R08AUk1xWcUtlr7oq6CV07Ji+aa69V2g7BSpblnQ==",
+          "integrity": "sha1-/AxsNgNj9zd+N5O5oWvM8QcMHKQ=",
           "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
@@ -14906,7 +14900,7 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -14919,13 +14913,13 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -15824,6 +15818,12 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "columnify": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
@@ -16014,7 +16014,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "parseurl": {
@@ -16942,7 +16942,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -17650,7 +17650,7 @@
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
     "dargs": {
@@ -18164,7 +18164,7 @@
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true
     },
     "diff": {
@@ -18257,7 +18257,7 @@
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
       "dev": true,
       "requires": {
         "custom-event": "~1.0.0",
@@ -18599,7 +18599,7 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
       "dev": true
     },
     "entities": {
@@ -21185,7 +21185,7 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -22761,7 +22761,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-what": {
@@ -23568,15 +23568,15 @@
       }
     },
     "karma": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.1.tgz",
-      "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.16.tgz",
+      "integrity": "sha512-nEU50jLvDe5yvXqkEJRf8IuvddUkOY2x5Xc4WXHz6dxINgGDrgD2uqQWeVrJs4hbfNaotn+HQ1LZJ4yOXrL7xQ==",
       "dev": true,
       "requires": {
-        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
+        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -23592,7 +23592,7 @@
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.4.1",
+        "socket.io": "^4.2.0",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
@@ -25628,7 +25628,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -25641,7 +25641,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -25766,7 +25766,7 @@
     "lodash.pickby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
       "dev": true
     },
     "lodash.template": {
@@ -28725,7 +28725,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
@@ -28915,7 +28915,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -28926,7 +28926,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -31750,7 +31750,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
@@ -31761,7 +31761,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
         "find-up": "^1.0.0",
@@ -31771,7 +31771,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
             "path-exists": "^2.0.0",
@@ -31781,7 +31781,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -34154,7 +34154,7 @@
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
@@ -34326,7 +34326,7 @@
     "suffix": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/suffix/-/suffix-0.1.1.tgz",
-      "integrity": "sha512-j5uf6MJtMCfC4vBe5LFktSe4bGyNTBk7I2Kdri0jeLrcv5B9pWfxVa5JQpoxgtR8vaVB7bVxsWgnfQbX5wkhAA==",
+      "integrity": "sha1-zFgjFkag7xEC95R47zqSSP2chC8=",
       "dev": true
     },
     "supports-color": {
@@ -35738,7 +35738,7 @@
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
     },
     "vue": {
@@ -37988,7 +37988,7 @@
     "yarn-install": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yarn-install/-/yarn-install-1.0.0.tgz",
-      "integrity": "sha512-VO1u181msinhPcGvQTVMnHVOae8zjX/NSksR17e6eXHRveDvHCF5mGjh9hkN8mzyfnCqcBe42LdTs7bScuTaeg==",
+      "integrity": "sha1-V/RQULgu/VcYKzlzxUqgXLXSUjA=",
       "dev": true,
       "requires": {
         "cac": "^3.0.3",
@@ -37999,13 +37999,13 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -38018,7 +38018,7 @@
         "cross-spawn": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -38028,7 +38028,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "html-webpack-plugin": "^5.3.1",
     "husky": "^3.1.0",
     "jasmine": "^3.5.0",
-    "karma": "^6.4.1",
+    "karma": "^6.3.16",
     "karma-benchmark": "^1.0.4",
     "karma-benchmark-json-reporter": "^1.0.1",
     "karma-benchmark-reporter": "^0.1.1",

--- a/packages/rum-core/karma.bench.conf.js
+++ b/packages/rum-core/karma.bench.conf.js
@@ -90,6 +90,7 @@ module.exports = function (config) {
       }
     }
   })
+  console.log('LOG: prepareConfig WEBPACK')
   const preparedConfig = prepareConfig(config)
   preparedConfig.preprocessors = {
     [specPattern]: ['webpack']

--- a/packages/rum/test/benchmarks/run.js
+++ b/packages/rum/test/benchmarks/run.js
@@ -48,6 +48,8 @@ process.on('unhandledRejection', reason => {
 
 !(async function run() {
   let exitCode = 0
+  console.log('run first step')
+
   try {
     /**
      * Generate custom apm build
@@ -64,6 +66,7 @@ process.on('unhandledRejection', reason => {
     const resultMap = new Map()
 
     for (let scenario of scenarios) {
+      console.log('run second step scenarios')
       for (let type of browserTypes) {
         const url = `http://localhost:${port}/${scenario}`
         /**


### PR DESCRIPTION
# Context

**Chrome 109** was causing Karma to crash when executing the benchmarks. The dependency that was installing such version is **google-chrome-unstable**. 

The only visible log in the CI was **"Cannot start ChromeHeadless"**, no more details related to the error were provided. 

# Applied action

To fix this situation we have replaced **google-chrome-unstable** with **google-chrome-stable**. Now, the version installed is 107, which works perfectly.