### PR TITLE
chore: disable SauceLabs on PRs and push to main

### DIFF
--- a/.github/workflows/ci-saucelabs.yml
+++ b/.github/workflows/ci-saucelabs.yml
@@ -10,18 +10,18 @@ on:
         default: true
         required: false
         type: boolean
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.asciidoc'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.asciidoc'
+  # push:
+  #   branches:
+  #     - main
+  #   paths-ignore:
+  #     - '**.md'
+  #     - '**.asciidoc'
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths-ignore:
+  #     - '**.md'
+  #     - '**.asciidoc'
 
 # Limit the access of the generated GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
As discussed we're going to run tests on demand. The workflow can still be triggered manually. We should check other alternatives to test in real devices