### PR TITLE
fix(rum): report breakdown span time in microseconds

### DIFF
--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -142,7 +142,7 @@ function getSpanBreakdown(
     span: details,
     samples: {
       'span.self_time.count': getValue(count),
-      'span.self_time.sum.us': getValue(duration)
+      'span.self_time.sum.us': getValue(duration * 1000)
     }
   }
 }

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -357,7 +357,7 @@ describe('ApmServer', function () {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980000}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10000}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()
@@ -389,8 +389,8 @@ describe('ApmServer', function () {
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true,"sample_rate":0.1}}\n',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10,"sample_rate":0.1}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
-      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980}}}}\n',
-      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type","subtype":"subtype"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}\n'
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980000}}}}\n',
+      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type","subtype":"subtype"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10000}}}}\n'
     ].join('')
     expect(result).toEqual([expected])
   })

--- a/packages/rum-core/test/performance-monitoring/breakdown.spec.js
+++ b/packages/rum-core/test/performance-monitoring/breakdown.spec.js
@@ -120,7 +120,7 @@ describe('Breakdown metrics', () => {
         value: 1
       },
       'span.self_time.sum.us': {
-        value: 20
+        value: 20000
       }
     })
   })
@@ -140,12 +140,12 @@ describe('Breakdown metrics', () => {
 
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 20 }
+      'span.self_time.sum.us': { value: 20000 }
     })
 
     expect(breakdown['bar.baz']).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 20 }
+      'span.self_time.sum.us': { value: 20000 }
     })
   })
 
@@ -164,7 +164,7 @@ describe('Breakdown metrics', () => {
 
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
   })
 
@@ -183,11 +183,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 40 }
+      'span.self_time.sum.us': { value: 40000 }
     })
   })
 
@@ -206,11 +206,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 15 }
+      'span.self_time.sum.us': { value: 15000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 20 }
+      'span.self_time.sum.us': { value: 20000 }
     })
   })
 
@@ -232,11 +232,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 10 }
+      'span.self_time.sum.us': { value: 10000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 3 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
   })
 
@@ -260,7 +260,7 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
   })
 
@@ -279,15 +279,15 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 10 }
+      'span.self_time.sum.us': { value: 10000 }
     })
     expect(breakdown['foo']).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 15 }
+      'span.self_time.sum.us': { value: 15000 }
     })
     expect(breakdown['bar']).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 10 }
+      'span.self_time.sum.us': { value: 10000 }
     })
   })
 
@@ -304,11 +304,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 20 }
+      'span.self_time.sum.us': { value: 20000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 10 }
+      'span.self_time.sum.us': { value: 10000 }
     })
   })
 
@@ -327,11 +327,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 10 }
+      'span.self_time.sum.us': { value: 10000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 25 }
+      'span.self_time.sum.us': { value: 25000 }
     })
   })
 
@@ -350,11 +350,11 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
     expect(breakdown['ext.http']).toEqual({
       'span.self_time.count': { value: 2 },
-      'span.self_time.sum.us': { value: 25 }
+      'span.self_time.sum.us': { value: 25000 }
     })
   })
 
@@ -372,7 +372,7 @@ describe('Breakdown metrics', () => {
     })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
-      'span.self_time.sum.us': { value: 30 }
+      'span.self_time.sum.us': { value: 30000 }
     })
 
     expect(breakdown['ext.http']).toBeUndefined()

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -666,7 +666,7 @@ describe('TransactionService', function () {
         span: { type: 'ext', subtype: 'http' },
         samples: {
           'span.self_time.count': { value: 2 },
-          'span.self_time.sum.us': { value: 40 }
+          'span.self_time.sum.us': { value: 40000 }
         }
       })
       done()


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-rum-js/issues/1360

# Summary

From now on, the breakdown metric `span.self_time.sum.us` will be calculated in microseconds.

By the way, although this is not a 100% sure breaking change - we don't know what users might do with the ingested data), it can be a "potentially breaking change", so we should indicate it.

For instance, I like how the Java APM agent team expresses that concept in their release notes:

<img width="355" alt="Screenshot 2023-07-04 at 19 03 02" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/7a3dd6d4-8494-42e3-b426-5a05f68c3379">

Example [here](https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#_potentially_breaking_changes)



**Important:** 

You will see that I've not updated the calculation for `transaction.duration.sum.us`. The reason is that almost two years ago, [APM server stopped recording that value](https://github.com/elastic/apm-server/pull/6180). In fact, everything related to transaction breakdown metrics [was removed from all APM agents.](https://github.com/elastic/apm/issues/505)

I believe that for us is a good time to do so since we are solving this bug.

I will do that in a different PR, so we can mention that separately in the release notes and also reference to reference it [here](https://github.com/elastic/apm/issues/505)

Edit: The related PR: https://github.com/elastic/apm-agent-rum-js/pull/1382
