### PR TITLE
ci: rewrite google cdn headers in lowercase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           glob: '*.js'
           process_gcloudignore: false
           headers: |-
-            Cache-Control:public,max-age=31536000,immutable
+            cache-control: public,max-age=31536000,immutable
 
       - id: 'upload-files-major-version'
         if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
@@ -129,7 +129,7 @@ jobs:
           glob: '*.js'
           process_gcloudignore: false
           headers: |-
-            Cache-Control:public,max-age=604800,immutable
+            cache-control: public,max-age=604800,immutable
 
       - id: 'upload-file-index'
         if: ${{ always() && hashFiles('index.html') }}
@@ -140,7 +140,7 @@ jobs:
           destination: '${{ env.ELASTIC_CDN_BUCKET_NAME }}'
           process_gcloudignore: false
           headers: |-
-            Cache-Control:public,max-age=604800,immutable
+            cache-control: public,max-age=604800,immutable
 
   status:
     if: always()


### PR DESCRIPTION
# Summary

The Google github action named [upload-cloud-storage](https://github.com/google-github-actions/upload-cloud-storage) expects the name of the headers in lowercase.

With this change, we intend to solve the CDN upload step in the release process: https://github.com/elastic/apm-agent-rum-js/actions/runs/6317518826/job/17154464506

