### PR TITLE
Fix status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,7 @@ jobs:
           scope: ${{ matrix.scope }}
           stack-version: ${{ matrix.stack-version }}
 
-  all-tests-puppeteer:
-    name: All Tests Puppeteer
+  all:
     if: always()
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,24 @@ jobs:
       - run: '.ci/scripts/lint.sh'
       - run: 'npm run ci:bundlesize'
         id: bundlesize
-      - uses: actions/github-script@v6
-        env:
-          BUNDLESIZE_PASS: ${{ steps.bundlesize.outputs.bundlesize_pass }}
-          BUNDLESIZE_FAIL: ${{ steps.bundlesize.outputs.bundlesize_fail }}
-        with:
-          script: |
-            const { BUNDLESIZE_PASS, BUNDLESIZE_FAIL } = process.env;
-            let state = 'success';
-            if (BUNDLESIZE_FAIL > 0) {
-              state = 'failure';
-            }
-            github.rest.repos.createCommitStatus({
-              ...context.repo,
-              sha: context.sha,
-              state: state,
-              context: `${context.workflow} / Bundlesize: ${BUNDLESIZE_PASS} pass / ${BUNDLESIZE_FAIL} fail`,
-            });
+# TODO: This fails on forked PRs
+#      - uses: actions/github-script@v6
+#        env:
+#          BUNDLESIZE_PASS: ${{ steps.bundlesize.outputs.bundlesize_pass }}
+#          BUNDLESIZE_FAIL: ${{ steps.bundlesize.outputs.bundlesize_fail }}
+#        with:
+#          script: |
+#            const { BUNDLESIZE_PASS, BUNDLESIZE_FAIL } = process.env;
+#            let state = 'success';
+#            if (BUNDLESIZE_FAIL > 0) {
+#              state = 'failure';
+#            }
+#            github.rest.repos.createCommitStatus({
+#              ...context.repo,
+#              sha: context.sha,
+#              state: state,
+#              context: `${context.workflow} / Bundlesize: ${BUNDLESIZE_PASS} pass / ${BUNDLESIZE_FAIL} fail`,
+#            });
 
   test-puppeteer:
     name: Test Puppeteer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - lint
       - test-puppeteer
     steps:
       - id: check


### PR DESCRIPTION
## Details

Only docs PR cannot be merged because the `Lint` status check is not created. 
However, the `all` status check is created because of the `ci-docs.yml` workflow.

Reference: https://github.com/elastic/apm-agent-rum-js/pull/1375#issuecomment-1589924749

This PR create a single status check named `all` in both only-docs and code changes which can then be set as required.

## To Do

Adjust branch protection rules shortly before merging:
- Add `all` as required status check
- Remove `Lint` as required status check
