### PR TITLE
fix(rum): stop recording transaction breakdown metrics

### DIFF
--- a/packages/rum-core/src/common/compress.js
+++ b/packages/rum-core/src/common/compress.js
@@ -290,30 +290,14 @@ export function compressError(error) {
 
 export function compressMetricsets(breakdowns) {
   return breakdowns.map(({ span, samples }) => {
-    const isSpan = span != null
-    if (isSpan) {
-      return {
-        y: { t: span.type },
-        sa: {
-          ysc: {
-            v: samples['span.self_time.count'].value
-          },
-          yss: {
-            v: samples['span.self_time.sum.us'].value
-          }
-        }
-      }
-    }
     return {
+      y: { t: span.type },
       sa: {
-        xdc: {
-          v: samples['transaction.duration.count'].value
+        ysc: {
+          v: samples['span.self_time.count'].value
         },
-        xds: {
-          v: samples['transaction.duration.sum.us'].value
-        },
-        xbc: {
-          v: samples['transaction.breakdown.count'].value
+        yss: {
+          v: samples['span.self_time.sum.us'].value
         }
       }
     }

--- a/packages/rum-core/src/performance-monitoring/breakdown.js
+++ b/packages/rum-core/src/performance-monitoring/breakdown.js
@@ -153,18 +153,8 @@ function getSpanBreakdown(
  */
 export function captureBreakdown(transaction, timings = PERF.timing) {
   const breakdowns = []
-  const trDuration = transaction.duration()
   const { name, type, sampled } = transaction
   const transactionDetails = { name, type }
-
-  breakdowns.push({
-    transaction: transactionDetails,
-    samples: {
-      'transaction.duration.count': getValue(1),
-      'transaction.duration.sum.us': getValue(trDuration),
-      'transaction.breakdown.count': getValue(sampled ? 1 : 0)
-    }
-  })
 
   /**
    * Capture breakdown metrics only for sampled transactions

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -357,7 +357,7 @@ describe('ApmServer', function () {
     const expected = [
       '{"m":{"se":{"n":"test","a":{"n":"rum-js","ve":"N/A"},"la":{"n":"javascript"}}}}',
       '{"e":{"id":"error-id-0","cl":"(inline script)","ex":{"mg":"error #0","st":[]},"c":null}}',
-      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"sa":{"xdc":{"v":1},"xds":{"v":990},"xbc":{"v":1}}},{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980000}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10000}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
+      '{"x":{"id":"transaction-id-0","tid":"trace-id-0","n":"transaction #0","t":"transaction","d":990,"c":null,"k":null,"me":[{"y":{"t":"app"},"sa":{"ysc":{"v":1},"yss":{"v":980000}}},{"y":{"t":"type"},"sa":{"ysc":{"v":1},"yss":{"v":10000}}}],"y":[{"id":"span-id-0-1","n":"name","t":"type","s":10,"d":10,"c":null,"sr":0.1,"su":"subtype"}],"yc":{"sd":1},"sm":true,"sr":0.1}}'
     ]
     expect(payload.split('\n').filter(a => a)).toEqual(expected)
     clock.uninstall()
@@ -388,7 +388,6 @@ describe('ApmServer', function () {
     const expected = [
       '{"transaction":{"id":"transaction-id-0","trace_id":"trace-id-0","name":"transaction #0","type":"transaction","duration":990,"span_count":{"started":1},"sampled":true,"sample_rate":0.1}}\n',
       '{"span":{"id":"span-id-0-1","transaction_id":"transaction-id-0","parent_id":"transaction-id-0","trace_id":"trace-id-0","name":"name","type":"type","subtype":"subtype","sync":false,"start":10,"duration":10,"sample_rate":0.1}}\n',
-      '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":990},"transaction.breakdown.count":{"value":1}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":980000}}}}\n',
       '{"metricset":{"transaction":{"name":"transaction #0","type":"transaction"},"span":{"type":"type","subtype":"subtype"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10000}}}}\n'
     ].join('')

--- a/packages/rum-core/test/performance-monitoring/breakdown.spec.js
+++ b/packages/rum-core/test/performance-monitoring/breakdown.spec.js
@@ -42,20 +42,18 @@ describe('Breakdown metrics', () => {
    */
   function getBreakdownObj(breakdowns) {
     let spanBreakdown = {}
-    if (breakdowns.length > 2) {
-      for (let i = 2; i < breakdowns.length; i++) {
-        const { span, samples } = breakdowns[i]
-        let key = span.type
-        if (typeof span.subtype !== 'undefined') {
-          key += '.' + span.subtype
-        }
-        spanBreakdown[key] = samples
+    for (let i = 0; i < breakdowns.length; i++) {
+      const { span, samples } = breakdowns[i]
+      let key = span.type
+      if (typeof span.subtype !== 'undefined') {
+        key += '.' + span.subtype
       }
+      spanBreakdown[key] = samples
     }
+
     return {
       details: breakdowns[0].transaction,
-      transaction: breakdowns[0].samples,
-      app: breakdowns[1].samples,
+      app: breakdowns[0].samples,
       ...spanBreakdown
     }
   }
@@ -73,55 +71,13 @@ describe('Breakdown metrics', () => {
       'Load'
     ]
 
-    const spans = breakdown.slice(1)
-
     spanTypes.forEach((type, index) => {
-      const breakdownSpan = spans[index]
+      const breakdownSpan = breakdown[index]
       expect(breakdownSpan.span.type).toBe(type)
       expect(breakdownSpan.samples['span.self_time.count'].value).toBe(1)
       expect(
         breakdownSpan.samples['span.self_time.sum.us'].value
       ).toBeGreaterThan(0)
-    })
-  })
-
-  it('set transaction breakdown count based on sampled flag', () => {
-    const tr = createTransaction('sampled')
-    const sampledBreakdown = captureBreakdown(tr)
-    expect(sampledBreakdown[0].samples['transaction.breakdown.count']).toEqual({
-      value: 1
-    })
-
-    tr.sampled = false
-    const unsampledBreakdown = captureBreakdown(tr)
-    expect(
-      unsampledBreakdown[0].samples['transaction.breakdown.count']
-    ).toEqual({
-      value: 0
-    })
-  })
-
-  it('breakdown with only transaction', () => {
-    const tr = createTransaction('custom')
-    tr.end(20)
-    const breakdown = getBreakdownObj(captureBreakdown(tr))
-
-    expect(breakdown.details).toEqual({
-      name: 'trname',
-      type: 'custom'
-    })
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 20 },
-      'transaction.breakdown.count': { value: 1 }
-    })
-    expect(breakdown.app).toEqual({
-      'span.self_time.count': {
-        value: 1
-      },
-      'span.self_time.sum.us': {
-        value: 20000
-      }
     })
   })
 
@@ -131,12 +87,6 @@ describe('Breakdown metrics', () => {
     span.end(40)
     tr.end(40)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 40 },
-      'transaction.breakdown.count': { value: 1 }
-    })
 
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
@@ -156,12 +106,6 @@ describe('Breakdown metrics', () => {
     tr.end(30)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
 
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
-
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 2 },
       'span.self_time.sum.us': { value: 30000 }
@@ -176,11 +120,6 @@ describe('Breakdown metrics', () => {
     sp2.end(40)
     tr.end(50)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 50 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 30000 }
@@ -199,11 +138,6 @@ describe('Breakdown metrics', () => {
     sp2.end(25)
     tr.end(30)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 15000 }
@@ -224,12 +158,6 @@ describe('Breakdown metrics', () => {
     sp3.end(40)
     tr.end(40)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 40 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 10000 }
@@ -248,12 +176,6 @@ describe('Breakdown metrics', () => {
     sp2.end(30)
     tr.end(30)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 0 }
@@ -272,11 +194,6 @@ describe('Breakdown metrics', () => {
     sp2.end(25)
     tr.end(30)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 10000 }
@@ -297,11 +214,6 @@ describe('Breakdown metrics', () => {
     tr.end(30)
     sp1.end(40)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 20000 }
@@ -320,11 +232,6 @@ describe('Breakdown metrics', () => {
     tr.end(30)
     sp1.end(35)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 10000 }
@@ -343,11 +250,6 @@ describe('Breakdown metrics', () => {
     sp2.end(30)
     tr.end(50)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 50 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 30000 }
@@ -364,12 +266,6 @@ describe('Breakdown metrics', () => {
     sp1.end(20)
     tr.end(30)
     const breakdown = getBreakdownObj(captureBreakdown(tr))
-
-    expect(breakdown.transaction).toEqual({
-      'transaction.duration.count': { value: 1 },
-      'transaction.duration.sum.us': { value: 30 },
-      'transaction.breakdown.count': { value: 1 }
-    })
     expect(breakdown.app).toEqual({
       'span.self_time.count': { value: 1 },
       'span.self_time.sum.us': { value: 30000 }
@@ -385,7 +281,6 @@ describe('Breakdown metrics', () => {
     tr.end()
 
     const breakdown = captureBreakdown(tr)
-    expect(breakdown.length).toBe(1)
-    expect(breakdown[0].samples['transaction.breakdown.count'].value).toBe(0)
+    expect(breakdown.length).toBe(0)
   })
 })

--- a/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
+++ b/packages/rum-core/test/performance-monitoring/transaction-service.spec.js
@@ -648,12 +648,7 @@ describe('TransactionService', function () {
 
     config.events.observe(TRANSACTION_END, () => {
       const breakdown = tr.breakdownTimings
-      expect(breakdown[0].samples).toEqual({
-        'transaction.duration.count': { value: 1 },
-        'transaction.duration.sum.us': { value: 30 },
-        'transaction.breakdown.count': { value: 1 }
-      })
-      expect(breakdown[1]).toEqual({
+      expect(breakdown[0]).toEqual({
         transaction: { name: 'transaction', type: 'custom' },
         span: { type: 'app', subtype: undefined },
         samples: {
@@ -661,7 +656,7 @@ describe('TransactionService', function () {
           'span.self_time.sum.us': { value: 0 }
         }
       })
-      expect(breakdown[2]).toEqual({
+      expect(breakdown[1]).toEqual({
         transaction: { name: 'transaction', type: 'custom' },
         span: { type: 'ext', subtype: 'http' },
         samples: {

--- a/scripts/ci-bundlesize.sh
+++ b/scripts/ci-bundlesize.sh
@@ -12,8 +12,8 @@ BUNDLESIZE_PATH="${WORKSPACE}/bundlesize.txt"
 npm run bundlesize | tee "${BUNDLESIZE_PATH}" || true
 
 # Extract passed and failed
-BUNDLESIZE_PASS=$(grep "✔" "${BUNDLESIZE_PATH}" | wc -l)
-BUNDLESIZE_FAIL=$(grep "✖" "${BUNDLESIZE_PATH}" | wc -l)
+BUNDLESIZE_PASS=$(grep "✔" "${BUNDLESIZE_PATH}" | wc -l) || true
+BUNDLESIZE_FAIL=$(grep "✖" "${BUNDLESIZE_PATH}" | wc -l) || true
 if [ ! -z "${GITHUB_OUTPUT}" ]; then
   echo "bundlesize_pass=${BUNDLESIZE_PASS}" >> "${GITHUB_OUTPUT}"
   echo "bundlesize_fail=${BUNDLESIZE_FAIL}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Follow up / Continuation of https://github.com/elastic/apm-agent-rum-js/pull/1381

# Summary

Almost two years ago,  [APM server stopped](https://github.com/elastic/apm-server/issues/6176) recording **transaction.duration.sum.us** and **transaction.duration.count**. 

The [context](https://github.com/elastic/apm/issues/505) for that is this:

> Agents capture and send transaction.duration.sum.us and transaction.duration.count metrics to apm-server, which we have been dutifully recording as part of transaction breakdown metrics. The original intention behind these was to enable metrics-based UI.
> 
> We now capture transaction latency distributions in apm-server, so the above mentioned metrics are no longer needed. They're not used anywhere, so let's stop recording them.
> 
> Additionally, **transaction.breakdown.count** is also not used (anymore). See https://github.com/elastic/apm/issues/505#issuecomment-943325753 for more details.


You will also see that all agents implemented that change in that period, too:


<img width="895" alt="Screenshot 2023-07-04 at 18 51 12" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/9c280499-590e-4a3d-ae43-36bde01b8bb7">


Like all the other agents, I wouldn't treat this as a breaking change. Although it would **be pretty interesting** to do what the APM java team does, treat this as a "potentially breaking change", since we cannot be sure what users do with the ingested data. 

example: https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#_potentially_breaking_changes_7

There are other agents (Node.js for instance) that treated this as a [bug](https://www.elastic.co/guide/en/apm/agent/nodejs/current/release-notes-3.x.html#_bug_fixes_22) and other ones (like the .NET) that treated this as a [feature](https://www.elastic.co/guide/en/apm/agent/dotnet/current/release-notes-1.x.html#_features_11) 

 If you disagree, let me know (that's also why I created this separate PR, to avoid blocking the [other one](https://github.com/elastic/apm-agent-rum-js/pull/1381) in case your opinion differs)


P.S. Tested with apiVersion 2 and 3