### PR TITLE
chore: use chrome stable to execute benchmarks

### DIFF
--- a/.ci/docker/node-playwright/Dockerfile
+++ b/.ci/docker/node-playwright/Dockerfile
@@ -99,13 +99,15 @@ RUN apt-get -qq install -y  --no-install-recommends \
     libxml2 \
     libxslt1.1
 
-# 4. Install Chrome unstable to run karma benchmark tests inside puppeteer
+# 4. Install Chrome stable to run karma benchmark tests inside puppeteer
+# before we were using the Chrome unstable, but with the unstable one the benchmarks were failing, karma launcher was crashing.
+# The error was "Cannot start ChromeHeadless", no more details were provided by the tool.
 RUN apt-get -qq install -y wget --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get -qq update  \
     && apt-get -qq install -y \
-        google-chrome-unstable \
+        google-chrome-stable \
         fonts-ipafont-gothic \
         fonts-wqy-zenhei \
         fonts-thai-tlwg \


### PR DESCRIPTION
## Context

Chrome 109 was causing Karma to crash when executing the benchmarks. The dependency that was installing such version is **google-chrome-unstable**.

The only visible log in the CI was **"Cannot start ChromeHeadless",** no useful details related to the error were provided.

<img width="1338" alt="Screenshot 2022-11-08 at 18 46 47" src="https://user-images.githubusercontent.com/15065076/200638068-f7e0114d-4fe5-4f27-9b77-95557d60b899.png">


## Applied action

To fix this situation we have replaced **google-chrome-unstable** with **google-chrome-stable**. Now, the version installed is **107**, which works perfectly.

## Thoughts

We are not exactly sure why Chrome **109** was failing, that version will be [released](https://chromiumdash.appspot.com/schedule) in 2023, so probably there are bugs that Chrome contributors need to fix. If the benchmarks start failing in **2023** for the same reason we will need to approach this issue in a different way. 
