### PR TITLE
ci: use python:3.10 and run npm ci on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: fix Node-Gyp Build Error
-        run: sudo apt-get install g++ build-essential
+      # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+      # See https://github.com/nodejs/node-gyp/issues/2219
+      # This can be removed when "node-gyp" is updated
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,10 @@ jobs:
           stack-version: ${{ matrix.stack-version }}
 
   test:
-    name: Test Puppeteer
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,12 @@ jobs:
           stack-version: ${{ matrix.stack-version }}
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: fix Node-Gyp Build Error
+        run: sudo apt-get install g++ build-essential
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           scope: ${{ matrix.scope }}
           stack-version: ${{ matrix.stack-version }}
 
-  test:
+  npm-ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -101,9 +101,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run test
-        run: npm run test:unit
 
   all:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
-      - test
+      - npm-ci
       - test-puppeteer
     steps:
       - id: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,26 @@ jobs:
           scope: ${{ matrix.scope }}
           stack-version: ${{ matrix.stack-version }}
 
+  test:
+    name: Test Puppeteer
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test
+        run: npm run test:unit
+
   all:
     if: always()
     runs-on: ubuntu-latest
     needs:
       - lint
+      - test
       - test-puppeteer
     steps:
       - id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -54,6 +54,14 @@ jobs:
       - uses: elastic/oblt-actions/git/setup@v1
         with:
           github-token: ${{ steps.get_token.outputs.token }}
+
+      # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+      # See https://github.com/nodejs/node-gyp/issues/2219
+      # This can be removed when "node-gyp" is updated
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/10636, it's not using ubuntu-22 but ubuntu-24


Therefore, the release is not working anymore and it fails with

```
npm error code 127
npm error path /home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/fibers
npm error command failed
npm error command sh -c node build.js || nodejs build.js
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@5.1.1
npm error gyp info using node@18.20.5 | linux | x64
npm error gyp info find Python using Python version 3.12.3 found at "/usr/bin/python"
npm error gyp http GET https://nodejs.org/download/release/v18.20.5/node-v18.20.5-headers.tar.gz
npm error gyp http 200 https://nodejs.org/download/release/v18.20.5/node-v18.20.5-headers.tar.gz
npm error gyp http GET https://nodejs.org/download/release/v18.20.5/SHASUMS256.txt
npm error gyp http 200 https://nodejs.org/download/release/v18.20.5/SHASUMS256.txt
npm error (node:2275) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
npm error (Use `node --trace-deprecation ...` to show where the warning was created)
npm error gyp info spawn /usr/bin/python
npm error gyp info spawn args [
npm error gyp info spawn args   '/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/gyp_main.py',
npm error gyp info spawn args   'binding.gyp',
npm error gyp info spawn args   '-f',
npm error gyp info spawn args   'make',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/fibers/build/config.gypi',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/addon.gypi',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/home/runner/.cache/node-gyp/18.20.5/include/node/common.gypi',
npm error gyp info spawn args   '-Dlibrary=shared_library',
npm error gyp info spawn args   '-Dvisibility=default',
npm error gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/18.20.5',
npm error gyp info spawn args   '-Dnode_gyp_dir=/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp',
npm error gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/18.20.5/<(target_arch)/node.lib',
npm error gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/fibers',
npm error gyp info spawn args   '-Dnode_engine=v8',
npm error gyp info spawn args   '--depth=.',
npm error gyp info spawn args   '--no-parallel',
npm error gyp info spawn args   '--generator-output',
npm error gyp info spawn args   'build',
npm error gyp info spawn args   '-Goutput_dir=.'
npm error gyp info spawn args ]
npm error Traceback (most recent call last):
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/gyp_main.py", line 50, in <module>
npm error     sys.exit(gyp.script_main())
npm error              ^^^^^^^^^^^^^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 554, in script_main
npm error     return main(sys.argv[1:])
npm error            ^^^^^^^^^^^^^^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 547, in main
npm error     return gyp_main(args)
npm error            ^^^^^^^^^^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 520, in gyp_main
npm error     [generator, flat_list, targets, data] = Load(
npm error                                             ^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 136, in Load
npm error     result = gyp.input.Load(build_files, default_variables, includes[:],
npm error              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 2782, in Load
npm error     LoadTargetBuildFile(build_file, data, aux_data,
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 391, in LoadTargetBuildFile
npm error     build_file_data = LoadOneBuildFile(build_file_path, data, aux_data,
npm error                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
npm error   File "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 234, in LoadOneBuildFile
npm error     build_file_contents = open(build_file_path, 'rU').read()
npm error                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
npm error ValueError: invalid mode: 'rU' while trying to load binding.gyp
npm error gyp ERR! configure error 
npm error gyp ERR! stack Error: `gyp` failed with exit code: 1
npm error gyp ERR! stack     at ChildProcess.onCpExit (/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/node-gyp/lib/configure.js:351:16)
npm error gyp ERR! stack     at ChildProcess.emit (node:events:517:28)
npm error gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
npm error gyp ERR! System Linux 6.8.0-1017-azure
npm error gyp ERR! command "/opt/hostedtoolcache/node/18.20.5/x64/bin/node" "/home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/.bin/node-gyp" "rebuild" "--release"
npm error gyp ERR! cwd /home/runner/work/apm-agent-rum-js/apm-agent-rum-js/node_modules/fibers
npm error gyp ERR! node -v v18.20.5
npm error gyp ERR! node-gyp -v v5.1.1
npm error gyp ERR! not ok 
npm error node-gyp exited with code: 1
npm error Please make sure you are using a supported platform and node version. If you
npm error would like to compile fibers on this machine please make sure you have setup your
npm error build environment--
npm error Windows + OS X instructions here: https://github.com/nodejs/node-gyp
npm error Ubuntu users please run: `sudo apt-get install g++ build-essential`
npm error RHEL users please run: `yum install gcc-c++` and `yum groupinstall 'Development Tools'` 
npm error Alpine users please run: `sudo apk add python make g++`
npm error sh: 1: nodejs: not found
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/[202](https://github.com/elastic/apm-agent-rum-js/actions/runs/12643693924/job/35230082388#step:7:203)5-01-07T01_52_42_995Z-debug-0.log
```


https://github.com/nodejs/node-gyp/issues/2219 is the issue.

And the workaround is pin the version for python to 3.10.

### Test

See https://github.com/elastic/apm-agent-rum-js/actions/runs/12647873070 and https://github.com/elastic/apm-agent-rum-js/actions/runs/12648168801

