### PR TITLE
ci: debug non-dry-run release mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,22 +142,22 @@ jobs:
           headers: |-
             cache-control: public,max-age=604800,immutable
 
-  status:
-    if: always()
-    needs:
-      - release
-    runs-on: ubuntu-latest
-    steps:
-      - id: check
-        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
-        with:
-          needs: ${{ toJSON(needs) }}
-      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
-        if: inputs.dry-run == false
-        with:
-          status: ${{ steps.check.outputs.status }}
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-js"
-          message: "Build result for release publication"
+  # status:
+  #   if: always()
+  #   needs:
+  #     - release
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - id: check
+  #       uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+  #       with:
+  #         needs: ${{ toJSON(needs) }}
+  #     - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+  #       if: inputs.dry-run == false
+  #       with:
+  #         status: ${{ steps.check.outputs.status }}
+  #         vaultUrl: ${{ secrets.VAULT_ADDR }}
+  #         vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+  #         vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+  #         slackChannel: "#apm-agent-js"
+  #         message: "Build result for release publication"

--- a/scripts/ci-release.mjs
+++ b/scripts/ci-release.mjs
@@ -59,7 +59,9 @@ async function main() {
   if (isDryRun) {
     await dryRunMode()
   } else {
-    await prodMode()
+    console.log('SEE changes to be committed: \n\n')
+    await execa('git', ['status']).pipeStdout(process.stdout)
+    // await prodMode()
   }
 }
 


### PR DESCRIPTION
# Goal

To verify if lerna publish in CI is also modifying the .npmrc file.

- release disabled. Added a git status to see if the worktree is clean, if that's the case, will add a statement to tell git to ignore modifications in the .npmrc in the release process (right now we are just doing that in the dry run mode)
- release notification status disabled in order to avoid being noisy