### PR TITLE
chore: add release dry run step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: '.ci/scripts/lint.sh'
-      - name: workaround for detached HEAD
-        run: |
-          git checkout ${GITHUB_REF#refs/heads/} -f
+      - run: git checkout -b dry-run-branch -f
+        id: createdryrunbranch
       - run: 'npm run ci:release-dry-run'
         id: release-dry-run
       - run: 'npm run ci:bundlesize'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,15 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
       - run: '.ci/scripts/lint.sh'
+      - name: workaround for detached HEAD
+        run: |
+          git checkout ${GITHUB_REF#refs/heads/} -f
       - run: 'npm run ci:release-dry-run'
         id: release-dry-run
       - run: 'npm run ci:bundlesize'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: '.ci/scripts/lint.sh'
-      - run: git checkout -b dry-run-branch -f
-        id: createdryrunbranch
       - run: 'npm run ci:release-dry-run'
         id: release-dry-run
       - run: 'npm run ci:bundlesize'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: '.ci/scripts/lint.sh'
+      - run: 'npm run ci:release-dry-run'
+        id: release-dry-run
       - run: 'npm run ci:bundlesize'
         id: bundlesize
 # TODO: This fails on forked PRs

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prerelease": "npm test && npm run clean",
     "release": "lerna publish && npm run github-release",
     "release-package": "node scripts/publish-package",
+    "release-dry-run": "npx lerna version --no-push --yes --allow-branch '*'",
     "github-release": "node scripts/github-release",
     "build-docs": "PREVIEW=1 sh ./scripts/build_docs.sh apm-agent-rum-js ./docs ./build",
     "lint": "run-p --silent lint:*",
@@ -28,7 +29,8 @@
     "package:snapshot": "npx lerna exec npm pack",
     "clean": "npx lerna exec -- rm -rf dist/",
     "ci:prepare-release": "node ./scripts/ci-prepare-release.js",
-    "ci:release": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release"
+    "ci:release": "lerna publish --otp=${TOTP_CODE} --yes && npm run github-release",
+    "ci:release-dry-run": "bash ./scripts/ci-release-dry-run.sh"
   },
   "lint-staged": {
     "*.{js,jsx,ts}": [

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Bash strict mode
+set -eo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# Create a tmp dir
+WORKSPACE=$(mktemp -d)
+DRYRUN_PATH="${WORKSPACE}/dryrun.txt"
+
+npm run release-dry-run | tee "${DRYRUN_PATH}" || true
+
+# Extract passed and failed
+VERSIONING=$(git log -1 --format="%b")
+if [ ! -z "${GITHUB_OUTPUT}" ]; then
+  echo "if you wanted to release the agent, the versions would be: \n${VERSIONING}" >> "${GITHUB_OUTPUT}"
+fi
+## also show this on standard output in order to make debuggability easier until we have the comment added in github :)
+echo "if you wanted to release the agent, the versions would be: \n${VERSIONING}"
+
+
+# Cleanup
+rm -rf "${WORKSPACE}"

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -18,11 +18,11 @@ npm run release-dry-run | tee "${DRYRUN_PATH}" || true
 # Extract passed and failed
 VERSIONING=$(git log -1 --format="%b")
 if [ ! -z "${GITHUB_OUTPUT}" ]; then
-  echo "if you wanted to release the agent, the versions would be: \n${VERSIONING}" >> "${GITHUB_OUTPUT}"
+  EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+  echo "DRYRUN_RESPONSE<<$EOF" >> "$GITHUB_OUTPUT"
+  echo "dryrun_response=${VERSIONING}" >> "${GITHUB_OUTPUT}"
+  echo "$EOF" >> "$GITHUB_OUTPUT"
 fi
-## also show this on standard output in order to make debuggability easier until we have the comment added in github :)
-echo "if you wanted to release the agent, the versions would be: \n${VERSIONING}"
-
 
 # Cleanup
 rm -rf "${WORKSPACE}"

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -10,6 +10,7 @@ DRYRUN_PATH="${WORKSPACE}/dryrun.txt"
 
 # to avoid Detached git HEAD error in CI
 git checkout -b lerna_release_dry_run
+git stash
 
 npm run release-dry-run | tee "${DRYRUN_PATH}" || true
 

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -24,8 +24,8 @@ if [ ! -z "${GITHUB_OUTPUT}" ]; then
   echo "$EOF" >> "$GITHUB_OUTPUT"
 fi
 
+# For better verfication always echo this
+echo "versions generated from the dry run command: $VERSIONING"
+
 # Cleanup
 rm -rf "${WORKSPACE}"
-
-# exits the temporal branch
-git checkout -

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -8,10 +8,6 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 WORKSPACE=$(mktemp -d)
 DRYRUN_PATH="${WORKSPACE}/dryrun.txt"
 
-# to avoid Detached git HEAD error in CI
-git checkout -b lerna_release_dry_run
-git stash
-
 npm run release-dry-run | tee "${DRYRUN_PATH}" || true
 
 # Extract passed and failed

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -8,6 +8,11 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 WORKSPACE=$(mktemp -d)
 DRYRUN_PATH="${WORKSPACE}/dryrun.txt"
 
+# Setup git env to allow lerna to generate versions properly
+git checkout -b dry-run-branch -f
+git config user.email "CI email"
+git config user.name "CI name"
+
 npm run release-dry-run | tee "${DRYRUN_PATH}" || true
 
 # Extract passed and failed

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -24,8 +24,5 @@ if [ ! -z "${GITHUB_OUTPUT}" ]; then
   echo "$EOF" >> "$GITHUB_OUTPUT"
 fi
 
-# For better verfication always echo this
-echo "versions generated from the dry run command: $VERSIONING"
-
 # Cleanup
 rm -rf "${WORKSPACE}"

--- a/scripts/ci-release-dry-run.sh
+++ b/scripts/ci-release-dry-run.sh
@@ -8,6 +8,9 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 WORKSPACE=$(mktemp -d)
 DRYRUN_PATH="${WORKSPACE}/dryrun.txt"
 
+# to avoid Detached git HEAD error in CI
+git checkout -b lerna_release_dry_run
+
 npm run release-dry-run | tee "${DRYRUN_PATH}" || true
 
 # Extract passed and failed
@@ -21,3 +24,6 @@ echo "if you wanted to release the agent, the versions would be: \n${VERSIONING}
 
 # Cleanup
 rm -rf "${WORKSPACE}"
+
+# exits the temporal branch
+git checkout -


### PR DESCRIPTION
# Context

At present, the only non-manual way to know what versions are generated for the tooling we use (lerna + [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)) is performing a release.

It's true that when we had Jenkins, the release process allowed:

- visualize the generated versions
- and allow a human to confirm if they were the proper ones

## Issues to take into account
Now that we are using Github actions the process has changed, and the manual confirmation is not there anymore. The reason is that it’s more complicated (from the technical standpoint) to wait for a human action within GitHub Action.

What is more, with the recent permission changes, once a commit has been merged into the main it's not possible (unless you ask someone with those permissions) to amend it in case something inconvenient (in terms of commit description) happens. 

# Summary

This PR goal is to address the issues described above. 

A new step named "release dry run" has been added to the CI. Those changes will allow us to see the hypothetical versions of a release in a dry-run mode.

With this information available in the PR, developers will be able to discern if the versioning makes sense and amend the commits of the PR consequently if it's not.

With this iteration, it's possible to see the versioning within the substeps of the` ci / Lint` section:


<img width="556" alt="dry-run-step" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/9d1c7d2b-8b34-46b2-916e-0b019d4c6dfc">


--


<img width="508" alt="Screenshot 2023-07-10 at 10 33 50" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/6b965462-d472-440a-8b37-ef93aa3329eb">


--
## Future next phase:

@amannocci, it would be great to see an automatic PR comment where we can see the versioning, so we can skip the step of going to the logs of the CI to see the versioning. This is something that we were doing with the bundle size too, here you can find an example: https://github.com/elastic/apm-agent-rum-js/pull/1311#issuecomment-1307638775. 

Let me know what you think