### PR TITLE
docs: update react docs

### DIFF
--- a/docs/react-integration.asciidoc
+++ b/docs/react-integration.asciidoc
@@ -26,19 +26,19 @@ To instrument the application routes, you can use `ApmRoutes` component provided
 `ApmRoutes` creates a transaction that has the path of the `Route` as its name and has `route-change`
 as its type.
 
-NOTE: `ApmRoutes` only supports applications using the version `6` of the
+NOTE: `ApmRoutes` only supports applications using version `6` of the
 https://github.com/remix-run/react-router[`react-router`] library.
 
 NOTE: `RouterProvider` instrumentation is not currently supported.
 
-First you should import `ApmRoutes` from the `@elastic/apm-rum-react` package:
+First import `ApmRoutes` from the `@elastic/apm-rum-react` package:
 
 [source,js]
 ----
 import { ApmRoutes } from '@elastic/apm-rum-react'
 ----
 
-Then, you should use `ApmRoutes` components from the `react-router` library. Every `<Route>` wrapped by `<ApmRoutes>` will be monitored.
+Then, use the `ApmRoutes` component from the `react-router` library. Every `<Route>` wrapped by `<ApmRoutes>` will be monitored.
 
 [source,js]
 ----
@@ -63,10 +63,10 @@ To instrument the application routes, you can use `ApmRoute` component provided 
 `ApmRoute` creates a transaction that has the path of the `Route` as its name and has `route-change`
 as its type.
 
-NOTE: `ApmRoute` only supports applications using the version `4` and `5` of the
+NOTE: `ApmRoute` only supports applications using versions `4` and `5` of the
 https://github.com/remix-run/react-router[`react-router`] library.
 
-First you should import `ApmRoute` from the `@elastic/apm-rum-react` package:
+First import `ApmRoute` from the `@elastic/apm-rum-react` package:
 
 [source,js]
 ----
@@ -111,7 +111,7 @@ please instrument the individual component using `withTransaction` in these case
 [float]
 ===== Instrumenting individual React components
 
-First you should import `withTransaction` from the `@elastic/apm-rum-react` package:
+First import `withTransaction` from the `@elastic/apm-rum-react` package:
 
 [source,js]
 ----

--- a/docs/react-integration.asciidoc
+++ b/docs/react-integration.asciidoc
@@ -20,14 +20,51 @@ npm install @elastic/apm-rum-react --save
 The React integration package provides two approaches to instrumenting your application:
 
 [float]
-===== Instrumenting application routes
+===== Instrumenting application routes with @elastic/apm-rum-react >= 2.0.0
+
+To instrument the application routes, you can use `ApmRoutes` component provided in the package.
+`ApmRoutes` creates a transaction that has the path of the `Route` as its name and has `route-change`
+as its type.
+
+NOTE: `ApmRoutes` only supports applications using the version `6` of the
+https://github.com/remix-run/react-router[`react-router`] library.
+
+NOTE: `RouterProvider` instrumentation is not currently supported.
+
+First you should import `ApmRoutes` from the `@elastic/apm-rum-react` package:
+
+[source,js]
+----
+import { ApmRoutes } from '@elastic/apm-rum-react'
+----
+
+Then, you should use `ApmRoutes` components from the `react-router` library. Every `<Route>` wrapped by `<ApmRoutes>` will be monitored.
+
+[source,js]
+----
+class App extends React.Component {
+  render() {
+    return (
+      <BrowserRouter>
+        <ApmRoutes>
+          <Route path="/" element={<HomeComponent />} />
+          <Route path="/about" element={<AboutComponent />} />
+        </ApmRoutes>
+      </BrowserRouter>
+    )
+  }
+}
+----
+
+[float]
+===== Instrumenting application routes with @elastic/apm-rum-react < 2.0.0
 
 To instrument the application routes, you can use `ApmRoute` component provided in the package. 
 `ApmRoute` creates a transaction that has the path of the `Route` as its name and has `route-change`
 as its type.
 
-NOTE: Currently `ApmRoute` only supports applications using 
-https://github.com/ReactTraining/react-router[`react-router`] library.
+NOTE: `ApmRoute` only supports applications using the version `4` and `5` of the
+https://github.com/remix-run/react-router[`react-router`] library.
 
 First you should import `ApmRoute` from the `@elastic/apm-rum-react` package:
 


### PR DESCRIPTION
Associated to: https://github.com/elastic/apm-agent-rum-js/pull/1410

**Note**: merge once the [new react package version](https://github.com/elastic/apm-agent-rum-js/pull/1410) has been released

- [x] Wait until `@elastic/apm-rum-react@2.0.0` is released

# Summary

Adds the `<ApmRoutes>` component to the [React docs](https://www.elastic.co/guide/en/apm/agent/rum-js/current/react-integration.html).

Preview:

<img width="886" alt="preview part 1" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/470dcf15-dd3d-48d4-83bb-ccdfb4689872">

--

and

--

<img width="888" alt="preview part 2" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/4759af34-f882-4ffd-aae2-fc730e34afc3">
