### PR TITLE
feat(rum): force minor version bump rum package

### DIFF
--- a/packages/rum/src/index.js
+++ b/packages/rum/src/index.js
@@ -50,7 +50,6 @@ function getApmBase() {
 }
 
 const apmBase = getApmBase()
-
 const init = apmBase.init.bind(apmBase)
 
 export default init


### PR DESCRIPTION
# Context

Lerna **will not** bump the minor version of a package if there are no files modified within that specific package, even if the commit contain "feat(specific-package)"

That is understandable from a technical standpoint but not from a user standpoint, at least in the case of **rum-core** and **rum**

The upcoming release among other things will contain a new feature ([the redirect span](https://github.com/elastic/apm-agent-rum-js/pull/1400)). The logic modified belongs to rum-core, so it's generating a minor bump in the package rum-core, but not in the one that **users will download** (apm-rum), so instead of **5.13.1** as it was generating it should create **5.14.0.** to clearly highlight that contains a new feature.

Needless to say that it wasn't the end of the world, in the past we have done releases without taking that into consideration. Despite that, I believe we should start being more mindful of semantic versioning.

# Changes

A dummy commit within the package rum, to force the minor versioning bump


cc: @vigneshshanmugam 


