### PR TITLE
fix(rum-core): add URL object support in fetch instrumentation

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -74,9 +74,9 @@ export function patchFetch(callback) {
     var fetchSelf = this
     var args = arguments
     var request, url
-    if (typeof input === 'string') {
+    if (typeof input === 'string' || input instanceof URL) {
       request = new Request(input, init)
-      url = input
+      url = request.url
     } else if (input) {
       request = input
       url = request.url

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -77,6 +77,20 @@ describe('fetchPatch', function () {
         })
       })
 
+      it('should fetch correctly with a URL Object as input', function (done) {
+        var promise = window.fetch(new URL(window.location.origin))
+        expect(promise).toBeDefined()
+        expect(typeof promise.then).toBe('function')
+        expect(events.map(e => e.event)).toEqual(['schedule'])
+        promise.then(function (resp) {
+          expect(resp).toBeDefined()
+          Promise.resolve().then(function () {
+            expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
+            done()
+          })
+        })
+      })
+
       it('should produce task events when fetch fails', function (done) {
         var promise = window.fetch('http://localhost:54321/')
         promise.catch(function (error) {

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -78,7 +78,7 @@ describe('fetchPatch', function () {
       })
 
       it('should fetch correctly with a URL Object as input', function (done) {
-        var promise = window.fetch(new URL(window.location.origin))
+        var promise = window.fetch(new URL(new Request('/').url))
         expect(promise).toBeDefined()
         expect(typeof promise.then).toBe('function')
         expect(events.map(e => e.event)).toEqual(['schedule'])


### PR DESCRIPTION
Passing in a `URL` to `fetch` is not handled properly in the patch causing requests to be sent without options, this includes options like `method` and `headers` etc

Fixes Next.js app router full page refresh 