### PR TITLE
chore: fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,19 +56,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       
-      # Ensure npm 11.5.1 or later is installed
+      # Latest npm (11.6.4) supports trusted publishers and Node.js v20
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.6.4
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      # This prevent lerna command from throwing this error in dry-run mode:
-      # "Working tree has uncommitted changes, please commit or remove the following changes before continuing"
-      - name: Ignore git uncommitted changes
-        run: |
-          git update-index --skip-worktree .npmrc
-      
       - name: Publish the release
         env:
           DRY_RUN: "${{ inputs.dry-run }}"

--- a/scripts/ci-release.mjs
+++ b/scripts/ci-release.mjs
@@ -106,6 +106,14 @@ async function dryRunMode() {
   }
 
   try {
+    // This prevent lerna command from throwing this error in dry-run mode:
+    // "Working tree has uncommitted changes, please commit or remove the following changes before continuing"
+    await execa(
+      'git',
+      ['update-index', '--skip-worktree', '.npmrc']
+    )
+      .pipeStdout(process.stdout)
+      .pipeStderr(process.stderr)
     await execa(
       'npx',
       ['lerna', 'publish', 'from-package', `--registry=${registryUrl}`, '--no-push', '--no-git-tag-version', '--no-changelog', '--yes', '--loglevel=debug'],


### PR DESCRIPTION
In https://github.com/elastic/apm-agent-rum-js/pull/1651 the release process switched to use trusted publishers. One of the requirements to publish that way is to do it with `npm@11.5.1` as explained in https://github.com/npm/cli/issues/8678#issuecomment-3431235853 This repo is using `node@20` so it needs to update `npm` if we want to publish.

Changes

- Update `npm` in CI before publishing
- Restored a git command to ignore `.npmrc` required for releasing in `dry-run` mode.