### PR TITLE
fix(rum-core): unsampled page load transaction start must be zero

### DIFF
--- a/packages/rum-core/src/performance-monitoring/navigation/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/navigation/capture-navigation.js
@@ -42,8 +42,10 @@ function captureNavigation(transaction) {
    * transactions set this flag to true
    */
   if (!transaction.captureTimings) {
-    // Make sure page load transactions always starts at 0 irrespective if we capture navigation metrics or not
-    // otherwise we would be reporting different page load durations for sampled and unsampled transactions
+    /**
+     * Make sure page load transactions always starts at 0 irrespective if we capture navigation metrics or not
+     * otherwise we would be reporting different page load durations for sampled and unsampled transactions
+     */
     if (transaction.type === PAGE_LOAD) {
       transaction._start = 0
     }

--- a/packages/rum-core/src/performance-monitoring/navigation/capture-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/navigation/capture-navigation.js
@@ -42,6 +42,12 @@ function captureNavigation(transaction) {
    * transactions set this flag to true
    */
   if (!transaction.captureTimings) {
+    // Make sure page load transactions always starts at 0 irrespective if we capture navigation metrics or not
+    // otherwise we would be reporting different page load durations for sampled and unsampled transactions
+    if (transaction.type === PAGE_LOAD) {
+      transaction._start = 0
+    }
+
     return
   }
 

--- a/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-navigation.spec.js
@@ -53,7 +53,7 @@ function mapSpan(s) {
 
 describe('Capture hard navigation', function () {
   /**
-   * Arbitrary value considering the transcation end would be called
+   * Arbitrary value considering the transaction end would be called
    * after load event has finished
    */
   const transactionEnd = timings.loadEventEnd + 100
@@ -396,6 +396,25 @@ describe('Capture hard navigation', function () {
     tr.end()
     captureNavigation(tr)
     expect(tr.marks.custom.testMark).toEqual(start + markValue)
+  })
+
+  // relevant for sampled and unsampled PAGE LOAD transactions:
+  ;[
+    {
+      value: true,
+      description: 'enabled'
+    },
+    {
+      value: false,
+      description: 'disabled'
+    }
+  ].forEach(({ value, description }) => {
+    it(`should set transaction._start to 0 for PAGE_LOAD when captureTimings flag is ${description}`, function () {
+      const tr = new Transaction('test', PAGE_LOAD)
+      tr.captureTimings = value
+      captureNavigation(tr)
+      expect(tr._start).toBe(0)
+    })
   })
 
   it('should not add API calls as resource timing spans', function () {


### PR DESCRIPTION
Fixes: #1430

# Summary

This PR fixes a duration discrepancy with sampled and unsampled `PAGE_LOAD` transactions. 

Unlike **unsampled** transactions, sampled ones capture navigation metrics (and that is where we set the start to 0).

It has been detected that the difference in behaviour between sampled and unsampled was affecting the page load duration reported by the agent.

Please, [see the issue](https://github.com/elastic/apm-agent-rum-js/issues/1430), which provides an exemplary description, for more details.

# Fix
Make sure the unsampled page load transactions start is set to 0, too.


# Notes

Unsampled page load transactions are not taken into account in the User Experience Page. This means this fix will not affect anything there. This fix might affect existing custom boards created by users. Thanks @vigneshshanmugam for checking that. Does it make sense to add a Potentially breaking change in the release notes?, WDYT @vigneshshanmugam?

