### PR TITLE
fix(rum-core): add URL object support in fetch instrumentation

### DIFF
--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -74,9 +74,18 @@ export function patchFetch(callback) {
     var fetchSelf = this
     var args = arguments
     var request, url
-    if (typeof input === 'string' || input instanceof URL) {
+    var isURL = input instanceof URL
+    if (typeof input === 'string' || isURL) {
       request = new Request(input, init)
-      url = request.url
+      if (isURL) {
+        url = request.url
+      } else {
+        // when input is string, the url value should be copied from it, rather than from request.url
+        // this is important, there are existing users using relative urls when using fetch, which generates a span.name like 'GET /path-example'
+        // switching to request.url like we do now with the introduction of URL objects support would start changing existing spans
+        // the name would start being something like 'GET http://the-url-of-the-web-page.tld/path-example' which would cause unexpected results in the Kibana side
+        url = input
+      }
     } else if (input) {
       request = input
       url = request.url

--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -80,7 +80,7 @@ export function patchFetch(callback) {
       if (isURL) {
         url = request.url
       } else {
-        // when input is string, the url value should be copied from it, rather than from request.url
+        // when the input is a string, the url value should be copied from it, rather than from request.url
         // this is important, there are existing users using relative urls when using fetch, which generates a span.name like 'GET /path-example'
         // switching to request.url like we do now with the introduction of URL objects support would start changing existing spans
         // the name would start being something like 'GET http://the-url-of-the-web-page.tld/path-example' which would cause unexpected results in the Kibana side

--- a/packages/rum-core/src/common/patching/fetch-patch.js
+++ b/packages/rum-core/src/common/patching/fetch-patch.js
@@ -74,9 +74,9 @@ export function patchFetch(callback) {
     var fetchSelf = this
     var args = arguments
     var request, url
-    if (typeof input === 'string') {
+    if (typeof input === 'string' || input instanceof URL) {
       request = new Request(input, init)
-      url = input
+      url = request.url
     } else if (input) {
       request = input
       url = request.url

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -77,6 +77,20 @@ describe('fetchPatch', function () {
         })
       })
 
+      it('should fetch correctly with a URL Object as input', function (done) {
+        var promise = window.fetch(new URL(window.location.origin))
+        expect(promise).toBeDefined()
+        expect(typeof promise.then).toBe('function')
+        expect(events.map(e => e.event)).toEqual(['schedule'])
+        promise.then(function (resp) {
+          expect(resp).toBeDefined()
+          Promise.resolve().then(function () {
+            expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
+            done()
+          })
+        })
+      })
+
       it('should produce task events when fetch fails', function (done) {
         var promise = window.fetch('http://localhost:54321/')
         promise.catch(function (error) {

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -81,64 +81,45 @@ describe('fetchPatch', function () {
         window.Response.prototype.clone = originalCloneFn
       })
 
-      it('should fetch correctly', function (done) {
-        const fetchArgs = createFetchArgs('GET')
-        var promise = window.fetch(fetchArgs.url, fetchArgs.options)
-        expect(promise).toBeDefined()
-        expect(typeof promise.then).toBe('function')
-        expect(events.map(e => e.event)).toEqual(['schedule'])
+      // Testing fetch with different input types
+      ;[
+        {
+          name: 'should fetch correctly when using string as input',
+          fetchArgs: createFetchArgs('GET'),
+          fetchFn(fetchArgs) {
+            return window.fetch(fetchArgs.url, fetchArgs.options)
+          }
+        },
+        {
+          name: 'should fetch correctly when using REQUEST object as input',
+          fetchArgs: createFetchArgs('PATCH'),
+          fetchFn(fetchArgs) {
+            return window.fetch(new Request(fetchArgs.url, fetchArgs.options))
+          }
+        },
+        {
+          name: 'should fetch correctly when using URL object as input',
+          fetchArgs: createFetchArgs('PUT'),
+          fetchFn(fetchArgs) {
+            return window.fetch(new URL(fetchArgs.url), fetchArgs.options)
+          }
+        }
+      ].forEach(({ name, fetchArgs, fetchFn }) => {
+        it(`${name}`, function (done) {
+          var promise = fetchFn(fetchArgs)
+          expect(typeof promise.then).toBe('function')
+          expect(events.map(e => e.event)).toEqual(['schedule'])
 
-        // Validate that fetch has been called with the proper data
-        const data = events[0].task.data
-        validateFetchData(data, fetchArgs)
+          // Validate that fetch has been called with the proper data
+          const data = events[0].task.data
+          validateFetchData(data, fetchArgs)
 
-        promise.then(function (resp) {
-          expect(resp).toBeDefined()
-          Promise.resolve().then(function () {
-            expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
-            done()
-          })
-        })
-      })
-
-      it('should fetch correctly when using REQUEST object as input', function (done) {
-        const fetchArgs = createFetchArgs('PATCH')
-        var promise = window.fetch(
-          new Request(fetchArgs.url, fetchArgs.options)
-        )
-        expect(promise).toBeDefined()
-        expect(typeof promise.then).toBe('function')
-        expect(events.map(e => e.event)).toEqual(['schedule'])
-
-        // Validate that fetch has been called with the proper data
-        const data = events[0].task.data
-        validateFetchData(data, fetchArgs)
-
-        promise.then(function (resp) {
-          expect(resp).toBeDefined()
-          Promise.resolve().then(function () {
-            expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
-            done()
-          })
-        })
-      })
-
-      it('should fetch correctly with a URL object as input', function (done) {
-        const fetchArgs = createFetchArgs('PUT')
-        var promise = window.fetch(new URL(fetchArgs.url), fetchArgs.options)
-        expect(promise).toBeDefined()
-        expect(typeof promise.then).toBe('function')
-        expect(events.map(e => e.event)).toEqual(['schedule'])
-
-        // Validate that fetch has been called with the proper data
-        const data = events[0].task.data
-        validateFetchData(data, fetchArgs)
-
-        promise.then(function (resp) {
-          expect(resp).toBeDefined()
-          Promise.resolve().then(function () {
-            expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
-            done()
+          promise.then(function (resp) {
+            expect(resp).toBeDefined()
+            Promise.resolve().then(function () {
+              expect(events.map(e => e.event)).toEqual(['schedule', 'invoke'])
+              done()
+            })
           })
         })
       })

--- a/packages/rum-core/test/common/fetch-patch.spec.js
+++ b/packages/rum-core/test/common/fetch-patch.spec.js
@@ -78,7 +78,7 @@ describe('fetchPatch', function () {
       })
 
       it('should fetch correctly with a URL Object as input', function (done) {
-        var promise = window.fetch(new URL(window.location.origin))
+        var promise = window.fetch(new URL(new Request('/').url))
         expect(promise).toBeDefined()
         expect(typeof promise.then).toBe('function')
         expect(events.map(e => e.event)).toEqual(['schedule'])


### PR DESCRIPTION
this contribution has been made by @alizeait in the following PR: https://github.com/elastic/apm-agent-rum-js/pull/1373

The reason for creating this PR is to force the new CI mechanism to execute the E2E Saucelabs tests, which at this moment are not being executed for PRs coming from forks: CC: @amannocci 

Thanks again to @alizeait for taking the time to make these changes.


For additional visibility, the contribution resolves https://github.com/elastic/apm-agent-rum-js/issues/1288 and https://github.com/elastic/apm-agent-rum-js/issues/1396


--

Additional context:

Example of fetch with URL object

```
                fetch(new URL("http://localhost:3000/api_test_post"), {
                        method: "POST",
                        headers: {
	                        Authorization: `Bearer test`,
                        },
                    })
```

**Before the change**, and since the fetch patch didn't handle URL objects, the outcome was a **GET** request without the extra header

**After the change**, the fetch patch outcome is now correct, it respects the method(**POST** in this case) and also includes the extra header.


**WORKAROUND**

Until this is released, the workaround is the same one as the one discussed [here](https://github.com/elastic/apm-agent-rum-js/issues/1288#issuecomment-1273406842) - using `toString()`

```
fetch(new URL("yoururl").toString())
```






