### PR TITLE
chore: fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55694,7 +55694,7 @@
     },
     "packages/rum": {
       "name": "@elastic/apm-rum",
-      "version": "5.16.1",
+      "version": "5.16.3",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum-core": "file:../rum-core"
@@ -55705,7 +55705,7 @@
     },
     "packages/rum-angular": {
       "name": "@elastic/apm-rum-angular",
-      "version": "3.0.4",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",
@@ -55727,7 +55727,7 @@
     },
     "packages/rum-core": {
       "name": "@elastic/apm-rum-core",
-      "version": "5.21.1",
+      "version": "5.22.1",
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^1.3.5",
@@ -55740,7 +55740,7 @@
     },
     "packages/rum-react": {
       "name": "@elastic/apm-rum-react",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",
@@ -55764,7 +55764,7 @@
     },
     "packages/rum-vue": {
       "name": "@elastic/apm-rum-vue",
-      "version": "2.1.7",
+      "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",


### PR DESCRIPTION
After a clean checkout and `npm install` the package lock gets the changes of this PR. I suspect the latest release did bump versions in `package.json` files but not in the lock file. This PR fixes it