### PR TITLE
fix(release): set the dependencies versions when publishign in dry-run mode

### DIFF
--- a/scripts/ci-release.mjs
+++ b/scripts/ci-release.mjs
@@ -84,26 +84,34 @@ async function dryRunMode() {
   }
 
   try {
-    // This prevent lerna command from throwing this error in dry-run mode:
-    // "Working tree has uncommitted changes, please commit or remove the following changes before continuing"
-    // UPDATE: we are not using lerna because Verdaccio deosnot support provenance or trusted publishers
-    // await execa(
-    //   'git',
-    //   ['update-index', '--skip-worktree', '.npmrc']
-    // )
-    //   .pipeStdout(process.stdout)
-    //   .pipeStderr(process.stderr)
-    
     // It appears Verdaccio does not support trusted publishers and lerna
     // has no option to disable it. Fall back to individually publishing them.
     const root = path.join(process.cwd(), 'packages')
     const dirs = ['rum-core', 'rum', 'rum-angular', 'rum-react', 'rum-vue']
+    const pkgs = {}
+
+    // get info of each package
+    for (const dir of dirs) {
+      const pkgPath = path.join(root, dir, 'package.json')
+      const pkgText = readFileSync(pkgPath, {encoding: 'utf-8'})
+      const pkgJson = JSON.parse(pkgText)
+      pkgs[dir] = { pkgPath, pkgJson, pkgText }
+    }
+
     for (const dir of dirs) {
       // Verdaccio does not support provenance for now so we disable it
       // ref: https://github.com/orgs/verdaccio/discussions/3903
-      const pkgPath = path.join(root, dir, 'package.json')
-      const pkgText = readFileSync(pkgPath, {encoding: 'utf-8'})
-      writeFileSync(pkgPath, pkgText.replace('"provenance": true', '"provenance": false'))
+      const { pkgPath, pkgText } = pkgs[dir]
+      let text = pkgText
+
+      // Disable provenence for verdaccio
+      text = text.replace('"provenance": true', '"provenance": false')
+      // Resolve the file:../ dependencies
+      for (const d of dirs) {
+        const { pkgJson } = pkgs[d]
+        text = text.replace(`file:../${d}`, `^${pkgJson.version}`)
+      }
+      writeFileSync(pkgPath, text)
 
       // And publish
       await execa(
@@ -115,6 +123,7 @@ async function dryRunMode() {
         .pipeStderr(process.stderr)
     }
   } catch (err) {
+    console.log(err)
     raiseError('Failed to publish npm packages')
   }
 


### PR DESCRIPTION
Last release related PR https://github.com/elastic/apm-agent-rum-js/pull/1683 had one thing missing which was pointed out by @vigneshshanmugam in https://github.com/elastic/apm-agent-rum-js/pull/1683#discussion_r2738578109

After several tests we can say:

- `dry-run` mode is affected and packages are published with a `file:..` reference in their dependencies
- `production` mode is not affected since we are still using `lerna` for this mode

This PR is fixing the issue for the dry run mode which publish in a local `verdaccio` registry. I verified with the following steps:

- start docker locally
- run `docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio` in one terminal
- run `DRY_RUN=true npm run ci:release` in another terminal. Like the release workflow is doing
- create a `package.json` file in a local folder then run `npm i @elastic/apm-rum-angular --registry=http://localhost:4873`
- Checked that:
  - `@elastic/apm-rum-core` & `@elastic/apm-rum` dependencies are installed correctly
  - `@elastic/apm-rum-angular` has the right version number for them