### PR TITLE
docs: update agent install instructions

### DIFF
--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -58,7 +58,7 @@ https://unpkg.com/@elastic/apm-rum/dist/bundles/elastic-apm-rum.umd.min.js[UNPKG
 
 [source,html]
 ----
-<script src="https://your-cdn-host.com/path/to/elastic-apm-rum.umd.min.js" crossorigin></script>
+<script src="https://unpkg.com/@elastic/apm-rum/dist/bundles/elastic-apm-rum.umd.min.js" crossorigin></script>
 <script>
   elasticApm.init({
     serviceName: '',


### PR DESCRIPTION
Backport https://github.com/elastic/apm-agent-rum-js/pull/1612 to 4.x