### PR TITLE
chore: stop using npx lerna in ci

### DIFF
--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - run: npm ci
       - run: npm run package:snapshot
 
       - name: Publish snaphosts

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "prerelease": "npm run clean",
     "release": "lerna publish && npm run github-release",
     "release-package": "node scripts/publish-package",
-    "release-dry-run": "npx lerna version --no-push --yes --allow-branch '*'",
     "github-release": "node scripts/github-release",
     "build-docs": "PREVIEW=1 sh ./scripts/build_docs.sh apm-agent-rum-js ./docs ./build",
     "lint": "run-p --silent lint:*",
@@ -26,8 +25,8 @@
     "serve": "node ./dev-utils/run-script.js startTestServers",
     "coverage": "lerna run build:module && lerna run karma:coverage",
     "bench:dev": "lerna run build:module && node ./scripts/benchmarks.js",
-    "package:snapshot": "npx lerna exec npm pack",
-    "clean": "npx lerna exec -- rm -rf dist/",
+    "package:snapshot": "lerna exec npm pack",
+    "clean": "lerna exec -- rm -rf dist/",
     "ci:prepare-release": "node ./scripts/ci-prepare-release.js",
     "ci:release": "node ./scripts/ci-release.mjs"
   },


### PR DESCRIPTION
# Summary

The [Snapshoty github action](https://github.com/elastic/apm-agent-rum-js/actions/workflows/snapshoty.yml) has been failing for a week.

The underlying process execute "npx lerna ...".

The "npx" command is installing a new version of lerna (7.3) which assumes that the Node.js version of the environment supports modern syntax such as "??".  (one week before it was using 7.2)

https://github.com/elastic/apm-agent-rum-js/actions/runs/6236074031/job/16972772623

<img width="215" alt="Screenshot 2023-09-21 at 12 26 11" src="https://github.com/elastic/apm-agent-rum-js/assets/15065076/a5b58b11-536a-4476-a1c4-5b946e239f8c">


# Solution

I'm removing the NPX statement and using the lerna we have already in the project.

Since now we will use our own lerna, I'm installing dependencies @amannocci any thoughts here? is this okay?


