### PR TITLE
chore: pin python requests dependency version

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -13,6 +13,11 @@ pip3 install docker==6.1.3
 
 pip install docker-compose>=1.25.4
 
+# https://github.com/docker/docker-py/issues/3256
+pip3 uninstall requests
+pip3 install requests==2.31.0
+
+
 # Tests are run within the node-puppeteer container and can fails.
 # To avoid flakiness, we retry up to 3 times to run them.
 for i in {1..3};


### PR DESCRIPTION
# Context

Our CI has been failing for a few weeks now.

The problem was a breaking change introduced by a python library named requests, specifically in version 2.32.0.

Please, see more details here: https://github.com/docker/docker-py/issues/3256

# Approached followed

I've pinned the [requests](https://pypi.org/project/requests/) dependency version to 2.31.0 as suggested in multiple discussions associated with the issue linked above