### PR TITLE
Fix microbenchmark pipeline

### DIFF
--- a/.ci/scripts/benchmarks.sh
+++ b/.ci/scripts/benchmarks.sh
@@ -6,6 +6,9 @@ USER_ID="$(id -u):$(id -g)"
 # will require us to invest a certain amount of time
 NODEJS_VERSION=14
 
+# Ensure local bin is in PATH, needed for updated docker-compose, see https://github.com/elastic/observability-robots/issues/2960
+export PATH="$HOME/.local/bin:$PATH"
+
 USER_ID="${USER_ID}" \
 NODEJS_VERSION="${NODEJS_VERSION}" \
 docker-compose -f ./dev-utils/docker-compose.yml down \


### PR DESCRIPTION
This pull request introduces a minor update to the `.ci/scripts/benchmarks.sh` script to improve compatibility with updated versions of `docker-compose`.

* Environment setup: Ensures that the local binary directory (`$HOME/.local/bin`) is added to the `PATH` to support updated `docker-compose` usage.