### PR TITLE
chore: add missing assets in github release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55694,7 +55694,7 @@
     },
     "packages/rum": {
       "name": "@elastic/apm-rum",
-      "version": "5.16.3",
+      "version": "5.17.0",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum-core": "file:../rum-core"
@@ -55705,7 +55705,7 @@
     },
     "packages/rum-angular": {
       "name": "@elastic/apm-rum-angular",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",
@@ -55727,7 +55727,7 @@
     },
     "packages/rum-core": {
       "name": "@elastic/apm-rum-core",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^1.3.5",
@@ -55740,7 +55740,7 @@
     },
     "packages/rum-react": {
       "name": "@elastic/apm-rum-react",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",
@@ -55764,7 +55764,7 @@
     },
     "packages/rum-vue": {
       "name": "@elastic/apm-rum-vue",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "MIT",
       "dependencies": {
         "@elastic/apm-rum": "file:../rum",

--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -75,14 +75,8 @@ function createRelease(token) {
 }
 
 function uploadAssets(uploadUrl, token) {
-  /**
-   * Exclude the files that are not required for releasing
-   *
-   * TODO: Remove this filtering logic once we revisit bundling steps
-   */
   const assets = fs
     .readdirSync(BUILD_DIR)
-    .filter(file => file.endsWith('.js'))
     .map(file => path.join(BUILD_DIR, file))
   return new Promise((resolve, reject) => {
     releaseAssets(


### PR DESCRIPTION
The github release for `rum-core` does not add the `*.map` files. 

Fixes: #1608 