### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -103,7 +103,5 @@ The core RUM agent supports websites based on multi-page (MPA) and single-page a
 
 The following platforms are supported:
 
-:::{image} images/compatibility.png
-:alt: Elastic APM RUM Agent compatibility
-:::
+![Elastic APM RUM Agent compatibility](images/compatibility.png)
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 