### PR TITLE
[docs] Add a note about Elastic Cloud Serverless support

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -9,7 +9,7 @@ This enables you to analyze performance throughout your microservice architectur
 
 [NOTE]
 ====
-The Elastic APM RUM JavaScript Agent is not compatible with {serverless-docs}[{serverless-full}].
+The Elastic APM RUM JavaScript Agent is _not_ compatible with {serverless-docs}[{serverless-full}] -- it cannot send data to the APM endpoint for serverless projects.
 ====
 
 [float]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,6 +7,11 @@ It has built-in support for popular platforms and frameworks, and an API for cus
 The Agent also supports <<distributed-tracing-guide,distributed tracing>> for all outgoing requests.
 This enables you to analyze performance throughout your microservice architecture -- all in one view.
 
+[NOTE]
+====
+The Elastic APM RUM JavaScript Agent is not compatible with {serverless-docs}[{serverless-full}].
+====
+
 [float]
 [[features]]
 === Features


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/issues/3394

Adds a note that lets users know that the agent is not compatible with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html).

Note: When this PR is finalized, I'll open a PR targeting `5.x`.

cc @chrisdistasio 