### PR TITLE
ci: fix semgrep reported run-shell-injection

### DIFF
--- a/.github/workflows/run-test/action.yml
+++ b/.github/workflows/run-test/action.yml
@@ -43,8 +43,11 @@ runs:
         && (inputs.sauce-username != null && inputs.sauce-username != '')
       shell: bash
       run: |
-        echo "SAUCE_ACCESS_KEY=${{ inputs.sauce-access-key }}" >> $GITHUB_ENV
-        echo "SAUCE_USERNAME=${{ inputs.sauce-username }}"     >> $GITHUB_ENV
+        echo "SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY" >> $GITHUB_ENV
+        echo "SAUCE_USERNAME=$SAUCE_USERNAME" >> $GITHUB_ENV
+      env:
+        SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
+        SAUCE_USERNAME: ${{ inputs.sauce-username }}
     - name: Run tests Elastic Stack ${{ matrix.stack-version }} - ${{ matrix.scope }} - ${{ fromJSON('{"none":"Puppeteer"}')[inputs.mode] || inputs.mode }}
       run: './.ci/scripts/test.sh'
       shell: bash


### PR DESCRIPTION
Update GH workflows and actions to fix the run-shell-injection vulnerability.
More info: https://semgrep.dev/r?q=yaml.github-actions.security.run-shell-injection.run-shell-injection

Tested in personal fork: https://github.com/oakrizan/apm-agent-rum-js/actions/runs/16774497902/job/47497235763?pr=1