### PR TITLE
docs: update framework integrations docs

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -117,13 +117,11 @@ The agent supports <<framework-integrations,integrations with certain frameworks
 To instrument custom metrics, like rendering time or mounting time of components on frameworks like React, Angular, Vue,
 etc., use the <<custom-transactions,custom transactions API>>.
 
-The core RUM agent supports websites based on multi-page (MPA) and single page (SPA) architectures, out of the box. This means that for SPAs to use <<framework-integrations,framework specific integrations>> is a recommendation rather than a requirement. We recommend them for the following reasons:
+The core RUM agent supports websites based on multi-page (MPA) and single-page architectures (SPA). The core RUM agent can be used on its own with SPA sites, but we recommend using our framework-specific integrations for the following reasons:
 
-* They group pages by routes better. This results in `transaction.name` mapped to the actual application route path the users have declared in their SPA application.
-* They exactly know when an SPA navigation is rendered, the core RUM agent does not know that and waits for the last network request before considering the SPA transition is finished. The integration packages on the other hand hook into the component lifecycle and measures the duration of the SPA transition correctly.
-* They improve error capturing. For instance, when an error is thrown inside an Angular application, the default error handler doesn’t rethrow them as browser events, which makes them invisible to the core RUM agent. The integration automatically captures those errors, too.
-
-To be clear, the core RUM agent can be used on its own with SPA sites, however also using the framework integration provides the additional capabilities shown.
+* *Pages are better grouped by routes*: This results in the `transaction.name` field mapping to the actual application route path declared in the SPA application.
+* *Exact SPA navigation rendering*: Integration packages hook into the component lifecycle and measure the duration of the SPA transaction correctly. The core RUM agent is unable to determine when an SPA navigation is rendered and instead waits for the last network request before considering the SPA transition is finished.
+* *Improved error capturing*: For example, when an error is thrown inside an Angular application, the framework integration will automatically capture it. The core RUM agent, however, is unable to capture the error as the default error handler doesn’t rethrow the error as a browser event.
 
 [float]
 [[platforms]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -117,12 +117,13 @@ The agent supports <<framework-integrations,integrations with certain frameworks
 To instrument custom metrics, like rendering time or mounting time of components on frameworks like React, Angular, Vue,
 etc., use the <<custom-transactions,custom transactions API>>.
 
-The core RUM agent supports MPAs and SPAs out of the box. This means that for SPAs to use <<framework-integrations,framework specific integrations>> is a recommendation rather than a requirement. We recommend them for the following reasons:
+The core RUM agent supports websites based on multi-page (MPA) and single page (SPA) architectures, out of the box. This means that for SPAs to use <<framework-integrations,framework specific integrations>> is a recommendation rather than a requirement. We recommend them for the following reasons:
 
 * They group pages by routes better. This results in `transaction.name` mapped to the actual application route path the users have declared in their SPA application.
-* They exactly know when a SPA navigation is rendered, the core RUM agent does not know that and waits for the last network request before considering the SPA transition is finished. The integration packages on the other hand hook into the component lifecycle and measures the duration of the SPA transition correctly.
+* They exactly know when an SPA navigation is rendered, the core RUM agent does not know that and waits for the last network request before considering the SPA transition is finished. The integration packages on the other hand hook into the component lifecycle and measures the duration of the SPA transition correctly.
 * They improve error capturing. For instance, when an error is thrown inside an Angular application, the default error handler doesn’t rethrow them as browser events, which makes them invisible to the core RUM agent. The integration automatically captures those errors, too.
 
+To be clear, the core RUM agent can be used on its own with SPA sites, however also using the framework integration provides the additional capabilities shown.
 
 [float]
 [[platforms]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -117,6 +117,12 @@ The agent supports <<framework-integrations,integrations with certain frameworks
 To instrument custom metrics, like rendering time or mounting time of components on frameworks like React, Angular, Vue,
 etc., use the <<custom-transactions,custom transactions API>>.
 
+The core RUM agent supports MPAs and SPAs out of the box. This means that for SPAs to use <<framework-integrations,framework specific integrations>> is a recommendation rather than a requirement. We recommend them for the following reasons:
+
+* They group pages by routes better. This results in `transaction.name` mapped to the actual application route path the users have declared in their SPA application.
+* They exactly know when a SPA navigation is rendered, the core RUM agent does not know that and waits for the last network request before considering the SPA transition is finished. The integration packages on the other hand hook into the component lifecycle and measures the duration of the SPA transition correctly.
+* They improve error capturing. For instance, when an error is thrown inside an Angular application, the default error handler doesn’t rethrow them as browser events, which makes them invisible to the core RUM agent. The integration automatically captures those errors, too.
+
 
 [float]
 [[platforms]]


### PR DESCRIPTION
# Summary

The goal of this documentation update is to highlight two things:

- RUM framework specific integration is a recommendation and not a requirement
- Enumerate the reasons why we recommend framework specific integration (Vue, React, Angular)

@vigneshshanmugam as we discussed a few days ago, the changes are added to the [frameworks](https://www.elastic.co/guide/en/apm/agent/rum-js/current/supported-technologies.html#frameworks) section of the [supported technologies page](https://www.elastic.co/guide/en/apm/agent/rum-js/current/supported-technologies.html)

Screenshot of the preview (edit: includes Paul's suggestions):
<img width="1035" alt="Screenshot 2023-04-05 at 14 51 18" src="https://user-images.githubusercontent.com/15065076/230086363-a9327456-9786-4d9f-9bc1-41e6b9e3964d.png">




