### PR TITLE
ci: support provenance phase 1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     permissions:
       # Needed to write the release changelog
       contents: write
+      # Needed to the provenance generation
+      id-token: write
     services:
       verdaccio:
         image: verdaccio/verdaccio:5
@@ -109,8 +111,13 @@ jobs:
         name: 'Prepare CDN release'
         run: echo "versions=$(npm run --silent ci:prepare-release)" >> ${GITHUB_OUTPUT}
 
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/packages/rum/dist/bundles/*.js"
+
       - id: 'upload-files-version'
-        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
+        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') && inputs.dry-run == false }}
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           parent: false
@@ -122,7 +129,7 @@ jobs:
             cache-control: public,max-age=31536000,immutable
 
       - id: 'upload-files-major-version'
-        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
+        if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') && inputs.dry-run == false }}
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           parent: false
@@ -134,7 +141,7 @@ jobs:
             cache-control: public,max-age=604800,immutable
 
       - id: 'upload-file-index'
-        if: ${{ always() && hashFiles('index.html') }}
+        if: ${{ always() && hashFiles('index.html') && inputs.dry-run == false }}
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           parent: false


### PR DESCRIPTION
## What does this pull request do?

* Skip the release steps for the CDN if `dry-run=true`
* Enable provenance for the generated files in `packages/rum/dist/bundles/*.js`


## Related issues

Closes #ISSUE