### PR TITLE
chore: upgrade ie11 windows os for saucelabs

### DIFF
--- a/dev-utils/test-config.js
+++ b/dev-utils/test-config.js
@@ -91,7 +91,7 @@ function getDefaultBrowsers() {
     },
     {
       browserName: 'internet explorer',
-      platformName: 'Windows 8.1',
+      platformName: 'Windows 10',
       browserVersion: '11'
     },
     {


### PR DESCRIPTION
# Summary

There is a bug when executing tests against IE 11 (Platform Window 8.1)

Although the tests pass, the CLI process runs indefinitely with this log:

`
"Check if 'log.json' for browser 'internet explorer 11 Windows 8.1' has already been stored."
`

That also means that the CI process never ends.

# Solution

Debugging I found that by changing the platform from Windows 8.1 to Windows 10, the problem goes away.

I also reported this bug to SauceLabs Support with all this info (and a few links to the corresponding executions). Also highlighted to them that this is a regression because it wasn't happening before

**Edit**: Saucelabs confirmed the bug. Their engineers are working on a solution.


