### PR TITLE
include element id in user-interaction transaction metadata

### DIFF
--- a/packages/rum-core/src/common/observers/page-clicks.js
+++ b/packages/rum-core/src/common/observers/page-clicks.js
@@ -78,6 +78,7 @@ function getTransactionMetadata(target) {
   }
 
   metadata.transactionName = buildTransactionName(target)
+  metadata.elementId = target.getAttribute('id')
 
   let classes = target.getAttribute('class')
   if (classes) {


### PR DESCRIPTION
Add `elementId` to the metadata returned by `getTransactionMetadata()` by capturing the target element's `id` attribute.

Currently, transactions for elements identified primarily by `id` fall back to a bare tagName like `Click - button`, making it hard to distinguish interactions in the APM UI.

`getAttribute('id')` returns `null` when absent, so no additional null-guard is needed — consistent with existing `name` attribute handling.

Relates to #937