### PR TITLE
feat: allow custom attribute for span name in user-interction transaction

### DIFF
--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -89,6 +89,7 @@ class Config {
       pageLoadTransactionName: '',
       propagateTracestate: false,
       transactionSampleRate: 1.0,
+      transactionNameCustomAttribute: '',
       centralConfig: false,
       monitorLongtasks: true,
       apiVersion: 2,

--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -114,7 +114,7 @@ function buildTransactionName(target, transactionNameCustomAttribute) {
     target,
     transactionNameCustomAttribute
   )
-  console.log('dtName:', dtName)
+
   if (dtName) {
     return dtName
   }
@@ -134,7 +134,7 @@ function findCustomTransactionName(target, transactionNameCustomAttribute) {
   const trCustomNameAttribute =
     transactionNameCustomAttribute || 'data-transaction-name'
   const fallbackName = target.getAttribute(trCustomNameAttribute)
-  console.log('fallbackName:', fallbackName)
+
   if (target.closest) {
     // Leverage closest API to traverse the element and its parents
     // only links and buttons are considered.

--- a/packages/rum/src/apm-base.js
+++ b/packages/rum/src/apm-base.js
@@ -124,7 +124,7 @@ export default class ApmBase {
 
         observePageVisibility(configService, transactionService)
         if (flags[EVENT_TARGET] && flags[CLICK]) {
-          observePageClicks(transactionService)
+          observePageClicks(configService, transactionService)
         }
         observeUserInteractions()
       } else {

--- a/packages/rum/src/index.d.ts
+++ b/packages/rum/src/index.d.ts
@@ -95,6 +95,7 @@ declare module '@elastic/apm-rum' {
     transactionThrottleLimit?: number
     transactionThrottleInterval?: number
     transactionSampleRate?: number
+    transactionNameCustomAttribute?: string
     centralConfig?: boolean
     ignoreTransactions?: Array<string | RegExp>
     propagateTracestate?: boolean


### PR DESCRIPTION
### Summary

In order to make `user-interaction` span names more meaningful, this PR allows setting a custom field to be used for this purpose. If this config is not provided, `data-transaction-name` or `name` property will be used as mentioned [here](https://github.com/elastic/apm-agent-rum-js/blob/main/docs/reference/supported-technologies.md#user-interactions-user-interactions).

#### Example config
```
import { init } from '@elastic/apm-rum';

init({
    ...apmConfig,
    logLevel: 'debug',
    transactionNameCustomAttribute: 'data-test-subj',
});
```
#### Example usage
```
<EuiButton
  data-test-subj="myCustomSpanName"
  fill
  color="primary"
  onClick={async () => {
    // Added this to ensure capturing the event
    await fetch('https://www.google.com/');
  }}
>
  <span>Some text</span>
  <EuiIcon type="logoElasticsearch" size="xl" />
</EuiButton>

// Span name: "Click - myCustomSpanName"
```
