### PR TITLE
ci: avoid reporting if no need to run

### DIFF
--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -44,8 +44,8 @@ jobs:
     if: |
       inputs.saucelab_test == true || inputs.saucelab_test == null
       && (github.event_name != 'pull_request'
-        || github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.fork == false)
+        || ( github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false ))
     runs-on: ubuntu-latest
     strategy:
       # Saucelab doesn't support running test in //.
@@ -84,3 +84,10 @@ jobs:
         with:
           needs: ${{ toJSON(needs) }}
       - run: ${{ steps.check.outputs.isSuccess }}
+        ## Use the condition in the step so the job runs always even if
+        ## test-saucelabs failed.
+        if: |
+          inputs.saucelab_test == true || inputs.saucelab_test == null
+          && (github.event_name != 'pull_request'
+            || ( github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.fork == false ))

--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -74,7 +74,12 @@ jobs:
 
   all-tests-saucelabs:
     name: All Tests SauceLabs
-    if: always()
+    if: |
+      always()
+      && (inputs.saucelab_test == true || inputs.saucelab_test == null)
+      && (github.event_name != 'pull_request'
+          || (github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.fork == false))
     runs-on: ubuntu-latest
     needs:
       - test-saucelabs
@@ -84,10 +89,3 @@ jobs:
         with:
           needs: ${{ toJSON(needs) }}
       - run: ${{ steps.check.outputs.isSuccess }}
-        ## Use the condition in the step so the job runs always even if
-        ## test-saucelabs failed.
-        if: |
-          inputs.saucelab_test == true || inputs.saucelab_test == null
-          && (github.event_name != 'pull_request'
-            || ( github.event_name == 'pull_request'
-            && github.event.pull_request.head.repo.fork == false ))


### PR DESCRIPTION
This workflow triggers another job always, so this should help with avoiding reporting any failures if `test-saucelabs` didn't get triggered.
