### PR TITLE
feat(rum-core): enhance user transaction name obtaining

### DIFF
--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -16,6 +16,12 @@ on:
     paths-ignore:
       - '**.md'
       - '**.asciidoc'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
 
 # Limit the access of the generated GITHUB_TOKEN
 permissions:

--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -41,7 +41,11 @@ jobs:
     name: Test SauceLabs
     # Inputs aren't defined on some events
     # When undefined, we need to emulate the default value
-    if: inputs.saucelab_test == true || inputs.saucelab_test == null
+    if: |
+      inputs.saucelab_test == true || inputs.saucelab_test == null
+      && (github.event_name != 'pull_request'
+        || github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     strategy:
       # Saucelab doesn't support running test in //.

--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -104,7 +104,7 @@ function buildTransactionName(target) {
   }
 
   // Just use the tagName
-  return tagName.toLowerCase()
+  return tagName
 }
 
 function findCustomTransactionName(target) {

--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -74,20 +74,7 @@ function getTransactionMetadata(target) {
     context: null
   }
 
-  const tagName = target.tagName.toLowerCase()
-
-  // use custom html attribute 'data-transaction-name' - otherwise fall back to "tagname" + "name"-Attribute
-  let transactionName = tagName
-  if (!!target.dataset.transactionName) {
-    transactionName = target.dataset.transactionName
-  } else {
-    const name = target.getAttribute('name')
-    if (!!name) {
-      transactionName = `${tagName}["${name}"]`
-    }
-  }
-
-  metadata.transactionName = transactionName
+  metadata.transactionName = buildTransactionName(target)
 
   let classes = target.getAttribute('class')
   if (classes) {
@@ -95,4 +82,35 @@ function getTransactionMetadata(target) {
   }
 
   return metadata
+}
+
+// builds the name of a transaction from the given target
+// Strategy: use custom html attribute 'data-transaction-name' - otherwise fall back to "tagname" + "name"-Attribute
+function buildTransactionName(target) {
+  // Verify if a custom transaction name has been defined
+  const dtName = findCustomTransactionName(target)
+  if (dtName) {
+    return dtName
+  }
+
+  const tagName = target.tagName.toLowerCase()
+  // "tagname" + "name"-Attribute
+  const name = target.getAttribute('name')
+  if (!!name) {
+    return `${tagName}["${name}"]`
+  }
+
+  // Just use the tagName
+  return tagName.toLowerCase()
+}
+
+function findCustomTransactionName(target) {
+  if (target.closest) {
+    // Leverage closest API to traverse the element and its parents
+    const element = target.closest('[data-transaction-name]')
+    return element ? element.dataset.transactionName : null
+  }
+
+  // browsers which don't support closest API will just look at the target element
+  return target.dataset.transactionName
 }

--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -25,6 +25,9 @@
 
 import { USER_INTERACTION } from '../constants'
 
+const INTERACTIVE_SELECTOR =
+  'a[data-transaction-name], button[data-transaction-name]'
+
 export function observePageClicks(transactionService) {
   const clickHandler = event => {
     // Real user clicks interactions will always be related to an Element.
@@ -107,7 +110,8 @@ function buildTransactionName(target) {
 function findCustomTransactionName(target) {
   if (target.closest) {
     // Leverage closest API to traverse the element and its parents
-    const element = target.closest('[data-transaction-name]')
+    // only links and buttons are considered.
+    const element = target.closest(INTERACTIVE_SELECTOR)
     return element ? element.dataset.transactionName : null
   }
 

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -192,6 +192,7 @@ type TransactionEvents = 'transaction:start' | 'transaction:end'
 type InstrumentationTypes =
   | 'page-load'
   | 'eventtarget'
+  | 'click'
   | 'error'
   | 'history'
   | 'fetch'


### PR DESCRIPTION
Related to https://github.com/elastic/apm-agent-rum-js/issues/1286

# Summary

We have improved the user-interaction transaction name obtaining. From now on, if a user performs click on an element from a nested HTML structure like this:

```
<button data-transaction-name="my transaction name">
  <span>Some text</span>
  <svg>button icon...</svg>
</button>
```

The users will always get  `Click - my transaction name ` rather than `Click - span` or `Click - svg`

For more details see the [issue](https://github.com/elastic/apm-agent-rum-js/issues/1286)


**Important**: 

The agent will keep applying the older "algorithm" in browsers not supporting the closest method. E.g. IE11

In addition, this will work if the target is inside a button or link - the ones we define as interactive selectors. See [the associated tests](https://github.com/elastic/apm-agent-rum-js/blob/933ffa6345feb86bebce7024a4c0a9b87c314ab8/packages/rum-core/test/common/observers/page-clicks.spec.js#L145,L193) in case you need more context
