### PR TITLE
ci: set up OIDC in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
           npm run ci:release
 
+        # The permissions configuration for this can be found at
+        # https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-agent-rum-js/02-gcp-oidc.tf
       - uses: elastic/oblt-actions/google/auth@v1
         with:
           project-id: ${{ env.ELASTIC_CDN_PROJECT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ permissions:
 
 env:
   ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-rum-test' }}
-  ELASTIC_CDN_PROJECT_ID: ${{ inputs.dry-run == false && 'elastic-cdn-4ae000ab' || 'elastic-observability-ci' }}
   ELASTIC_CDN_PROJECT_NUMBER: ${{ inputs.dry-run == false && '382950469386' || '911195782929' }}
   SLACK_BUILD_MESSAGE: "Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)"
 
@@ -67,7 +66,6 @@ jobs:
         # https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-agent-rum-js/02-gcp-oidc.tf
       - uses: elastic/oblt-actions/google/auth@v1
         with:
-          project-id: ${{ env.ELASTIC_CDN_PROJECT_ID }}
           project-number: ${{ env.ELASTIC_CDN_PROJECT_NUMBER }}
 
       - id: prepare-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-agent-rum-js-ci' }}
+  ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-rum-test' }}
   ELASTIC_CDN_PROJECT_ID: ${{ inputs.dry-run == false && 'elastic-cdn-4ae000ab' || 'elastic-observability-ci' }}
   ELASTIC_CDN_PROJECT_NUMBER: ${{ inputs.dry-run == false && '382950469386' || '911195782929' }}
   SLACK_BUILD_MESSAGE: "Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ permissions:
 
 env:
   ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-agent-rum-js-ci' }}
-  ELASTIC_CDN_CREDENTIALS: ${{ inputs.dry-run == false && 'secret/gce/elastic-cdn/service-account/apm-rum-admin' || 'secret/observability-team/ci/service-account/apm-agent-rum-js' }}
+  ELASTIC_CDN_PROJECT_ID: ${{ inputs.dry-run == false && 'elastic-cdn-4ae000ab' || 'elastic-observability-ci' }}
+  ELASTIC_CDN_PROJECT_NUMBER: ${{ inputs.dry-run == false && '382950469386' || '911195782929' }}
   SLACK_BUILD_MESSAGE: "Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)"
 
 jobs:
@@ -61,21 +62,10 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
           npm run ci:release
 
-      - name: Read GCE vault secrets
-        uses: hashicorp/vault-action@v3.0.0
+      - uses: elastic/oblt-actions/google/auth@v1
         with:
-          method: approle
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            ${{ env.ELASTIC_CDN_CREDENTIALS }} value | GOOGLE_CREDENTIALS ;
-
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: '${{ env.GOOGLE_CREDENTIALS }}'
-          create_credentials_file: true
+          project-id: ${{ env.ELASTIC_CDN_PROJECT_ID }}
+          project-number: ${{ env.ELASTIC_CDN_PROJECT_NUMBER }}
 
       - id: prepare-release
         name: 'Prepare CDN release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-agent-rum-js-ci' }}
@@ -27,6 +26,7 @@ jobs:
     permissions:
       # Needed to write the release changelog
       contents: write
+      id-token: write
     services:
       verdaccio:
         image: verdaccio/verdaccio:5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
           npm run ci:release
 
         # The permissions configuration for this can be found at
-        # https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-agent-rum-js/02-gcp-oidc.tf
+        # https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-agent-rum-js/02-gcp-oidc-elastic-cdn.tf
+        # and
+        # https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-agent-rum-js/02-gcp-oidc-elastic-observability.tf
       - uses: elastic/oblt-actions/google/auth@v1
         with:
           project-number: ${{ env.ELASTIC_CDN_PROJECT_NUMBER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   ELASTIC_CDN_BUCKET_NAME: ${{ inputs.dry-run == false && 'apm-rum-357700bc' || 'oblt-apm-agent-rum-js-ci' }}


### PR DESCRIPTION
This sets up keyless authentication to GCP with OIDC.

I have a successful dry-run here: https://github.com/elastic/apm-agent-rum-js/actions/runs/10850931893, which is deploying to a test bucket in the elastic-observability-ci GCP project
