### PR TITLE
ci(release): support dry-run

### DIFF
--- a/scripts/ci-pre-release.mjs
+++ b/scripts/ci-pre-release.mjs
@@ -99,7 +99,7 @@ async function dryRunMode() {
   }
 
   try {
-    await execa('git', ['--no-pager', 'diff'], {
+    await execa('git', ['--no-pager', 'diff', 'HEAD~1'], {
       stdin: process.stdin
     })
       .pipeStdout(process.stdout)

--- a/scripts/ci-pre-release.mjs
+++ b/scripts/ci-pre-release.mjs
@@ -86,7 +86,7 @@ async function dryRunMode() {
   }
 
   try {
-    await execa('npx', ['lerna', 'version', '--no-push', '--no-git-tag-version', '--no-changelog', 'yes'], {
+    await execa('npx', ['lerna', 'version', '--yes', '--no-push'], {
       stdin: process.stdin,
       env: {
         GH_TOKEN: githubToken
@@ -96,6 +96,16 @@ async function dryRunMode() {
       .pipeStderr(process.stderr)
   } catch (err) {
     raiseError('Failed to version npm')
+  }
+
+  try {
+    await execa('git', ['--no-pager', 'diff'], {
+      stdin: process.stdin
+    })
+      .pipeStdout(process.stdout)
+      .pipeStderr(process.stderr)
+  } catch (err) {
+    raiseError('Failed to git diff')
   }
 }
 


### PR DESCRIPTION
Fixes the issue when running the pre-release step with `dry-run`.


Ideally, https://github.com/cli/cli/issues/8375 will help with the dry-run.


### Tests

See https://github.com/elastic/apm-agent-rum-js/actions/runs/7503019059