### PR TITLE
ci: use github secrets for saucelabs

### DIFF
--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -28,8 +28,6 @@ permissions:
   contents: read
 
 env:
-  DOCKER_ELASTIC_SECRET: secret/observability-team/ci/docker-registry/prod
-  SAUCELABS_SECRET: secret/apm-team/ci/apm-agent-rum-saucelabs@elastic/apm-rum
   CODECOV_SECRET: secret/apm-team/ci/apm-agent-rum-codecov
 
 concurrency:
@@ -68,9 +66,8 @@ jobs:
           mode: 'saucelabs'
           scope: ${{ matrix.scope }}
           stack-version: ${{ matrix.stack-version }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
 
   all-tests-saucelabs:
     name: All Tests SauceLabs

--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -27,9 +27,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CODECOV_SECRET: secret/apm-team/ci/apm-agent-rum-codecov
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/run-test/action.yml
+++ b/.github/workflows/run-test/action.yml
@@ -21,14 +21,11 @@ inputs:
     options:
       - none
       - saucelabs
-  vault-url:
-    description: 'Vault URL'
+  sauce-username:
+    description: 'Sauce username'
     required: false
-  vault-role-id:
-    description: 'Vault role ID'
-    required: false
-  vault-secret-id:
-    description: 'Vault secret ID'
+  sauce-access-key:
+    description: 'Sauce access key'
     required: false
 
 runs:
@@ -40,20 +37,6 @@ runs:
     - name: Pull and build docker infra
       run: './.ci/scripts/pull_and_build.sh'
       shell: bash
-    - uses: hashicorp/vault-action@v3.0.0
-      if: |
-        (inputs.mode == 'saucelabs')
-        && (inputs.vault-url != null && inputs.vault-url != '')
-        && (inputs.vault-role-id != null && inputs.vault-role-id != '')
-        && (inputs.vault-secret-id != null && inputs.vault-secret-id != '')
-      with:
-        url: ${{ inputs.vault-url }}
-        roleId: ${{ inputs.vault-role-id }}
-        secretId: ${{ inputs.vault-secret-id }}
-        method: approle
-        secrets: |
-          ${{ env.SAUCELABS_SECRET }} SAUCE_USERNAME | SAUCE_USERNAME ;
-          ${{ env.SAUCELABS_SECRET }} SAUCE_ACCESS_KEY | SAUCE_ACCESS_KEY
     - name: Run tests Elastic Stack ${{ matrix.stack-version }} - ${{ matrix.scope }} - ${{ fromJSON('{"none":"Puppeteer"}')[inputs.mode] || inputs.mode }}
       run: './.ci/scripts/test.sh'
       shell: bash
@@ -62,6 +45,8 @@ runs:
         MODE: ${{ inputs.mode }}
         SCOPE: ${{ inputs.scope }}
         STACK_VERSION: ${{ inputs.stack-version }}
+        SAUCE_USERNAME: ${{ inputs.sauce-username }}
+        SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
     - name: Store test results
       if: success() || failure()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/run-test/action.yml
+++ b/.github/workflows/run-test/action.yml
@@ -37,6 +37,14 @@ runs:
     - name: Pull and build docker infra
       run: './.ci/scripts/pull_and_build.sh'
       shell: bash
+    - if: |
+        (inputs.mode == 'saucelabs')
+        && (inputs.sauce-access-key != null && inputs.sauce-access-key != '')
+        && (inputs.sauce-username != null && inputs.sauce-username != '')
+      shell: bash
+      run: |
+        echo "SAUCE_ACCESS_KEY=${{ inputs.sauce-access-key }}" >> $GITHUB_ENV
+        echo "SAUCE_USERNAME=${{ inputs.sauce-username }}"     >> $GITHUB_ENV
     - name: Run tests Elastic Stack ${{ matrix.stack-version }} - ${{ matrix.scope }} - ${{ fromJSON('{"none":"Puppeteer"}')[inputs.mode] || inputs.mode }}
       run: './.ci/scripts/test.sh'
       shell: bash
@@ -45,8 +53,6 @@ runs:
         MODE: ${{ inputs.mode }}
         SCOPE: ${{ inputs.scope }}
         STACK_VERSION: ${{ inputs.stack-version }}
-        SAUCE_USERNAME: ${{ inputs.sauce-username }}
-        SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
     - name: Store test results
       if: success() || failure()
       uses: actions/upload-artifact@v3
@@ -54,3 +60,9 @@ runs:
         name: test-results
         path: |
           packages/**/reports/TESTS-*.xml
+    - name: Reset environment
+      if: always()
+      shell: bash
+      run: |
+        echo "SAUCE_ACCESS_KEY=" >> $GITHUB_ENV
+        echo "SAUCE_USERNAME="   >> $GITHUB_ENV


### PR DESCRIPTION
Remove access to Vault to gather the Saucelab credentials and use GitHub secrets

### Question
- Can the env variables `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` be defined with empty values?