### PR TITLE
ci: enable prod release mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       # This prevent lerna command from throwing this error:
       # "Working tree has uncommitted changes, please commit or remove the following changes before continuing"
-      - name: Ignore git uncommited changes
+      - name: Ignore git uncommitted changes
         run: |
           git update-index --skip-worktree .npmrc
 
@@ -148,22 +148,22 @@ jobs:
           headers: |-
             cache-control: public,max-age=604800,immutable
 
-  # status:
-  #   if: always()
-  #   needs:
-  #     - release
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - id: check
-  #       uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
-  #       with:
-  #         needs: ${{ toJSON(needs) }}
-  #     - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
-  #       if: inputs.dry-run == false
-  #       with:
-  #         status: ${{ steps.check.outputs.status }}
-  #         vaultUrl: ${{ secrets.VAULT_ADDR }}
-  #         vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-  #         vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-  #         slackChannel: "#apm-agent-js"
-  #         message: "Build result for release publication"
+  status:
+    if: always()
+    needs:
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        if: inputs.dry-run == false
+        with:
+          status: ${{ steps.check.outputs.status }}
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-agent-js"
+          message: "Build result for release publication"

--- a/scripts/ci-release.mjs
+++ b/scripts/ci-release.mjs
@@ -59,9 +59,7 @@ async function main() {
   if (isDryRun) {
     await dryRunMode()
   } else {
-    console.log('SEE changes to be committed: \n\n')
-    await execa('git', ['status']).pipeStdout(process.stdout)
-    // await prodMode()
+    await prodMode()
   }
 }
 


### PR DESCRIPTION
# Summary

This PR is the last step of the prod-release troubleshooting process:

These are the previous ones:

1. https://github.com/elastic/apm-agent-rum-js/pull/1440
2. https://github.com/elastic/apm-agent-rum-js/pull/1441

with all these changes the file `.npmrc` will not give problems anymore when Lerna releases the agent
