### PR TITLE
ci(benchmarks): use docker compose v1

### DIFF
--- a/.ci/scripts/benchmarks.sh
+++ b/.ci/scripts/benchmarks.sh
@@ -8,13 +8,13 @@ NODEJS_VERSION=14
 
 USER_ID="${USER_ID}" \
 NODEJS_VERSION="${NODEJS_VERSION}" \
-docker compose -f ./dev-utils/docker-compose.yml down \
+docker-compose -f ./dev-utils/docker-compose.yml down \
   --remove-orphans \
   --volumes || true
 
 USER_ID="${USER_ID}" \
 NODEJS_VERSION="${NODEJS_VERSION}" \
-docker compose -f ./dev-utils/docker-compose.yml up \
+docker-compose -f ./dev-utils/docker-compose.yml up \
   --build \
   --abort-on-container-exit \
   --exit-code-from node-benchmark \

--- a/.ci/scripts/load-testing.sh
+++ b/.ci/scripts/load-testing.sh
@@ -10,14 +10,14 @@ NODEJS_VERSION=14
 USER_ID="${USER_ID}" \
 NODEJS_VERSION="${NODEJS_VERSION}" \
 STACK_VERSION=${STACK_VERSION} \
-docker compose -f ./dev-utils/docker-compose.yml down \
+docker-compose -f ./dev-utils/docker-compose.yml down \
   --remove-orphans \
   --volumes || true
 
 USER_ID="${USER_ID}" \
 NODEJS_VERSION="${NODEJS_VERSION}" \
 STACK_VERSION=${STACK_VERSION} \
-docker compose -f ./dev-utils/docker-compose.yml up \
+docker-compose -f ./dev-utils/docker-compose.yml up \
   --build \
   --exit-code-from load-testing \
   load-testing


### PR DESCRIPTION
current bare-metals are configured with docker-compose instead of docker compose


See 

<img width="605" alt="image" src="https://github.com/user-attachments/assets/aa0c2336-4323-42df-a850-6054ba467f59" />


vs

<img width="650" alt="image" src="https://github.com/user-attachments/assets/ac95c644-9730-433d-b8a1-625a9a22eada" />
