### PR TITLE
[5.x] [docs] Add a note about Elastic Cloud Serverless support

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -9,7 +9,7 @@ This enables you to analyze performance throughout your microservice architectur
 
 [NOTE]
 ====
-The Elastic APM RUM JavaScript Agent is not compatible with {serverless-docs}[{serverless-full}].
+The Elastic APM RUM JavaScript Agent is _not_ compatible with {serverless-docs}[{serverless-full}] -- it cannot send data to the APM endpoint for serverless projects.
 ====
 
 [float]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,6 +7,11 @@ It has built-in support for popular platforms and frameworks, and an API for cus
 The Agent also supports <<distributed-tracing-guide,distributed tracing>> for all outgoing requests.
 This enables you to analyze performance throughout your microservice architecture -- all in one view.
 
+[NOTE]
+====
+The Elastic APM RUM JavaScript Agent is not compatible with {serverless-docs}[{serverless-full}].
+====
+
 [float]
 [[features]]
 === Features


### PR DESCRIPTION
Backports https://github.com/elastic/apm-agent-rum-js/pull/1557 to 5.x