### PR TITLE
ci(pre-release): pin python version

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           github-token: ${{ steps.get_token.outputs.token }}
 
+      # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+      # See https://github.com/nodejs/node-gyp/issues/2219
+      # This can be removed when "node-gyp" is updated
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
Similarly done in https://github.com/elastic/apm-agent-rum-js/pull/1560