### PR TITLE
fix(rum): make sure custom transaction name logic is IE11 compliant

### DIFF
--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -108,13 +108,15 @@ function buildTransactionName(target) {
 }
 
 function findCustomTransactionName(target) {
+  const trCustomNameAttribute = 'data-transaction-name'
+  const fallbackName = target.getAttribute(trCustomNameAttribute)
   if (target.closest) {
     // Leverage closest API to traverse the element and its parents
     // only links and buttons are considered.
     const element = target.closest(INTERACTIVE_SELECTOR)
-    return element ? element.dataset.transactionName : null
+    return element ? element.getAttribute(trCustomNameAttribute) : fallbackName
   }
 
-  // browsers which don't support closest API will just look at the target element
-  return target.dataset.transactionName
+  // browsers (such as IE11) which don't support closest API will just look at the target element
+  return fallbackName
 }


### PR DESCRIPTION
Resolves #1510 

### Fix:

We stop using [dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) (even in browsers where it works) and we use [getAttribute](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute)

Since we are modifying this area, we also take the opportunity to fix this other [issue](https://github.com/elastic/apm-agent-rum-js/pull/1452) that was reported a while ago