### PR TITLE
feat(rum-core): allow sending transactions with no spans using config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -368,7 +368,7 @@ If APM Server is deployed in an origin different than the page’s origin, you w
 ::::
 
 
-### `recordTransactionsWithoutSpans` [record-transactions-without-spans]
+### `reportTransactionsWithoutSpans` [report-transactions-without-spans]
 
 * **Type:** Boolean
 * **Default:** `false`

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -96,7 +96,7 @@ class Config {
       session: false,
       apmRequest: null,
       sendCredentials: false,
-      recordTransactionsWithoutSpans: false
+      reportTransactionsWithoutSpans: false
     }
 
     this.events = new EventHandler()

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -362,7 +362,7 @@ export default class PerformanceMonitoring {
       }
 
       const recordEmpty = this._configService.get(
-        'recordTransactionsWithoutSpans'
+        'reportTransactionsWithoutSpans'
       )
       if (tr.sampled && tr.spans.length === 0 && !recordEmpty) {
         if (__DEV__) {

--- a/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
+++ b/packages/rum-core/test/performance-monitoring/performance-monitoring.spec.js
@@ -131,7 +131,7 @@ describe('PerformanceMonitoring', function () {
     spyOn(logger, 'debug').and.callThrough()
     configService.setConfig({
       ...agentConfig,
-      recordTransactionsWithoutSpans: true
+      reportTransactionsWithoutSpans: true
     })
     const transaction1 = new Transaction('transaction', 'custom', {
       id: 1,


### PR DESCRIPTION
The route change transaction is a type of transaction that can be interesting eve if it does not contain spans. Can be used to track the journey of the users across the instrumented web application. Is specifically useful for single page applications (SPA) where the URL can change without performing any HTTP request (hence no spans) because of the app caching data or because there is no need to fetch data.

~The change introduces a new flag in configuration named `sendAllRouteChanges` which defaults to `false` keeping the current behavior. Apps that wants to record all transactions of type `route-change` can set this config to `true`.~

UPDATE: changed the config options to allow all transactions without spans.

The change introduces a new flag in configuration named `reportTransactionsWithoutSpans` which defaults to `false` keeping the current behavior. Apps that wants to record all transactions regardless if they have spans or not can set this config to `true`.