### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,18 +20,29 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      # Needed to write the release changelog
-      contents: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["apm-agent-rum-js"]
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -49,6 +60,8 @@ jobs:
         id: pre-release
         env:
           DRY_RUN: "${{ inputs.dry-run }}"
+          # as long as we use the GitHub app for generating the token, we need to pass the token to the action
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
           npm run ci:pre-release
           if [ -e .pr.txt ] ; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,24 +22,35 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      # Needed to write the release changelog
-      contents: write
     services:
       verdaccio:
         image: verdaccio/verdaccio:5
         ports:
           - 4873:4873
-    env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
+
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["apm-agent-rum-js"]
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -80,6 +91,9 @@ jobs:
       - id: prepare-release
         name: 'Prepare CDN release'
         run: echo "versions=$(npm run --silent ci:prepare-release)" >> ${GITHUB_OUTPUT}
+        env:
+          # as long as we use the GitHub app for generating the token, we need to pass the token to the action
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - id: 'upload-files-version'
         if: ${{ always() && hashFiles('packages/rum/dist/bundles/*.js') }}
@@ -119,6 +133,8 @@ jobs:
       - name: Post-release
         env:
           DRY_RUN: "${{ inputs.dry-run }}"
+          # as long as we use the GitHub app for generating the token, we need to pass the token to the action
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         run: npm run ci:post-release
 
       - if: ${{ success() && inputs.dry-run == false }}


### PR DESCRIPTION
## What does this PR do?

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.

#### Why

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the GH workflow requires to run in terms of access
* GitHub Token with Permissions does not trigger GitHub builds 

#### Implementation details

Use `tibdex/github-app-token` with the required permissions and the repository scope
Remove the `permissions` configuration in the GH workflow.
Configure git checkout with the ephemeral token
Configure the GH_TOKEN with the ephemeral token
