### PR TITLE
feat(rum-core): stringify object rejected by a promise

### DIFF
--- a/packages/rum-core/src/error-logging/error-logging.js
+++ b/packages/rum-core/src/error-logging/error-logging.js
@@ -33,6 +33,7 @@ import stackParser from 'error-stack-parser'
  * List of keys to be ignored from getting added to custom error properties
  */
 const IGNORE_KEYS = ['stack', 'message']
+const PROMISE_REJECTION_PREFIX = 'Unhandled promise rejection: '
 
 function getErrorProperties(error) {
   /**
@@ -172,7 +173,6 @@ class ErrorLogging {
   }
 
   logPromiseEvent(promiseRejectionEvent) {
-    const prefix = 'Unhandled promise rejection: '
     let { reason } = promiseRejectionEvent
     if (reason == null) {
       reason = '<no reason specified>'
@@ -186,18 +186,10 @@ class ErrorLogging {
       const name = reason.name ? reason.name + ': ' : ''
       errorEvent = {
         error: reason,
-        message: prefix + name + reason.message
+        message: PROMISE_REJECTION_PREFIX + name + reason.message
       }
     } else {
-      reason =
-        typeof reason === 'object'
-          ? '<object>'
-          : typeof reason === 'function'
-          ? '<function>'
-          : reason
-      errorEvent = {
-        message: prefix + reason
-      }
+      errorEvent = this._parseRejectReason(reason)
     }
     this.logErrorEvent(errorEvent)
   }
@@ -210,6 +202,32 @@ class ErrorLogging {
       errorEvent.error = messageOrError
     }
     return this.logErrorEvent(errorEvent)
+  }
+
+  _parseRejectReason(reason) {
+    const errorEvent = {
+      message: PROMISE_REJECTION_PREFIX
+    }
+
+    if (Array.isArray(reason)) {
+      errorEvent.message += '<object>'
+    } else if (typeof reason === 'object') {
+      try {
+        errorEvent.message += JSON.stringify(reason)
+        errorEvent.error = reason
+      } catch (error) {
+        // fallback. JSON.stringify can throw exceptions in different circumstances.
+        // please, see this link for more info:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions
+        errorEvent.message += '<object>'
+      }
+    } else if (typeof reason === 'function') {
+      errorEvent.message += '<function>'
+    } else {
+      errorEvent.message += reason
+    }
+
+    return errorEvent
   }
 }
 

--- a/packages/rum-core/test/error-logging/error-logging.spec.js
+++ b/packages/rum-core/test/error-logging/error-logging.spec.js
@@ -393,9 +393,29 @@ describe('ErrorLogging', function () {
     )
 
     errorLogging.logPromiseEvent({
-      reason: [{ a: '1' }]
+      reason: ['array-value']
     })
     expect(getEvents()[7][ERRORS].exception.message).toBe(
+      'Unhandled promise rejection: <object>'
+    )
+
+    errorLogging.logPromiseEvent({
+      reason: { a: '1' }
+    })
+    expect(getEvents()[8][ERRORS].exception.message).toBe(
+      'Unhandled promise rejection: {"a":"1"}'
+    )
+
+    // Make sure that the object fallback case works
+    // Circular objects causes JSON.stringify to fail
+    const circularObj = {
+      foo: 'bar'
+    }
+    circularObj.self = circularObj
+    errorLogging.logPromiseEvent({
+      reason: circularObj
+    })
+    expect(getEvents()[9][ERRORS].exception.message).toBe(
       'Unhandled promise rejection: <object>'
     )
 
@@ -403,14 +423,14 @@ describe('ErrorLogging', function () {
     errorLogging.logPromiseEvent({
       reason: noop
     })
-    expect(getEvents()[8][ERRORS].exception.message).toBe(
+    expect(getEvents()[10][ERRORS].exception.message).toBe(
       'Unhandled promise rejection: <function>'
     )
 
     errorLogging.logPromiseEvent({
       reason: null
     })
-    expect(getEvents()[9][ERRORS].exception.message).toBe(
+    expect(getEvents()[11][ERRORS].exception.message).toBe(
       'Unhandled promise rejection: <no reason specified>'
     )
 

--- a/packages/rum/src/index.js
+++ b/packages/rum/src/index.js
@@ -50,6 +50,7 @@ function getApmBase() {
 }
 
 const apmBase = getApmBase()
+
 const init = apmBase.init.bind(apmBase)
 
 export default init


### PR DESCRIPTION
Solves: https://github.com/elastic/apm-agent-rum-js/issues/1423

# Context

Before this change, if the promise rejection reason was an object:

```
       const obj = {
              foo: "bar",
              rum: "Agent",
              hello: "world"
       };

       Promise.reject(obj)
```

The RUM agent was capturing the error this way:

`Unhandled promise rejection: <object>`. Additionally, none of the properties were included in the error custom properties, making it difficult for users to identify the error's context.

There was an exception to that rule. Objects containing a "message" property:

<img width="771" alt="Screenshot 2023-09-18 at 17 03 29" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/33c1f41c-f74a-4064-a340-d3b672a34fcc">

But unfortunately, this is not something that users can always control.

# Enhancement

From now onwards, if the rejection reason of a promise is an object (with no message property), then two things will happen:

1. The RUM agent will `JSON.stringify` the obj so that the properties will be visible in the error message. This is similar to the native behaviour of browsers like Google Chrome.
2. The non-standard properties will also be added to the error custom properties


You can see an example in the screenshots below:


<img width="880" alt="Screenshot 2023-09-18 at 16 48 10" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/6091340b-a4ab-407f-ad1f-b6f03043c96b">


<img width="626" alt="Screenshot 2023-09-18 at 16 49 21" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/fbba6ec2-f964-4ce6-8dbe-ef604d09b17b">


# Notes

1. the behaviour of other types remains unchanged.
    - arrays -> `<object>`
    - functions -> `<function>`

2. The "stringify" of the object will fail at least in [two circumstances](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions):
     - it contains a circular reference
     - one of the values is a BigInt

If that happens, a fallback will be applied, meaning that the error will be captured as if was being captured before this change.