### PR TITLE
ci: add head branch

### DIFF
--- a/scripts/ci-pre-release.mjs
+++ b/scripts/ci-pre-release.mjs
@@ -73,7 +73,7 @@ async function dryRunMode() {
     raiseError("The 'GITHUB_TOKEN' env var isn't defined")
   }
 
-  const branch = `release/${version}-next`
+  const branch = `prerelease/${version}-next`
 
   try {
     await execa('git', ['checkout', '-b', branch], {

--- a/scripts/ci-pre-release.mjs
+++ b/scripts/ci-pre-release.mjs
@@ -155,7 +155,7 @@ async function prodMode() {
   }
 
   try {
-    await execa('gh', ['pr', 'create', '--fill-first'], {
+    await execa('gh', ['pr', 'create', '--fill-first', '--head', branch], {
       stdin: process.stdin,
       env: {
         GH_TOKEN: githubToken


### PR DESCRIPTION
```
lerna success version finished
remote: 
remote: Create a pull request for 'release/5.16.1-next' on GitHub by visiting:        
remote:      https://github.com/elastic/apm-agent-rum-js/pull/new/release/5.16.1-next        
remote: 
To https://github.com/elastic/apm-agent-rum-js
 * [new branch]      release/5.16.1-next -> release/5.16.1-next
Warning: 1 uncommitted change
Failed to create GitHub PR
aborted: you must first push the current branch to a remote, or use the --head flag
```

but the branch is already pushed and `--head` is defaulted to the current branch...

```
  -H, --head branch          The branch that contains commits for your pull request (default [current branch])
```

Let's try to use the explicit flag just in case that's the reason for the failure


and also change the branch name to avoid issues with the branch protection for those temporary branches


