### PR TITLE
docs: update 5.13.0 release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,11 +39,10 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 ===== Features
 * Support for Angular 16 is made available via `@elastic/apm-rum-angular@3.0.0`: {pull}1380[#1380]
 * Improve user-interaction transactions naming. Unsupported browsers: IE11 {pull}1390[#1390]
-* Add `apmRequest` config to TypeScript typings: {pull}1254[#1254]
-* Add `sendCredentials` config to TypeScript typings: {pull}1243[#1243]
+* Add `apmRequest` and `sendCredentials` config to TypeScript typings: {pull}1254[#1254] {pull}1243[#1243]
 
 ===== Bug fixes
-* Check if a performance metric is available before trying to measure it: {pull}1246[#1246]
+* Fix warnings where performance entries are not supported: {pull}1246[#1246]
 
 [[release-notes-5.12.0]]
 ==== 5.12.0 (2022-06-14)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,22 @@ See Conventional Commits (https://conventionalcommits.org) for commit guidelines
 [[release-notes-5.x]]
 === RUM JS Agent version 5.x
 
+[[release-notes-5.13.0]]
+==== 5.13.0 (2023-07-19)
+[float]
+===== Potentially breaking changes
+* Previously, breakdown timings were reported as milliseconds values in the `span.self_time.sum.us` field, which was wrong. From now on, it will be reported as microsecond values to match the APM specification: {pull}1381[#1381]
+* The metrics `transaction.duration.sum.us`, `transaction.duration.count` and `transaction.breakdown.count` are no longer recorded: {pull}1382[#1382]
+
+===== Features
+* Support for Angular 16 is made available via `@elastic/apm-rum-angular@3.0.0`: {pull}1380[#1380]
+* Improve user-interaction transactions naming. Unsupported browsers: IE11 {pull}1390[#1390]
+* Add `apmRequest` config to TypeScript typings: {pull}1254[#1254]
+* Add `sendCredentials` config to TypeScript typings: {pull}1243[#1243]
+
+===== Bug fixes
+* Check if a performance metric is available before trying to measure it: {pull}1246[#1246]
+
 [[release-notes-5.12.0]]
 ==== 5.12.0 (2022-06-14)
 [float]

--- a/docs/angular-integration.asciidoc
+++ b/docs/angular-integration.asciidoc
@@ -6,7 +6,7 @@ This document covers how to use Real User Monitoring JavaScript agent with Angul
 [[angular-supported-versions]]
 ==== Supported versions
 
-This integration supports Angular versions ≥ 9.0.
+This integration supports Angular versions ≥ 12.0
 
 [[installing-angular-integration]]
 ==== Installing Elastic APM Angular package
@@ -17,6 +17,9 @@ Install the `@elastic/apm-rum-angular` package as a dependency to your applicati
 ----
 npm install @elastic/apm-rum-angular --save
 ----
+
+NOTE: If you are using an Angular version < 12.0, use @elastic/apm-rum-angular 2.x to instrument your application.
+
 
 NOTE: If you are using an Angular version < 9.0, use @elastic/apm-rum-angular 1.x to instrument your application. Details are available in a https://www.elastic.co/guide/en/apm/agent/rum-js/4.x/angular-integration.html[prior release].
 


### PR DESCRIPTION
- Release notes for 5.13.0

**PREVIEW**

<img width="806" alt="preview" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/7b1b130d-767c-4e3c-8303-0d07493ed377">



--

Additionally, I updated the docs for Angular, preview here:


<img width="802" alt="Screenshot 2023-07-19 at 16 24 46" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/5f84638c-4714-4536-ad78-0a126a6dc3da">






P.S. Once this is merged, I will also update the docs for 5.x branch