### PR TITLE
ci: initial ci release to gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: release
 
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   release-npm:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to wrtie the release changelog
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,18 +29,22 @@ jobs:
       - name: Read NPM vault secrets
         uses: hashicorp/vault-action@v2.5.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
           method: approle
+          url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/jenkins-ci/npmjs/elasticmachine token | NPMJS_TOKEN ;
             totp/code/npmjs-elasticmachine code | TOTP_CODE
 
+      - uses: elastic/apm-pipeline-library/.github/actions/setup-npmrc@current
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          secret: secret/jenkins-ci/npmjs/elasticmachine
+          secret-key: token
+
       - name: Publish the release
-        permissions:
-          # Needed to wrtie the release changelog
-          contents: write
         run: npm run release-ci
 
   release-cdn:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+permissions:
+  contents: read
+
+jobs:
+  release-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read NPM vault secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/jenkins-ci/npmjs/elasticmachine token | NPMJS_TOKEN ;
+            totp/code/npmjs-elasticmachine code | TOTP_CODE
+
+      - name: Publish the release
+        permissions:
+          # Needed to wrtie the release changelog
+          contents: write
+        run: npm run release-ci
+
+  release-cdn:
+    runs-on: ubuntu-latest
+    env:
+      BUCKET_NAME: 'apm-rum-357700bc'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run build
+
+      - uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: approle
+          secrets: |
+            secret/gce/elastic-cdn/service-account/apm-rum-admin value | GOOGLE_CREDENTIALS ;
+
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ env.GOOGLE_CREDENTIALS }}'
+          create_credentials_file: true
+
+      - id: prepare-release
+        name: 'Prepare CDN release'
+        run: echo "versions=$(npm run --silent ci:prepare-release)" >> ${GITHUB_OUTPUT}
+
+      - id: 'upload-files-version'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          parent: false
+          path: 'packages/rum/dist/bundles/'
+          destination: '${{ env.BUCKET_NAME }}/${{ fromJSON(steps.prepare-release.outputs.versions).version }}'
+          glob: '*.js'
+          process_gcloudignore: false
+
+      - id: 'upload-files-major-version'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          parent: false
+          path: 'packages/rum/dist/bundles/'
+          destination: '${{ env.BUCKET_NAME }}/${{ fromJSON(steps.prepare-release.outputs.versions).major_version }}'
+          glob: '*.js'
+          process_gcloudignore: false
+
+      - id: 'upload-file-index'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          parent: false
+          path: 'index.html'
+          destination: '${{ env.BUCKET_NAME }}'
+          process_gcloudignore: false
+
+  status:
+    if: always()
+    needs:
+      - release-npm
+      - release-cdn
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          status: ${{ steps.check.outputs.status }}
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-agent-js"
+          message: "Build result for release publication"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,14 +42,8 @@ Before releasing, be sure to update the following documentation:
 
 The release process is also automated in the way any specific commit from the main branch can be potentially released, for such it's required the below steps:
 
-1. Login to apm-ci.elastic.co
-1. Go to the [main](https://apm-ci.elastic.co/job/apm-agent-rum/job/apm-agent-rum-mbp/job/main/) pipeline.
-1. Click on `Build with parameters` with the below checkbox:
-  * `release` to be selected.
-  * other checkboxes should be left as default.
-1. Click on `Build`.
-1. Wait for an email to confirm the release is ready to be approved, it might take roughly 30 minutes.
-1. Confirm if the list of changes are the ones that are expected.
-1. Click on the URL from the email.
-1. Click on approve or abort.
-1. Then you can go to the `https://www.npmjs.com/package/@elastic/apm-rum` and [GitHub releases](https://github.com/elastic/apm-agent-rum-js/releases) to validate that the bundles and release notes have been published.
+* Go to the [GitHub Actions](https://github.com/elastic/apm-agent-rum-js/actions/workflows/release.yml) workflow.
+* Click on `Run workflow` and select the `main` branch.
+* Click on `Run workflow`.
+* Wait for completion.
+* You can go to the `https://www.npmjs.com/package/@elastic/apm-rum` and [GitHub releases](https://github.com/elastic/apm-agent-rum-js/releases) to validate that the bundles and release notes have been published.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "bench:dev": "lerna run build:module && node ./scripts/benchmarks.js",
     "package:snapshot": "npx lerna exec npm pack",
     "clean": "npx lerna exec -- rm -rf dist/",
-    "release-ci": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
+    "ci:prepare-release": "node ./scripts/ci-prepare-release.js",
+    "ci:release": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
   },
   "lint-staged": {
     "*.{js,jsx,ts}": [

--- a/scripts/ci-prepare-release.js
+++ b/scripts/ci-prepare-release.js
@@ -1,0 +1,64 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017-present, Elasticsearch BV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const { version } = require('../packages/rum/package.json')
+const fs = require('fs').promises
+const path = require('node:path')
+const process = require('node:process')
+
+// Script logic
+async function main() {
+  // Extract major version
+  const majorVersion = `${version.split('.')[0]}.x`
+
+  // Generate index file
+  const indexTemplate = await fs.readFile(
+    path.join(process.cwd(), '.ci/scripts/index.html.template'),
+    'utf8'
+  )
+  const indexContent = indexTemplate.replace(/VERSION/g, majorVersion)
+  await fs.writeFile(
+    path.join(process.cwd(), 'index.html'),
+    indexContent,
+    'utf8'
+  )
+
+  // Print versions
+  console.log(
+    JSON.stringify({
+      version,
+      major_version: majorVersion
+    })
+  )
+}
+
+// Entrypoint
+;(async () => {
+  try {
+    await main()
+  } catch (err) {
+    console.log(err)
+  }
+})()


### PR DESCRIPTION
## What is the change being made?

* Migrate release pipeline from Jenkins to GitHub Actions

## Why is the change being made?

* Jenkins is deprecated

## How has this been tested?

* It has been tested with another Google Cloud Account
* https://github.com/elastic/apm-agent-rum-js/actions/runs/5203874294
