### PR TITLE
docs: Update APM guide links to Observability guide links (#1528)

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -2,7 +2,7 @@
 
 === `Agent` API
 
-You can access agent API after initializing the agent: 
+You can access agent API after initializing the agent:
 
 [source,js]
 ----
@@ -45,7 +45,7 @@ The given `context` argument must be an object and can contain the following pro
 
 The provided user context is stored under `context.user` in Elasticsearch on both errors and transactions.
 
-It’s possible to call this function multiple times within the scope of the same active transaction. 
+It’s possible to call this function multiple times within the scope of the same active transaction.
 For each call, the properties of the context argument are shallow merged with the context previously given.
 
 
@@ -62,13 +62,13 @@ Call this to enrich collected errors and transactions with any information that 
 
 The provided custom context is stored under `context.custom` in Elasticsearch on both errors and transactions.
 
-It’s possible to call this function multiple times within the scope of the same active transaction. 
+It’s possible to call this function multiple times within the scope of the same active transaction.
 For each call, the properties of the context argument are shallow merged with the context previously given.
 
 The given `context` argument must be an object and can contain any property that can be JSON encoded.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{observability-guide}/apm-api-metadata.html[metadata] that are available.
 
 
 [float]
@@ -80,13 +80,13 @@ TIP: Before using custom context, ensure you understand the different types of
 apm.addLabels({ [name]: value })
 ----
 
-Set labels on transactions and errors. 
+Set labels on transactions and errors.
 Starting with APM Server 7.6+, the labels are added to spans as well.
 
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>). You can set multiple labels.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{observability-guide}/apm-api-metadata.html[metadata] that are available.
 
 Arguments:
 
@@ -153,12 +153,12 @@ Arguments:
 
 * `type` - The type of the transaction (string). Defaults to `custom`
 
-* `options` - Options to modify the created transaction (object). 
+* `options` - Options to modify the created transaction (object).
 This argument is optional. The following options are supported:
 
 ** `managed` - Controls whether the transaction is managed by the agent or not. Defaults to `false`.
 
-Use this method to create a custom transaction. 
+Use this method to create a custom transaction.
 
 By default, custom transactions are not managed by the agent, however, you can start a managed transaction
  by passing `{ managed: true }` as the `options` argument.
@@ -276,11 +276,11 @@ Arguments:
 * `callback` - A callback function to execute once the event is fired.
 
 
-Use this method to listen for RUM agent internal events. 
+Use this method to listen for RUM agent internal events.
 
 The following events are supported for the transaction lifecycle:
 
-* `transaction:start` event is fired on every transaction start. 
+* `transaction:start` event is fired on every transaction start.
 * `transaction:end` event is fired on transaction end and before it is added to the queue to be sent to APM Server.
 
 The callback function for these events receives the corresponding transaction object

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,8 +31,8 @@ captures the following information:
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
-and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].
+APM Agents work in conjunction with the {observability-guide}/apm.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {observability-guide}/apm.html[APM Guide] provides details on how these components work together,
+and provides a matrix outlining {observability-guide}/apm-agent-server-compatibility.html[Agent and Server compatibility].
 
 include::./set-up.asciidoc[]

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -2,7 +2,7 @@
 == Set up the Agent
 
 To start reporting your web page performance to Elastic APM,
-you must first {apm-guide-ref}/configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration. 
+you must first {observability-guide}/apm-configuration-rum.html[enable the RUM endpoint] in your `apm-server` configuration.
 
 Once the APM Server endpoint has been configured, you can:
 
@@ -78,7 +78,7 @@ Install the Real User Monitoring APM agent as a dependency to your application:
 
 [source,bash]
 ----
-npm install @elastic/apm-rum --save 
+npm install @elastic/apm-rum --save
 ----
 
 Configure the agent:
@@ -88,13 +88,13 @@ Configure the agent:
 import { init as initApm } from '@elastic/apm-rum'
 
 const apm = initApm({
-  
+
   // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   serviceName: '',
 
   // Set custom APM Server URL (default: http://localhost:8200)
   serverUrl: 'http://localhost:8200',
-  
+
   // Set service version (required for sourcemap feature)
   serviceVersion: ''
 })
@@ -130,7 +130,7 @@ You can learn more about this in https://webpack.js.org/plugins/environment-plug
 [float]
 ==== Rollup
 
-For optimized rollup production build, include the replace plugin which ensures the right build environment is used. 
+For optimized rollup production build, include the replace plugin which ensures the right build environment is used.
 
 [source, js]
 ----
@@ -152,7 +152,7 @@ If APM Server is deployed in an origin different than the page's origin,
 you will need to configure Cross-Origin Resource Sharing (CORS).
 
 A list of permitted origins can be supplied to the
-{apm-guide-ref}/configuration-rum.html#rum-allow-origins[`apm-server.rum.allow_origins`]
+{observability-guide}/apm-configuration-rum.html#apm-rum-allow-origins[`apm-server.rum.allow_origins`]
 configuration option.
 By default, APM Server allows all origins.
 

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -10,17 +10,17 @@ without losing the ability to quickly and easily debug your applications.
 
 There are three steps required to enable, upload, and apply a source map to error stack traces.
 An overview is listed below, and a complete walk-through is available in the
-{apm-guide-ref}/sourcemaps.html[generate and upload a source map] guide.
+{observability-guide}/apm-source-map-how-to.html[generate and upload a source map] guide.
 
 1. Set the <<service-version,`serviceVersion`>> when initializing the RUM Agent.
-2. {apm-guide-ref}/sourcemaps.html#sourcemap-rum-generate[Generate a source map]
+2. {observability-guide}/apm-source-map-how-to.html#apm-source-map-rum-generate[Generate a source map]
 for your application with the `serviceVersion` from step one.
-3. {apm-guide-ref}/sourcemaps.html#sourcemap-rum-upload[Enable and upload the source map file] to APM Server.
+3. {observability-guide}/apm-source-map-how-to.html#apm-source-map-rum-upload[Enable and upload the source map file] to APM Server.
 
 // Don't link to this section
 [[secret-token]]
-You can also configure a {apm-guide-ref}/secret-token.html[secret token] or
-{apm-guide-ref}/api-key.html[API key] to restrict the uploading of sourcemaps.
+You can also configure a {observability-guide}/apm-secret-token.html[secret token] or
+{observability-guide}/apm-api-key.html[API key] to restrict the uploading of sourcemaps.
 
 TIP: Don't forget,
-you must enable {apm-guide-ref}/configuration-rum.html[RUM support] in the APM Server for this endpoint to work.
+you must enable {observability-guide}/apm-configuration-rum.html[RUM support] in the APM Server for this endpoint to work.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -126,7 +126,7 @@ it will also get tagged with the same labels.
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{observability-guide}/apm-api-metadata.html[metadata] that are available.
 
 Arguments:
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {observability-guide}/apm-agent-server-compatibility.html[Agent and Server compatibility chart]
 
 The following upgrade guides are also available:
 


### PR DESCRIPTION
Backports https://github.com/elastic/apm-agent-rum-js/pull/1528 to 5.x