### PR TITLE
ci: support headers in the CDN google bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,8 @@ jobs:
           destination: '${{ env.ELASTIC_CDN_BUCKET_NAME }}/${{ fromJSON(steps.prepare-release.outputs.versions).version }}'
           glob: '*.js'
           process_gcloudignore: false
+          headers: |-
+            Cache-Control:public,max-age=31536000,immutable
 
       - id: 'upload-files-major-version'
         uses: 'google-github-actions/upload-cloud-storage@v1'
@@ -124,6 +126,8 @@ jobs:
           destination: '${{ env.ELASTIC_CDN_BUCKET_NAME }}/${{ fromJSON(steps.prepare-release.outputs.versions).major_version }}'
           glob: '*.js'
           process_gcloudignore: false
+          headers: |-
+            Cache-Control:public,max-age=604800,immutable
 
       - id: 'upload-file-index'
         uses: 'google-github-actions/upload-cloud-storage@v1'
@@ -132,6 +136,8 @@ jobs:
           path: 'index.html'
           destination: '${{ env.ELASTIC_CDN_BUCKET_NAME }}'
           process_gcloudignore: false
+          headers: |-
+            Cache-Control:public,max-age=604800,immutable
 
   status:
     if: always()


### PR DESCRIPTION
This was already implemented in Jenkins see https://github.com/elastic/apm-agent-rum-js/pull/793/files\#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R399

Uses `headers - (Optional) Set object metadata.` as explained in https://github.com/google-github-actions/upload-cloud-storage

A leftover from the CI migration