### PR TITLE
chore: use conventionalcommits changelog preset

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,6 +9,7 @@
       "allowBranch": ["main", "4.x"],
       "conventionalCommits": true,
       "message": "chore(release): publish",
+      "changelogPreset": "conventionalcommits",
       "gitRemote": "upstream",
       "loglevel": "verbose"
     },


### PR DESCRIPTION
# Context

**Important**: this fixes our problems with Lerna generating the wrong bump of package versions.

Before the change, it wasn't possible to add a breaking change just for one package since the conventions were not working as expected. The breaking change bump was being propagated to the main rum package which was totally wrong.

This was the output:

```
...
@elastic/apm-rum-angular@2.1.7 > - @elastic/apm-rum-angular@3.0.0
@elastic/apm-rum@5.12.0 > @elastic/apm-rum@6.0.0
...
```

Because of that, previous breaking changes of integration packages were published manually.

# Fix

From now on, we will start using the preset that handles all our commits properly. Now the output is:

```
...
- @elastic/apm-rum-angular@2.1.7 => 3.0.0
- @elastic/apm-rum@5.12.0 => 5.13.0
...
```

Those are the correct versions with the current git history.

As of now, we will be able to also automate the release of breaking changes for integration packages (angular, vue, react)


