### PR TITLE
ci: ignore git uncommitted changes when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,12 @@ jobs:
           secrets: |
             totp/code/npmjs-elasticmachine code | TOTP_CODE
 
+      # This prevent lerna command from throwing this error:
+      # "Working tree has uncommitted changes, please commit or remove the following changes before continuing"
+      - name: Ignore git uncommited changes
+        run: |
+          git update-index --skip-worktree .npmrc
+
       - name: Configure npm registry
         uses: elastic/apm-pipeline-library/.github/actions/setup-npmrc@current
         if: inputs.dry-run == false

--- a/scripts/ci-release.mjs
+++ b/scripts/ci-release.mjs
@@ -101,12 +101,7 @@ async function dryRunMode() {
     } else {
       raiseError('Failed to add user to private registry')
     }
-    // since we modify the .npmrc (which is a tracked file) in dry-run mode to interact with verdaccio
-    // we don't want lerna to fail with the error "uncommited changes in the workspace".
-    // because of that we tell git to ignore the .npmrc change
-    await execa('git', ['update-index', '--skip-worktree', '.npmrc'], {
-      stdin: process.stdin
-    })
+
     await appendFile(path.join(process.cwd(), '.npmrc'), '\n' + npmrcData)
   } catch (err) {
     raiseError('Failed to login to private registry')


### PR DESCRIPTION
# Goal

If we want to make sure .npmrc modifications don't affect the lerna release, we should tell git to ignore the modifications with `git update-index --no-skip-worktree .npmrc ` 

At this point, we still have the release and notifications disabled to avoid being noisy