### PR TITLE
ci: correct github token configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,16 @@ jobs:
       - name: Configure git user
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
 
+      - name: Configure github token
+        uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - name: Publish the release
         env:
           DRY_RUN: ${{ inputs.dry-run }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run ci:release
 
       - name: Setup credentials


### PR DESCRIPTION
## What is the change being made?
* The auto-generate github token isn't enough to push on protected branches.

## Why is the change being made?
* We should be able to push on protected branches for release process.