### PR TITLE
feat(rum-core): add fallback to click transaction name

### DIFF
--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -112,7 +112,9 @@ function findCustomTransactionName(target) {
     // Leverage closest API to traverse the element and its parents
     // only links and buttons are considered.
     const element = target.closest(INTERACTIVE_SELECTOR)
-    return element ? element.dataset.transactionName : null
+    return element
+      ? element.dataset.transactionName
+      : target.dataset.transactionName
   }
 
   // browsers which don't support closest API will just look at the target element

--- a/packages/rum-core/test/common/observers/page-clicks.spec.js
+++ b/packages/rum-core/test/common/observers/page-clicks.spec.js
@@ -165,7 +165,7 @@ describe('observePageClicks', () => {
             'should not use customTransactionName when click target is not descendant from <button> nor <a>',
           parentTagName: 'div',
           customTransactionName: 'div-custom-name-html',
-          expected: 'Click - span'
+          expected: 'Click - div-custom-name-html'
         }
       ].forEach(({ name, parentTagName, customTransactionName, expected }) => {
         it(`${name}`, () => {


### PR DESCRIPTION
I came across a scenario in [findCustomTransactionName](https://github.com/elastic/apm-agent-rum-js/blob/main/packages/rum-core/src/common/observers/page-clicks.js#L110), where it returns `null` if it doesn't find a closest element matching the `INTERACTIVE_SELECTOR`. In our frontend, we utilize clickable elements like images that are not wrapped in `button` or `a` tags, but they do have the `data-transaction-name` attribute defined. However, the current implementation still leads to a `Click - img` transaction name.

I noticed the current behavior is covered in unit tests which suggests it might be by design? If not, then I'm proposing a slight modification to the `findCustomTransactionName` function to return `target.dataset.transactionName` as a fallback when no closest matching element is found.

Looking forward to your feedback. Thank you!