### PR TITLE
feat(ci): run CDN if dist files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
         run: echo "versions=$(npm run --silent ci:prepare-release)" >> ${GITHUB_OUTPUT}
 
       - id: 'upload-files-version'
+        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           parent: false
@@ -117,6 +118,7 @@ jobs:
           process_gcloudignore: false
 
       - id: 'upload-files-major-version'
+        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           parent: false
@@ -126,6 +128,7 @@ jobs:
           process_gcloudignore: false
 
       - id: 'upload-file-index'
+        if: ${{ always() && hashFiles('index.html') }}
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           parent: false


### PR DESCRIPTION
Upload artifacts only if artifacts exists. This should help with the corner case when one of the components in the mono-repo does not produce bundles.

 as explained in https://github.com/orgs/community/discussions/25790 and https://github.com/google-github-actions/upload-cloud-storage/issues/332