### PR TITLE
ci: initial microbenchmark migration to GitHub Actions

### DIFF
--- a/.ci/bump-elastic-stack.yml
+++ b/.ci/bump-elastic-stack.yml
@@ -58,3 +58,14 @@ targets:
       content: >-
         '{{ source `latestRelease` }}'
       matchpattern: \'[0-9]+\.[0-9]+\.[0-9]+\'
+
+  update-microbenchmark-workflow:
+    name: 'Update elastic stack version to {{ source "latestRelease" }}'
+    sourceid: latestRelease
+    scmid: default
+    kind: file
+    spec:
+      file: .github/workflows/microbenchmark.yml
+      content: >-
+        '{{ source `latestRelease` }}'
+      matchpattern: \'[0-9]+\.[0-9]+\.[0-9]+\'

--- a/.ci/scripts/bench.sh
+++ b/.ci/scripts/bench.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Bash strict mode
+set -eo pipefail
+
+# Found current script directory
+RELATIVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Found project directory
+BASE_PROJECT="$(dirname "$(dirname "${RELATIVE_DIR}")")"
+
+## Buildkite specific configuration
+if [ "${CI}" == "true" ] ; then
+  # If HOME is not set then use the Buildkite workspace
+  # that's normally happening when running in the CI
+  # owned by Elastic.
+  if [ -z "${HOME}" ] ; then
+    export HOME="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    export HOME
+  fi
+
+  # required when running the benchmark
+  PATH="${PATH}:${HOME}/.local/bin"
+  export PATH
+
+  echo 'Docker login is done in the Buildkite hooks'
+fi
+
+# Validate env vars
+[ -z "${ES_USER_SECRET}" ] && echo "Environment variable 'ES_USER_SECRET' must be defined" && exit 1;
+[ -z "${ES_PASS_SECRET}" ] && echo "Environment variable 'ES_PASS_SECRET' must be defined" && exit 1;
+[ -z "${ES_URL_SECRET}" ] && echo "Environment variable 'ES_URL_SECRET' must be defined" && exit 1;
+[ -z "${STACK_VERSION}" ] && echo "Environment variable 'STACK_VERSION' must be defined" && exit 1;
+
+# Debug env vars
+echo "Will run microbenchmarks on STACK_VERSION=${STACK_VERSION}"
+
+# It does not fail so it runs for benchmark, load testing and then we report the error at the end.
+set +e
+status=0
+
+# Run the benchmarks
+REPORT_FILE="apm-agent-benchmark-results.json" "${BASE_PROJECT}/.ci/scripts/benchmarks.sh"
+
+# Gather error if any
+if [ $? -gt 0 ] ; then
+  status=1
+fi
+
+# Then we ship the data using the helper
+sendBenchmark "${ES_USER_SECRET}" "${ES_PASS_SECRET}" "${ES_URL_SECRET}" "${BASE_PROJECT}/apm-agent-benchmark-results.json"
+
+# Run the load testing
+REPORT_FILE="apm-agent-load-testing-results.json" "${BASE_PROJECT}/.ci/scripts/load-testing.sh" "${STACK_VERSION}"
+
+# Gather error if any
+if [ $? -gt 0 ] ; then
+  status=1
+fi
+
+# Then we ship the data using the helper
+sendBenchmark "${ES_USER_SECRET}" "${ES_PASS_SECRET}" "${ES_URL_SECRET}" "${BASE_PROJECT}/apm-agent-load-testing-results.json"
+
+# Report status
+exit $status

--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -1,0 +1,56 @@
+name: microbenchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack_version:
+        description: 'Stack Version'
+        default: '8.6.1'
+        required: false
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  microbenchmark:
+    runs-on: ubuntu-latest
+    # wait up to 1 hour
+    timeout-minutes: 60
+    steps:
+      - id: buildkite
+        name: Run buildkite pipeline
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        env:
+          STACK_VERSION: ${{ inputs.stack_version || '8.6.1' }}
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: apm-agent-microbenchmark
+          triggerMessage: "${{ github.repository }}@${{ github.ref_name }}"
+          waitFor: true
+          printBuildLogs: true
+          buildEnvVars: |
+            script=.ci/scripts/bench.sh
+            repo=apm-agent-rum-js
+            sha=${{ github.sha }}
+            STACK_VERSION=${{ env.STACK_VERSION }}
+            BRANCH_NAME=${{ github.ref_name }}
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-js"
+          message: |
+            :ghost: [${{ github.repository }}] microbenchmark *${{ github.ref_name }}* failed to run in Buildkite.
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -7,6 +7,7 @@ on:
       - bump-elastic-stack
       - ci
       - ci-saucelabs
+      - microbenchmark
     types: [completed]
 
 jobs:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,18 +7,9 @@ pipeline {
   environment {
     REPO = 'apm-agent-rum-js'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
-    NOTIFY_TO = credentials('notify-to')
-    JOB_GCS_BUCKET = credentials('gcs-bucket')
     PIPELINE_LOG_LEVEL = 'INFO'
-    CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-rum-codecov'
-    SAUCELABS_SECRET = 'secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum'
-    DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     OPBEANS_REPO = 'opbeans-frontend'
-    NPMRC_SECRET = 'secret/jenkins-ci/npmjs/elasticmachine'
-    TOTP_SECRET = 'totp/code/npmjs-elasticmachine'
     PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-    MODE = "none"
-    STACK_VERSION = "${params.stack_version}"
   }
   options {
     //timeout(time: 3, unit: 'HOURS')
@@ -30,142 +21,10 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
     quietPeriod(10)
   }
-  triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run benchmark tests)")
-  }
-  parameters {
-    booleanParam(name: 'Run_As_Main_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on main branch.')
-    booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
-    booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from main.')
-    string(name: 'stack_version', defaultValue: "8.6.1", description: "What's the Stack Version to be used for the load testing?")
-  }
   stages {
     stage('Initializing'){
       options { skipDefaultCheckout() }
       stages {
-        /**
-        Checkout the code and stash it, to use it on other stages.
-        */
-        stage('Checkout') {
-          steps {
-            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-            deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
-            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              dir("${BASE_DIR}"){
-                // Look for changes related to the benchmark, if so then set the env variable.
-                def patternList =[
-                  '^packages/.*/test/benchmarks/.*',
-                  '^scripts/benchmarks.js',
-                  '^packages/rum-core/karma.bench.conf.js'
-                ]
-                env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: patternList)
-
-                // Skip all the stages except docs for PR's with asciidoc/md changes only
-                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
-              }
-            }
-
-            whenTrue(params.release) {
-              setEnvVar('PRE_RELEASE_STAGE', 'true')
-              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release build just started",
-                           body: "Please go to (<${env.BUILD_URL}|here>) to see the build status or wait for further notifications.")
-            }
-          }
-        }
-        /**
-        Run Benchmarks and send the results to ES.
-        */
-        stage('Benchmarks') {
-          when {
-            beforeAgent true
-            allOf {
-              anyOf {
-                branch 'main'
-                expression { return params.Run_As_Main_Branch }
-                expression { return env.BENCHMARK_UPDATED != "false" }
-                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
-              }
-              expression { return params.bench_ci }
-              expression { return env.ONLY_DOCS == "false" }
-              // Releases from main should skip this particular stage.
-              not {
-                allOf {
-                  branch 'main'
-                  expression { return params.release }
-                }
-              }
-            }
-          }
-          parallel {
-            stage('Benchmarks') {
-              agent { label 'microbenchmarks-pool' }
-              environment {
-                REPORT_FILE = 'apm-agent-benchmark-results.json'
-              }
-              steps {
-                withGithubNotify(context: 'Benchmarks') {
-                  deleteDir()
-                  unstash 'source'
-                  unstash 'cache'
-                  dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: 'docker.elastic.co')
-                  dir("${BASE_DIR}") {
-                    sh './.ci/scripts/benchmarks.sh'
-                  }
-                }
-              }
-              post {
-                always {
-                  archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-                    log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
-                    whenTrue(env.CHANGE_ID == null){
-                      sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-rum-js')
-                    }
-                  }
-                  catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-                    deleteDir()
-                  }
-                }
-              }
-            }
-            stage('Load testing') {
-              agent { label 'microbenchmarks-pool' }
-              options {
-                warnError('load testing failed')
-              }
-              environment {
-                REPORT_FILE = 'apm-agent-load-testing-results.json'
-              }
-              steps {
-                withGithubNotify(context: 'Load testing') {
-                  deleteDir()
-                  unstash 'source'
-                  unstash 'cache'
-                  dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: 'docker.elastic.co')
-                  dir("${BASE_DIR}") {
-                    sh ".ci/scripts/load-testing.sh ${env.STACK_VERSION}"
-                  }
-                }
-              }
-              post {
-                always {
-                  archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${env.REPORT_FILE}", onlyIfSuccessful: false)
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-                    log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
-                    whenTrue(env.CHANGE_ID == null){
-                      sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmarks-rum-load-test')
-                    }
-                  }
-                  catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-                    deleteDir()
-                  }
-                }
-              }
-            }
-          }
-        }
         stage('Opbeans') {
           options { skipDefaultCheckout() }
           when {
@@ -177,7 +36,7 @@ pipeline {
           }
           steps {
             deleteDir()
-            dir("${OPBEANS_REPO}"){
+            dir("${OPBEANS_REPO}") {
               git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git",
                   branch: 'main')
@@ -192,20 +51,4 @@ pipeline {
       }
     }
   }
-  post {
-    failure {
-      whenTrue(params.release && env.PRE_RELEASE_STAGE == 'true') {
-        notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Pre-release steps failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
-      }
-    }
-  }
-}
-
-def notifyStatus(def args = [:]) {
-  releaseNotification(slackChannel: '#apm-agent-js',
-                      slackColor: args.slackStatus,
-                      slackCredentialsId: 'jenkins-slack-integration-token',
-                      to: "${env.NOTIFY_TO}",
-                      subject: args.subject,
-                      body: args.body)
 }

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - "xpack.security.authc.api_key.enabled=true"
       - "logger.org.elasticsearch=${ES_LOG_LEVEL:-error}"
       - "action.destructive_requires_name=false"
-      - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION}"
     ulimits:
       memlock:
         soft: -1

--- a/dev-utils/kibana/kibana.yml
+++ b/dev-utils/kibana/kibana.yml
@@ -72,8 +72,11 @@ xpack.fleet.agentPolicies:
                       value: http://fleet-server:8200
                       frozen: true
                     - name: rum_allow_headers
-                      value: 
+                      value:
                         - x-custom-header
+                      frozen: true
+                    - name: expvar_enabled
+                      value: true
                       frozen: true
           - name: Fleet Server
             package:

--- a/scripts/apm-server-load-test.js
+++ b/scripts/apm-server-load-test.js
@@ -245,7 +245,7 @@ async function postPayload(url, payload) {
       },
       body: data.join('')
     })
-    return response.text()
+    return response.statusText
   } catch (error) {
     return error
   }
@@ -345,12 +345,17 @@ const iterations = 10
   }
 
   if (outputFile) {
-    const outputPath = join(__dirname, '../', outputFile)
-    let ndJSONOutput =
-      '{"index": { "_index": "benchmarks-rum-load-test" }}' + '\n'
-    ndJSONOutput += JSON.stringify(results)
-    await writeFile(outputPath, ndJSONOutput)
+    let ndJSONOutput = ''
+    for (const result of results) {
+      ndJSONOutput += ndJsonStringify({
+        index: {
+          _index: 'benchmarks-rum-load-test'
+        }
+      })
+      ndJSONOutput += ndJsonStringify(result)
+    }
+    await writeFile(join(__dirname, '../', outputFile), ndJSONOutput)
   } else {
-    console.log(result)
+    console.log(results)
   }
 })()

--- a/scripts/benchmarks.js
+++ b/scripts/benchmarks.js
@@ -156,6 +156,7 @@ function runBenchmarks() {
        */
       let ndJSONOutput = '{"index": { "_index": "benchmarks-rum-js" }}' + '\n'
       ndJSONOutput += JSON.stringify(output)
+      ndJSONOutput += '\n'
 
       const outputPath = join(PKG_DIR, outputFile)
       await pWriteFile(outputPath, ndJSONOutput)


### PR DESCRIPTION
## What is the change being made?

* Migrate microbenchmarking from Jenkins to GitHub Actions and Buildkite.
* Correct broken load testing and benchmarking reporting.
* Add automation to bump stack version in the microbenchmark workflow.
* Cleanup `Jenkinsfile` before last migration step.

## Why is the change being made?

* Jenkins is deprecated.
* The microbenchmark reporting is broken.

## How has this been tested?

* https://github.com/elastic/apm-agent-rum-js/actions/runs/5393533277/jobs/9793402071