### PR TITLE
feat: add support for adding labels to captured errors

### DIFF
--- a/docs/reference/agent-api.md
+++ b/docs/reference/agent-api.md
@@ -215,12 +215,15 @@ Use this method to get the current active transaction. If there is no active tra
 ## `apm.captureError()` [capture-error]
 
 ```js
-apm.captureError(error)
+apm.captureError(error, options)
 ```
 
 Arguments:
 
 * `error` - An instance of `Error`.
+* `options` - The following options are supported:
+
+  * `labels` - Add additional context with labels, these labels will be added to the error along with the labels from the current transaction.
 
 Use this method to manually send an error to APM Server:
 

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -316,10 +316,10 @@ export default class ApmBase {
     }
   }
 
-  captureError(error, opt) {
+  captureError(error, opts) {
     if (this.isEnabled()) {
       var errorLogging = this.serviceFactory.getService(ERROR_LOGGING)
-      return errorLogging.logError(error, opt)
+      return errorLogging.logError(error, opts)
     }
   }
 

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -316,10 +316,10 @@ export default class ApmBase {
     }
   }
 
-  captureError(error) {
+  captureError(error, opt) {
     if (this.isEnabled()) {
       var errorLogging = this.serviceFactory.getService(ERROR_LOGGING)
-      return errorLogging.logError(error)
+      return errorLogging.logError(error, opt)
     }
   }
 

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -110,6 +110,10 @@ declare module '@elastic/apm-rum' {
     }) => boolean
   }
 
+  export interface ErrorOptions {
+    labels: Labels
+  }
+
   type Init = (options?: AgentConfigOptions) => ApmBase
   const init: Init
 
@@ -142,7 +146,7 @@ declare module '@elastic/apm-rum' {
       options?: SpanOptions
     ): Span | undefined
     getCurrentTransaction(): Transaction | undefined
-    captureError(error: Error | string): void
+    captureError(error: Error | string, opt?: ErrorOptions): void
     addFilter(fn: FilterFn): void
   }
   const apmBase: ApmBase

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -146,7 +146,7 @@ declare module '@elastic/apm-rum' {
       options?: SpanOptions
     ): Span | undefined
     getCurrentTransaction(): Transaction | undefined
-    captureError(error: Error | string, opt?: ErrorOptions): void
+    captureError(error: Error | string, opts?: ErrorOptions): void
     addFilter(fn: FilterFn): void
   }
   const apmBase: ApmBase

--- a/packages/rum/test/specs/index.spec.js
+++ b/packages/rum/test/specs/index.spec.js
@@ -74,7 +74,9 @@ describe('index', function () {
     try {
       throw new Error('ApmBase test error')
     } catch (error) {
-      apmBase.captureError(error)
+      apmBase.captureError(error, {
+        labels: { testLabelKey: 'testLabelValue' }
+      })
       expect(apmServer.sendEvents).not.toHaveBeenCalled()
 
       if (isPlatformSupported()) {
@@ -82,6 +84,10 @@ describe('index', function () {
         setTimeout(() => {
           expect(apmServer.sendEvents).toHaveBeenCalled()
           var callData = apmServer.sendEvents.calls.mostRecent()
+          var eventData = callData.args[0][0]
+          expect(eventData.errors.context.tags.testLabelKey).toBe(
+            'testLabelValue'
+          )
           callData.returnValue.then(
             () => {
               // Wait before ending the test to make sure the result are processed by the agent.


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-rum-js/issues/1591

### Summary

This PR allows adding labels to the captureError function, similar to what we have in Node.js agent:
https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#apm-capture-error

Example usage:
```
apm.captureError(error, {
      labels: {
        errorType: 'ToastError',
      },
    });
```