### PR TITLE
ci(release): create GH_TOKEN for the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Publish the release
         env:
           DRY_RUN: "${{ inputs.dry-run }}"
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
           npm run ci:release


### PR DESCRIPTION
Fixes

```
Git User: username=obltmachine, email=obltmachine@users.noreply.github.com
Running in prod mode
The 'GITHUB_TOKEN' env var isn't defined
```