### PR TITLE
chore: prevent slack notification in dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           process_gcloudignore: false
 
   status:
-    if: inputs.dry-run == null || !inputs.dry-run
+    if: inputs.dry-run != null && !inputs.dry-run
     needs:
       - release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           process_gcloudignore: false
 
   status:
-    if: always()
+    if: inputs.dry-run == null || !inputs.dry-run
     needs:
       - release
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

The PR changes prevent the dry-run release process from sending Slack notification